### PR TITLE
Unify other library links with redis/redis-om-dotnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 **Redis OM Spring** extends [Spring Data Redis](https://spring.io/projects/spring-data-redis) to take full advantage of the power of Redis.
 
+[Redis OM .NET](https://github.com/redis/redis-om-dotnet) | [Redis OM Node.js](https://github.com/redis/redis-om-node) | **Redis OM Spring** | [Redis OM Python](https://github.com/redis/redis-om-python)
+
 | Project Stage | Snapshot | Issues |  | License |
 | --- | --- | --- | --- | --- |
 | [![Project stage][badge-Stage]][badge-stage-page] | [![Snapshots][badge-snapshots]][link-snapshots] | [![Percentage of issues still open][badge-open-issues]][open-issues] | [![Average time to resolve an issue][badge-issue-resolution]][issue-resolution] | [![License][license-image]][license-url] |


### PR DESCRIPTION
When browsing through the README, I noticed some of the links were based on an old code location, so I have updated those in this PR, and the PRs linked below for each repo:
redis/redis-om-dotnet#46
redis/redis-om-node#37
redis/redis-om-python/pull/95
redis/redis-om-spring#14