### PR TITLE
refactor: changes RedisDocumentRepositoryFactory* to extend KeyValueRepositoryFactory*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ tmp/
 .settings/
 .project
 
+### IDEA ###
+.idea
+
 ### Mac ###
 **/.DS_Store
 redis-om-spring/target/maven-status/maven-compiler-plugin/compile/default-compile/createdFiles.lst

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -86,17 +86,17 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
   @Bean(name = "redisModulesOperations")
   @Primary
   @ConditionalOnMissingBean
-  RedisModulesOperations<?, ?> redisModulesOperations(RedisModulesClient rmc, RedisTemplate<?, ?> template) {
+  RedisModulesOperations<?> redisModulesOperations(RedisModulesClient rmc, RedisTemplate<?, ?> template) {
     return new RedisModulesOperations<>(rmc, template);
   }
 
   @Bean(name = "redisJSONOperations")
-  JSONOperations<?> redisJSONOperations(RedisModulesOperations<?, ?> redisModulesOperations) {
+  JSONOperations<?> redisJSONOperations(RedisModulesOperations<?> redisModulesOperations) {
     return redisModulesOperations.opsForJSON();
   }
 
   @Bean(name = "redisBloomOperations")
-  BloomOperations<?> redisBloomOperations(RedisModulesOperations<?, ?> redisModulesOperations) {
+  BloomOperations<?> redisBloomOperations(RedisModulesOperations<?> redisModulesOperations) {
     return redisModulesOperations.opsForBloom();
   }
 
@@ -132,7 +132,7 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
   }
 
   @Bean(name = "streamingQueryBuilder")
-  EntityStream streamingQueryBuilder(RedisModulesOperations<?, ?> redisModulesOperations) {
+  EntityStream streamingQueryBuilder(RedisModulesOperations<?> redisModulesOperations) {
     return new EntityStreamImpl(redisModulesOperations);
   }
 
@@ -149,7 +149,7 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
   public void processBloom(ContextRefreshedEvent cre) {
     ApplicationContext ac = cre.getApplicationContext();
     @SuppressWarnings("unchecked")
-    RedisModulesOperations<String, String> rmo = (RedisModulesOperations<String, String>) ac
+    RedisModulesOperations<String> rmo = (RedisModulesOperations<String>) ac
         .getBean("redisModulesOperations");
 
     Set<BeanDefinition> beanDefs = getBeanDefinitionsFor(ac, Document.class, RedisHash.class);
@@ -175,7 +175,7 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
 
   private void createIndicesFor(Class<?> cls, ApplicationContext ac) {
     @SuppressWarnings("unchecked")
-    RedisModulesOperations<String, String> rmo = (RedisModulesOperations<String, String>) ac
+    RedisModulesOperations<String> rmo = (RedisModulesOperations<String>) ac
         .getBean("redisModulesOperations");
 
     Set<BeanDefinition> beanDefs = new HashSet<BeanDefinition>();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/autocomplete/AutoCompleteAspect.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/autocomplete/AutoCompleteAspect.java
@@ -36,10 +36,10 @@ import io.redisearch.Suggestion;
 @Aspect
 @Component
 public class AutoCompleteAspect implements Ordered {
-  private RedisModulesOperations<String, String> rmo;
+  private RedisModulesOperations<String> rmo;
   private GsonBuilder gsonBuilder = GsonBuidlerFactory.getBuilder();
 
-  public AutoCompleteAspect(RedisModulesOperations<String, String> rmo) {
+  public AutoCompleteAspect(RedisModulesOperations<String> rmo) {
     this.rmo = rmo;
   }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/ops/RedisModulesOperations.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/ops/RedisModulesOperations.java
@@ -16,7 +16,7 @@ import com.redis.om.spring.ops.pds.TopKOperationsImpl;
 import com.redis.om.spring.ops.search.SearchOperations;
 import com.redis.om.spring.ops.search.SearchOperationsImpl;
 
-public class RedisModulesOperations<K,V> {
+public class RedisModulesOperations<K> {
 
   private RedisModulesClient client;
   private RedisTemplate<?, ?> template;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -85,7 +85,7 @@ public class RediSearchQuery implements RepositoryQuery {
   private List<String> paramNames = new ArrayList<String>();
   private Class<?> domainType;
 
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
   KeyValueOperations keyValueOperations;
 
   private boolean isANDQuery = false;
@@ -95,16 +95,16 @@ public class RediSearchQuery implements RepositoryQuery {
 
   @SuppressWarnings("unchecked")
   public RediSearchQuery(//
-      QueryMethod queryMethod, //
-      RepositoryMetadata metadata, //
-      QueryMethodEvaluationContextProvider evaluationContextProvider, //
-      KeyValueOperations keyValueOperations, //
-      RedisModulesOperations<?, ?> rmo, //
-      Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
+                         QueryMethod queryMethod, //
+                         RepositoryMetadata metadata, //
+                         QueryMethodEvaluationContextProvider evaluationContextProvider, //
+                         KeyValueOperations keyValueOperations, //
+                         RedisModulesOperations<?> rmo, //
+                         Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
     logger.info(String.format("Creating %s query method", queryMethod.getName()));
 
     this.keyValueOperations = keyValueOperations;
-    this.modulesOperations = (RedisModulesOperations<String, String>) rmo;
+    this.modulesOperations = (RedisModulesOperations<String>) rmo;
     this.queryMethod = queryMethod;
     this.searchIndex = this.queryMethod.getEntityInformation().getJavaType().getName() + "Idx";
     this.metadata = metadata;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
@@ -76,7 +76,7 @@ public class RedisEnhancedQuery implements RepositoryQuery {
   private List<String> paramNames = new ArrayList<String>();
   private Class<?> domainType;
 
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
   MappingRedisConverter mappingConverter;
   RedisOperations<?, ?> redisOperations;
 
@@ -87,13 +87,13 @@ public class RedisEnhancedQuery implements RepositoryQuery {
 
   @SuppressWarnings("unchecked")
   public RedisEnhancedQuery(QueryMethod queryMethod, //
-      RepositoryMetadata metadata, //
-      QueryMethodEvaluationContextProvider evaluationContextProvider, //
-      KeyValueOperations keyValueOperations, RedisOperations<?, ?> redisOperations, RedisModulesOperations<?, ?> rmo, //
-      Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
+                            RepositoryMetadata metadata, //
+                            QueryMethodEvaluationContextProvider evaluationContextProvider, //
+                            KeyValueOperations keyValueOperations, RedisOperations<?, ?> redisOperations, RedisModulesOperations<?> rmo, //
+                            Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
     logger.debug(String.format("Creating query %s", queryMethod.getName()));
 
-    this.modulesOperations = (RedisModulesOperations<String, String>) rmo;
+    this.modulesOperations = (RedisModulesOperations<String>) rmo;
     this.queryMethod = queryMethod;
     this.searchIndex = this.queryMethod.getEntityInformation().getJavaType().getName() + "Idx";
     this.domainType = this.queryMethod.getEntityInformation().getJavaType();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/autocomplete/AutoCompleteQueryExecutor.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/autocomplete/AutoCompleteQueryExecutor.java
@@ -23,9 +23,9 @@ public class AutoCompleteQueryExecutor {
   public static final String AUTOCOMPLETE_PREFIX = "autoComplete";
   
   RepositoryQuery query;
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
 
-  public AutoCompleteQueryExecutor(RepositoryQuery query, RedisModulesOperations<String, String> modulesOperations) {
+  public AutoCompleteQueryExecutor(RepositoryQuery query, RedisModulesOperations<String> modulesOperations) {
     this.query = query;
     this.modulesOperations = modulesOperations;
   }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/bloom/BloomQueryExecutor.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/bloom/BloomQueryExecutor.java
@@ -19,9 +19,9 @@ public class BloomQueryExecutor {
   private static final Log logger = LogFactory.getLog(BloomQueryExecutor.class);
   public static final String EXISTS_BY_PREFIX = "existsBy";
   RepositoryQuery query;
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
   
-  public BloomQueryExecutor(RepositoryQuery query, RedisModulesOperations<String, String> modulesOperations) {
+  public BloomQueryExecutor(RepositoryQuery query, RedisModulesOperations<String> modulesOperations) {
     this.query = query;
     this.modulesOperations = modulesOperations;
   }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactory.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactory.java
@@ -33,7 +33,7 @@ public class RedisDocumentRepositoryFactory extends KeyValueRepositoryFactory {
   private final KeyValueOperations keyValueOperations;
   private final Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
   private final Class<? extends RepositoryQuery> repositoryQueryType;
-  private final RedisModulesOperations<?, ?> rmo;
+  private final RedisModulesOperations<?> rmo;
 
   /**
    * Creates a new {@link KeyValueRepositoryFactory} for the given
@@ -42,7 +42,7 @@ public class RedisDocumentRepositoryFactory extends KeyValueRepositoryFactory {
    * @param keyValueOperations must not be {@literal null}.
    * @param rmo                must not be {@literal null}.
    */
-  public RedisDocumentRepositoryFactory(KeyValueOperations keyValueOperations, RedisModulesOperations<?, ?> rmo) {
+  public RedisDocumentRepositoryFactory(KeyValueOperations keyValueOperations, RedisModulesOperations<?> rmo) {
     this(keyValueOperations, rmo, DEFAULT_QUERY_CREATOR);
   }
 
@@ -53,7 +53,7 @@ public class RedisDocumentRepositoryFactory extends KeyValueRepositoryFactory {
    * @param keyValueOperations must not be {@literal null}.
    * @param queryCreator       must not be {@literal null}.
    */
-  public RedisDocumentRepositoryFactory(KeyValueOperations keyValueOperations, RedisModulesOperations<?, ?> rmo,
+  public RedisDocumentRepositoryFactory(KeyValueOperations keyValueOperations, RedisModulesOperations<?> rmo,
       Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
 
     this(keyValueOperations, rmo, queryCreator, RediSearchQuery.class);
@@ -67,7 +67,7 @@ public class RedisDocumentRepositoryFactory extends KeyValueRepositoryFactory {
    * @param queryCreator        must not be {@literal null}.
    * @param repositoryQueryType must not be {@literal null}.
    */
-  public RedisDocumentRepositoryFactory(KeyValueOperations keyValueOperations, RedisModulesOperations<?, ?> rmo,
+  public RedisDocumentRepositoryFactory(KeyValueOperations keyValueOperations, RedisModulesOperations<?> rmo,
       Class<? extends AbstractQueryCreator<?, ?>> queryCreator, Class<? extends RepositoryQuery> repositoryQueryType) {
 
     super(keyValueOperations, queryCreator, repositoryQueryType);
@@ -103,7 +103,7 @@ public class RedisDocumentRepositoryFactory extends KeyValueRepositoryFactory {
 
     private QueryMethodEvaluationContextProvider evaluationContextProvider;
     private KeyValueOperations keyValueOperations;
-    private RedisModulesOperations<?, ?> rmo;
+    private RedisModulesOperations<?> rmo;
 
     private Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
     private Class<? extends RepositoryQuery> repositoryQueryType;
@@ -115,9 +115,9 @@ public class RedisDocumentRepositoryFactory extends KeyValueRepositoryFactory {
      * @param queryCreator
      */
     public RediSearchQueryLookupStrategy(@Nullable Key key,
-        QueryMethodEvaluationContextProvider evaluationContextProvider, KeyValueOperations keyValueOperations,
-        RedisModulesOperations<?, ?> rmo, Class<? extends AbstractQueryCreator<?, ?>> queryCreator,
-        Class<? extends RepositoryQuery> repositoryQueryType) {
+                                         QueryMethodEvaluationContextProvider evaluationContextProvider, KeyValueOperations keyValueOperations,
+                                         RedisModulesOperations<?> rmo, Class<? extends AbstractQueryCreator<?, ?>> queryCreator,
+                                         Class<? extends RepositoryQuery> repositoryQueryType) {
 
       Assert.notNull(evaluationContextProvider, "EvaluationContextProvider must not be null!");
       Assert.notNull(keyValueOperations, "KeyValueOperations must not be null!");

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactoryBean.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactoryBean.java
@@ -13,7 +13,7 @@ import org.springframework.util.Assert;
 public class RedisDocumentRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
     extends KeyValueRepositoryFactoryBean<T, S, ID> {
 
-  private @Nullable RedisModulesOperations<String, String> rmo;
+  private @Nullable RedisModulesOperations<String> rmo;
 
   /**
    * Creates a new {@link RedisDocumentRepositoryFactoryBean} for the given repository
@@ -30,7 +30,7 @@ public class RedisDocumentRepositoryFactoryBean<T extends Repository<S, ID>, S, 
    *
    * @param rmo must not be {@literal null}.
    */
-  public void setRedisModulesOperations(RedisModulesOperations<String, String> rmo) {
+  public void setRedisModulesOperations(RedisModulesOperations<String> rmo) {
     Assert.notNull(rmo, "RedisModulesOperations must not be null!");
 
     this.rmo = rmo;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactoryBean.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactoryBean.java
@@ -1,6 +1,6 @@
 package com.redis.om.spring.repository.support;
 
-import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.keyvalue.core.KeyValueOperations;
 import org.springframework.data.keyvalue.repository.config.QueryCreatorType;
 import org.springframework.data.mapping.context.MappingContext;
@@ -18,6 +18,7 @@ public class RedisDocumentRepositoryFactoryBean<T extends Repository<S, ID>, S, 
     extends RepositoryFactoryBeanSupport<T, S, ID> {
 
   private @Nullable KeyValueOperations operations;
+  @Autowired
   private @Nullable RedisModulesOperations<String, String> rmo;
   private @Nullable Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
   private @Nullable Class<? extends RepositoryQuery> repositoryQueryType;
@@ -28,9 +29,8 @@ public class RedisDocumentRepositoryFactoryBean<T extends Repository<S, ID>, S, 
    *
    * @param repositoryInterface must not be {@literal null}.
    */
-  public RedisDocumentRepositoryFactoryBean(Class<? extends T> repositoryInterface, @Qualifier("redisModulesOperations") RedisModulesOperations<?,?> rmo) {
+  public RedisDocumentRepositoryFactoryBean(Class<? extends T> repositoryInterface) {
     super(repositoryInterface);
-    setRedisModulesOperations(rmo);
   }
 
   /**
@@ -47,7 +47,7 @@ public class RedisDocumentRepositoryFactoryBean<T extends Repository<S, ID>, S, 
   /**
    * Configures the {@link RedisModulesOperations} to be used for the repositories.
    *
-   * @param operations must not be {@literal null}.
+   * @param rmo must not be {@literal null}.
    */
   @SuppressWarnings("unchecked")
   public void setRedisModulesOperations(RedisModulesOperations<?,?> rmo) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactoryBean.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactoryBean.java
@@ -1,27 +1,19 @@
 package com.redis.om.spring.repository.support;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import com.redis.om.spring.ops.RedisModulesOperations;
 import org.springframework.data.keyvalue.core.KeyValueOperations;
-import org.springframework.data.keyvalue.repository.config.QueryCreatorType;
+import org.springframework.data.keyvalue.repository.support.KeyValueRepositoryFactoryBean;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.repository.Repository;
-import org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport;
-import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.query.RepositoryQuery;
 import org.springframework.data.repository.query.parser.AbstractQueryCreator;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
-import com.redis.om.spring.ops.RedisModulesOperations;
-
 public class RedisDocumentRepositoryFactoryBean<T extends Repository<S, ID>, S, ID>
-    extends RepositoryFactoryBeanSupport<T, S, ID> {
+    extends KeyValueRepositoryFactoryBean<T, S, ID> {
 
-  private @Nullable KeyValueOperations operations;
-  @Autowired
   private @Nullable RedisModulesOperations<String, String> rmo;
-  private @Nullable Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
-  private @Nullable Class<? extends RepositoryQuery> repositoryQueryType;
 
   /**
    * Creates a new {@link RedisDocumentRepositoryFactoryBean} for the given repository
@@ -34,93 +26,31 @@ public class RedisDocumentRepositoryFactoryBean<T extends Repository<S, ID>, S, 
   }
 
   /**
-   * Configures the {@link KeyValueOperations} to be used for the repositories.
-   *
-   * @param operations must not be {@literal null}.
-   */
-  public void setKeyValueOperations(KeyValueOperations operations) {
-    Assert.notNull(operations, "KeyValueOperations must not be null!");
-
-    this.operations = operations;
-  }
-
-  /**
    * Configures the {@link RedisModulesOperations} to be used for the repositories.
    *
    * @param rmo must not be {@literal null}.
    */
-  @SuppressWarnings("unchecked")
-  public void setRedisModulesOperations(RedisModulesOperations<?,?> rmo) {
+  public void setRedisModulesOperations(RedisModulesOperations<String, String> rmo) {
     Assert.notNull(rmo, "RedisModulesOperations must not be null!");
-    this.rmo = (RedisModulesOperations<String, String>)rmo;
+
+    this.rmo = rmo;
   }
 
-  /* (non-Javadoc)
-   *
-   * @see
-   * org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport
-   * #setMappingContext(org.springframework.data.mapping.context.
-   * MappingContext) */
   @Override
   public void setMappingContext(MappingContext<?, ?> mappingContext) {
     super.setMappingContext(mappingContext);
   }
 
-  /**
-   * Configures the {@link QueryCreatorType} to be used.
-   *
-   * @param queryCreator must not be {@literal null}.
-   */
-  public void setQueryCreator(Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
-    Assert.notNull(queryCreator, "Query creator type must not be null!");
-    this.queryCreator = queryCreator;
-  }
-
-  /**
-   * Configures the {@link RepositoryQuery} type to be created.
-   *
-   * @param repositoryQueryType must not be {@literal null}.
-   * @since 1.1
-   */
-  public void setQueryType(Class<? extends RepositoryQuery> repositoryQueryType) {
-    Assert.notNull(queryCreator, "Query creator type must not be null!");
-    this.repositoryQueryType = repositoryQueryType;
-  }
-
-  /* (non-Javadoc)
-   *
-   * @see
-   * org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport
-   * #createRepositoryFactory() */
   @Override
-  protected final RepositoryFactorySupport createRepositoryFactory() {
-    return createRepositoryFactory(operations, queryCreator, repositoryQueryType);
-  }
-
-  /**
-   * Create the repository factory to be used to create repositories.
-   *
-   * @param operations          will never be {@literal null}.
-   * @param queryCreator        will never be {@literal null}.
-   * @param repositoryQueryType will never be {@literal null}.
-   * @return must not be {@literal null}.
-   */
-  protected RedisDocumentRepositoryFactory createRepositoryFactory(KeyValueOperations operations,
+  protected final RedisDocumentRepositoryFactory createRepositoryFactory(KeyValueOperations operations,
       Class<? extends AbstractQueryCreator<?, ?>> queryCreator, Class<? extends RepositoryQuery> repositoryQueryType) {
+
     return new RedisDocumentRepositoryFactory(operations, rmo, queryCreator, repositoryQueryType);
   }
 
-  /* (non-Javadoc)
-   *
-   * @see
-   * org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport
-   * #afterPropertiesSet() */
   @Override
   public void afterPropertiesSet() {
-
-    Assert.notNull(operations, "KeyValueOperations must not be null!");
-    Assert.notNull(queryCreator, "Query creator type must not be null!");
-    Assert.notNull(repositoryQueryType, "RepositoryQueryType type type must not be null!");
+    Assert.notNull(rmo, "RedisModulesOperations must not be null!");
 
     super.afterPropertiesSet();
   }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisEnhancedRepositoryFactory.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisEnhancedRepositoryFactory.java
@@ -39,7 +39,7 @@ public class RedisEnhancedRepositoryFactory extends RepositoryFactorySupport {
 
   private final KeyValueOperations keyValueOperations;
   private final RedisOperations<?, ?> redisOperations;
-  private final RedisModulesOperations<?, ?> rmo;
+  private final RedisModulesOperations<?> rmo;
   private final MappingContext<?, ?> context;
   private final Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
   private final Class<? extends RepositoryQuery> repositoryQueryType;
@@ -53,7 +53,7 @@ public class RedisEnhancedRepositoryFactory extends RepositoryFactorySupport {
   public RedisEnhancedRepositoryFactory( //
       KeyValueOperations keyValueOperations, //
       RedisOperations<?, ?> redisOperations, //
-      RedisModulesOperations<?, ?> rmo) {
+      RedisModulesOperations<?> rmo) {
     this(keyValueOperations, redisOperations, rmo, DEFAULT_QUERY_CREATOR);
   }
 
@@ -65,10 +65,10 @@ public class RedisEnhancedRepositoryFactory extends RepositoryFactorySupport {
    * @param queryCreator       must not be {@literal null}.
    */
   public RedisEnhancedRepositoryFactory( //
-      KeyValueOperations keyValueOperations, //
-      RedisOperations<?, ?> redisOperations, //
-      RedisModulesOperations<?, ?> rmo, //
-      Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
+                                         KeyValueOperations keyValueOperations, //
+                                         RedisOperations<?, ?> redisOperations, //
+                                         RedisModulesOperations<?> rmo, //
+                                         Class<? extends AbstractQueryCreator<?, ?>> queryCreator) {
 
     this(keyValueOperations, redisOperations, rmo, queryCreator, RedisEnhancedQuery.class);
   }
@@ -83,11 +83,11 @@ public class RedisEnhancedRepositoryFactory extends RepositoryFactorySupport {
    * @since 1.1
    */
   public RedisEnhancedRepositoryFactory( //
-      KeyValueOperations keyValueOperations, //
-      RedisOperations<?, ?> redisOperations, //
-      RedisModulesOperations<?, ?> rmo, //
-      Class<? extends AbstractQueryCreator<?, ?>> queryCreator, //
-      Class<? extends RepositoryQuery> repositoryQueryType) {
+                                         KeyValueOperations keyValueOperations, //
+                                         RedisOperations<?, ?> redisOperations, //
+                                         RedisModulesOperations<?> rmo, //
+                                         Class<? extends AbstractQueryCreator<?, ?>> queryCreator, //
+                                         Class<? extends RepositoryQuery> repositoryQueryType) {
 
     Assert.notNull(keyValueOperations, "KeyValueOperations must not be null!");
     Assert.notNull(redisOperations, "RedisOperations must not be null!");
@@ -163,7 +163,7 @@ public class RedisEnhancedRepositoryFactory extends RepositoryFactorySupport {
 
     private QueryMethodEvaluationContextProvider evaluationContextProvider;
     private KeyValueOperations keyValueOperations;
-    private RedisModulesOperations<?, ?> rmo;
+    private RedisModulesOperations<?> rmo;
     private RedisOperations<?, ?> redisOperations;
 
     private Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
@@ -177,12 +177,12 @@ public class RedisEnhancedRepositoryFactory extends RepositoryFactorySupport {
      * @since 1.1
      */
     public RedisEnhancedQueryLookupStrategy(@Nullable Key key,
-        QueryMethodEvaluationContextProvider evaluationContextProvider, //
-        KeyValueOperations keyValueOperations, //
-        RedisOperations<?, ?> redisOperations, //
-        RedisModulesOperations<?, ?> rmo, //
-        Class<? extends AbstractQueryCreator<?, ?>> queryCreator, //
-        Class<? extends RepositoryQuery> repositoryQueryType) {
+                                            QueryMethodEvaluationContextProvider evaluationContextProvider, //
+                                            KeyValueOperations keyValueOperations, //
+                                            RedisOperations<?, ?> redisOperations, //
+                                            RedisModulesOperations<?> rmo, //
+                                            Class<? extends AbstractQueryCreator<?, ?>> queryCreator, //
+                                            Class<? extends RepositoryQuery> repositoryQueryType) {
 
       Assert.notNull(evaluationContextProvider, "EvaluationContextProvider must not be null!");
       Assert.notNull(keyValueOperations, "KeyValueOperations must not be null!");

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisEnhancedRepositoryFactoryBean.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisEnhancedRepositoryFactoryBean.java
@@ -20,7 +20,7 @@ public class RedisEnhancedRepositoryFactoryBean<T extends Repository<S, ID>, S, 
     extends RepositoryFactoryBeanSupport<T, S, ID> {
 
   private @Nullable KeyValueOperations operations;
-  private @Nullable RedisModulesOperations<String, String> rmo;
+  private @Nullable RedisModulesOperations<String> rmo;
   private @Nullable RedisOperations<?, ?> redisOperations;
   private @Nullable Class<? extends AbstractQueryCreator<?, ?>> queryCreator;
   private @Nullable Class<? extends RepositoryQuery> repositoryQueryType;
@@ -32,7 +32,7 @@ public class RedisEnhancedRepositoryFactoryBean<T extends Repository<S, ID>, S, 
    * @param repositoryInterface must not be {@literal null}.
    */
   public RedisEnhancedRepositoryFactoryBean(Class<? extends T> repositoryInterface,
-      RedisOperations<?, ?> redisOperations, RedisModulesOperations<?, ?> rmo) {
+      RedisOperations<?, ?> redisOperations, RedisModulesOperations<?> rmo) {
     super(repositoryInterface);
     setRedisModulesOperations(rmo);
     setRedisOperations(redisOperations);
@@ -57,10 +57,10 @@ public class RedisEnhancedRepositoryFactoryBean<T extends Repository<S, ID>, S, 
    * @param rmo must not be {@literal null}.
    */
   @SuppressWarnings("unchecked")
-  public void setRedisModulesOperations(RedisModulesOperations<?, ?> rmo) {
+  public void setRedisModulesOperations(RedisModulesOperations<?> rmo) {
     Assert.notNull(rmo, "RedisModulesOperations must not be null!");
 
-    this.rmo = (RedisModulesOperations<String, String>) rmo;
+    this.rmo = (RedisModulesOperations<String>) rmo;
   }
 
   /**

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -22,13 +22,13 @@ import com.redislabs.modules.rejson.Path;
 
 public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueRepository<T, ID> implements RedisDocumentRepository<T, ID> {
   
-  protected RedisModulesOperations<String, String> modulesOperations;
+  protected RedisModulesOperations<String> modulesOperations;
   protected EntityInformation<T, ID> metadata;
 
   @SuppressWarnings("unchecked")
-  public SimpleRedisDocumentRepository(EntityInformation<T, ID> metadata, KeyValueOperations operations, @Qualifier("redisModulesOperations") RedisModulesOperations<?, ?> rmo) {
+  public SimpleRedisDocumentRepository(EntityInformation<T, ID> metadata, KeyValueOperations operations, @Qualifier("redisModulesOperations") RedisModulesOperations<?> rmo) {
     super(metadata, operations);
-    this.modulesOperations = (RedisModulesOperations<String, String>)rmo;
+    this.modulesOperations = (RedisModulesOperations<String>)rmo;
     this.metadata = metadata;
   }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/EntityStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/EntityStreamImpl.java
@@ -4,11 +4,11 @@ import com.redis.om.spring.ops.RedisModulesOperations;
 
 public class EntityStreamImpl implements EntityStream {
 
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
 
   @SuppressWarnings("unchecked")
-  public EntityStreamImpl(RedisModulesOperations<?, ?> rmo) {
-    this.modulesOperations = (RedisModulesOperations<String, String>) rmo;
+  public EntityStreamImpl(RedisModulesOperations<?> rmo) {
+    this.modulesOperations = (RedisModulesOperations<String>) rmo;
   }
 
   @Override

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -49,7 +49,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
   private static final Log logger = LogFactory.getLog(SearchStreamImpl.class);
 
   @SuppressWarnings("unused")
-  private RedisModulesOperations<String, String> modulesOperations;
+  private RedisModulesOperations<String> modulesOperations;
   private SearchOperations<String> ops;
   private String searchIndex;
   private Class<E> entityClass;
@@ -59,7 +59,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
   private Optional<Integer> skip = Optional.empty();
   private Optional<SortedField> sortBy = Optional.empty();
 
-  public SearchStreamImpl(Class<E> entityClass, RedisModulesOperations<String, String> modulesOperations) {
+  public SearchStreamImpl(Class<E> entityClass, RedisModulesOperations<String> modulesOperations) {
     this.modulesOperations = modulesOperations;
     this.entityClass = entityClass;
     searchIndex = entityClass.getName() + "Idx";

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/autocompletable/AutoCompleteTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/autocompletable/AutoCompleteTest.java
@@ -35,7 +35,7 @@ public class AutoCompleteTest extends AbstractBaseDocumentTest {
   public AirportsRepository repository;
 
   @Autowired
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
 
   @BeforeEach
   public void loadAirports(@Value("classpath:/data/airport_codes.csv") File dataFile) throws IOException {

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/bloom/fixtures/EmailTakenImpl.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/bloom/fixtures/EmailTakenImpl.java
@@ -8,7 +8,7 @@ import com.redis.om.spring.ops.pds.BloomOperations;
 public class EmailTakenImpl implements EmailTaken {
   
   @Autowired
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
 
   @Override
   public boolean isEmailTaken(String email) {

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/MyDocQueriesImpl.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/MyDocQueriesImpl.java
@@ -15,7 +15,7 @@ import io.redisearch.SearchResult;
 public class MyDocQueriesImpl implements MyDocQueries {
 
   @Autowired
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
 
   private static final Gson gson = new Gson();
 

--- a/redis-om-spring/src/test/java/com/redis/om/spring/ops/json/OpsForJSONTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/ops/json/OpsForJSONTest.java
@@ -29,7 +29,7 @@ public class OpsForJSONTest extends AbstractBaseDocumentTest {
   }
 
   @Autowired
-  RedisModulesOperations<String, IRLObject> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
 
   @Test
   public void testJSONClient() {

--- a/redis-om-spring/src/test/java/com/redis/om/spring/ops/pds/OpsForPDSesTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/ops/pds/OpsForPDSesTest.java
@@ -10,7 +10,7 @@ import com.redis.om.spring.ops.RedisModulesOperations;
 
 public class OpsForPDSesTest extends AbstractBaseDocumentTest {
   @Autowired
-  RedisModulesOperations<String,String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
   
   @Test
   public void testBasicBloomOperations() {

--- a/redis-om-spring/src/test/java/com/redis/om/spring/ops/search/JSONSearchTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/ops/search/JSONSearchTest.java
@@ -52,7 +52,7 @@ public class JSONSearchTest extends AbstractBaseDocumentTest {
   }
 
   @Autowired
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
 
   @Autowired
   private StringRedisTemplate template;

--- a/redis-om-spring/src/test/java/com/redis/om/spring/ops/search/OpsForSearchTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/ops/search/OpsForSearchTest.java
@@ -27,7 +27,7 @@ public class OpsForSearchTest extends AbstractBaseDocumentTest {
   static String HASH_PREFIX = "Article";
 
   @Autowired
-  RedisModulesOperations<String, String> modulesOperations;
+  RedisModulesOperations<String> modulesOperations;
   
   @Autowired
   RedisTemplate<String, String> template;


### PR DESCRIPTION
- refactor: changes RedisDocumentRepositoryFactory* to extend KeyValueRepositoryFactory*
  - this reduces duplication in most cases
  - we cannot use the fields of KeyValueRepositoryFactory, so we need local fields for that, otherwise we would need getters and setters in the extended class

- refactor: removed value (V) type from RedisModulesOperations
  - it was unused, maybe copy & pasted and forgotten