### PR TITLE
fix: adds null check to bean fetching in RedisModulesConfiguration

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -336,6 +336,11 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
     Map<String, Object> annotatedBeans = ac.getBeansWithAnnotation(SpringBootApplication.class);
     Class<?> app = annotatedBeans.isEmpty() ? null : annotatedBeans.values().toArray()[0].getClass();
     Set<BeanDefinition> beanDefs = new HashSet<BeanDefinition>();
+
+    if (app == null) {
+      return beanDefs;
+    }
+
     if (app.isAnnotationPresent(EnableRedisDocumentRepositories.class)) {
       EnableRedisDocumentRepositories edr = (EnableRedisDocumentRepositories) app
           .getAnnotation(EnableRedisDocumentRepositories.class);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -328,17 +328,17 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
 
   @SuppressWarnings({ "unchecked", "rawtypes" })
   private Set<BeanDefinition> getBeanDefinitionsFor(ApplicationContext ac, Class... classes) {
-    ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
-    for (Class cls : classes) {
-      provider.addIncludeFilter(new AnnotationTypeFilter(cls));
-    }
-
     Map<String, Object> annotatedBeans = ac.getBeansWithAnnotation(SpringBootApplication.class);
     Class<?> app = annotatedBeans.isEmpty() ? null : annotatedBeans.values().toArray()[0].getClass();
-    Set<BeanDefinition> beanDefs = new HashSet<BeanDefinition>();
+    Set<BeanDefinition> beanDefs = new HashSet<>();
 
     if (app == null) {
       return beanDefs;
+    }
+
+    ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
+    for (Class cls : classes) {
+      provider.addIncludeFilter(new AnnotationTypeFilter(cls));
     }
 
     if (app.isAnnotationPresent(EnableRedisDocumentRepositories.class)) {


### PR DESCRIPTION
- This lead to errors when application contexts changed, which did not have the `SpringBootApplication` class