### PR TITLE
Redis JSON ARR* functionality as terminal operations on Entity Streams

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 
 import com.redis.om.spring.metamodel.MetamodelField;
 import com.redis.om.spring.search.stream.actions.ArrayAppendAction;
+import com.redis.om.spring.search.stream.actions.ArrayInsertAction;
 import com.redis.om.spring.search.stream.predicates.tag.ContainsAllPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.EqualPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.InPredicate;
@@ -41,4 +42,12 @@ public class TagField<E, T> extends MetamodelField<E, T> {
     return new ArrayAppendAction<E>(field, value);
   }
 
+  public Consumer<? super E> insert(Object value, Long index) {
+    return new ArrayInsertAction<E>(field, value, index);
+  }
+  
+  public Consumer<? super E> prepend(Object value) {
+    return new ArrayInsertAction<E>(field, value, 0L);
+  }
+  
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
@@ -11,6 +11,7 @@ import com.redis.om.spring.search.stream.actions.ArrayIndexOfAction;
 import com.redis.om.spring.search.stream.actions.ArrayInsertAction;
 import com.redis.om.spring.search.stream.actions.ArrayLengthAction;
 import com.redis.om.spring.search.stream.actions.ArrayPopAction;
+import com.redis.om.spring.search.stream.actions.ArrayTrimAction;
 import com.redis.om.spring.search.stream.predicates.tag.ContainsAllPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.EqualPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.InPredicate;
@@ -80,6 +81,10 @@ public class TagField<E, T> extends MetamodelField<E, T> {
   
   public <R> ArrayPopAction<? super E,R> remove(Long index) {
     return pop(index);
+  }
+
+  public Consumer<? super E> trimToRange(Long begin, Long end) {
+    return new ArrayTrimAction<E>(field, begin, end);
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
@@ -3,10 +3,12 @@ package com.redis.om.spring.metamodel.indexed;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.function.Consumer;
+import java.util.function.ToLongFunction;
 
 import com.redis.om.spring.metamodel.MetamodelField;
 import com.redis.om.spring.search.stream.actions.ArrayAppendAction;
 import com.redis.om.spring.search.stream.actions.ArrayInsertAction;
+import com.redis.om.spring.search.stream.actions.ArrayLengthAction;
 import com.redis.om.spring.search.stream.predicates.tag.ContainsAllPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.EqualPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.InPredicate;
@@ -50,4 +52,8 @@ public class TagField<E, T> extends MetamodelField<E, T> {
     return new ArrayInsertAction<E>(field, value, 0L);
   }
   
+  public ToLongFunction<? super E> length() {
+    return new ArrayLengthAction<E>(field);
+  }
+
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
@@ -2,8 +2,10 @@ package com.redis.om.spring.metamodel.indexed;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 import com.redis.om.spring.metamodel.MetamodelField;
+import com.redis.om.spring.search.stream.actions.ArrayAppendAction;
 import com.redis.om.spring.search.stream.predicates.tag.ContainsAllPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.EqualPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.InPredicate;
@@ -33,6 +35,10 @@ public class TagField<E, T> extends MetamodelField<E, T> {
   
   public NotEqualPredicate<? super E,T> containsNone(T value) {
     return new NotEqualPredicate<E,T>(field,value);
+  }
+  
+  public Consumer<? super E> add(Object value) {
+    return new ArrayAppendAction<E>(field, value);
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
@@ -7,6 +7,7 @@ import java.util.function.ToLongFunction;
 
 import com.redis.om.spring.metamodel.MetamodelField;
 import com.redis.om.spring.search.stream.actions.ArrayAppendAction;
+import com.redis.om.spring.search.stream.actions.ArrayIndexOfAction;
 import com.redis.om.spring.search.stream.actions.ArrayInsertAction;
 import com.redis.om.spring.search.stream.actions.ArrayLengthAction;
 import com.redis.om.spring.search.stream.predicates.tag.ContainsAllPredicate;
@@ -56,4 +57,8 @@ public class TagField<E, T> extends MetamodelField<E, T> {
     return new ArrayLengthAction<E>(field);
   }
 
+  public ToLongFunction<? super E> indexOf(Object element) {
+    return new ArrayIndexOfAction<E>(field, element);
+  }
+  
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
@@ -10,6 +10,7 @@ import com.redis.om.spring.search.stream.actions.ArrayAppendAction;
 import com.redis.om.spring.search.stream.actions.ArrayIndexOfAction;
 import com.redis.om.spring.search.stream.actions.ArrayInsertAction;
 import com.redis.om.spring.search.stream.actions.ArrayLengthAction;
+import com.redis.om.spring.search.stream.actions.ArrayPopAction;
 import com.redis.om.spring.search.stream.predicates.tag.ContainsAllPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.EqualPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.InPredicate;
@@ -61,4 +62,24 @@ public class TagField<E, T> extends MetamodelField<E, T> {
     return new ArrayIndexOfAction<E>(field, element);
   }
   
+  public <R> ArrayPopAction<? super E,R> pop(Long index) {
+    return new ArrayPopAction<E,R>(field, index);
+  }
+  
+  public <R> ArrayPopAction<? super E,R> pop() {
+    return pop(-1L);
+  }
+  
+  public <R> ArrayPopAction<? super E,R> removeFirst() {
+    return pop(0L);
+  }
+  
+  public <R> ArrayPopAction<? super E,R> removeLast() {
+    return pop(-1L);
+  }
+  
+  public <R> ArrayPopAction<? super E,R> remove(Long index) {
+    return pop(index);
+  }
+
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -34,6 +34,7 @@ import com.redis.om.spring.metamodel.MetamodelField;
 import com.redis.om.spring.ops.RedisModulesOperations;
 import com.redis.om.spring.ops.json.JSONOperations;
 import com.redis.om.spring.ops.search.SearchOperations;
+import com.redis.om.spring.search.stream.actions.ArrayAppendAction;
 import com.redis.om.spring.search.stream.actions.NumIncrByAction;
 import com.redis.om.spring.search.stream.actions.StrLengthAction;
 import com.redis.om.spring.search.stream.actions.StringAppendAction;
@@ -234,6 +235,10 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
       StringAppendAction stringAppend = (StringAppendAction) action;
       stringAppend.setJSONOperations(json);
       resolveStream().forEach(stringAppend);
+    } else if (action.getClass() == ArrayAppendAction.class) {
+      ArrayAppendAction arrayAppend = (ArrayAppendAction) action;
+      arrayAppend.setJSONOperations(json);
+      resolveStream().forEach(arrayAppend);
     } else {
       resolveStream().forEach(action);
     }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayAppendAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayAppendAction.java
@@ -8,7 +8,7 @@ import com.redis.om.spring.ops.json.JSONOperations;
 import com.redis.om.spring.util.ObjectUtils;
 import com.redislabs.modules.rejson.Path;
 
-public class ArrayAppendAction<E> implements Consumer<E> {
+public class ArrayAppendAction<E> implements TakesJSONOperations, Consumer<E> {
   
   private Field field;
   private JSONOperations<String> json;
@@ -28,6 +28,7 @@ public class ArrayAppendAction<E> implements Consumer<E> {
     }
   }
 
+  @Override
   public void setJSONOperations(JSONOperations<String> json) {
     this.json = json;
   }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayAppendAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayAppendAction.java
@@ -1,0 +1,34 @@
+package com.redis.om.spring.search.stream.actions;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import com.redis.om.spring.ops.json.JSONOperations;
+import com.redis.om.spring.util.ObjectUtils;
+import com.redislabs.modules.rejson.Path;
+
+public class ArrayAppendAction<E> implements Consumer<E> {
+  
+  private Field field;
+  private JSONOperations<String> json;
+  private Object value;
+
+  public ArrayAppendAction(Field field, Object value) {
+    this.field = field;
+    this.value = value;
+  }
+
+  @Override
+  public void accept(E entity) {
+    Optional<?> maybeId = ObjectUtils.getIdFieldForEntity(entity);
+    
+    if (maybeId.isPresent()) {
+      json.arrAppend(entity.getClass().getName() + ":" + maybeId.get().toString(), Path.of("." + field.getName()), value);
+    }
+  }
+
+  public void setJSONOperations(JSONOperations<String> json) {
+    this.json = json;
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayIndexOfAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayIndexOfAction.java
@@ -1,0 +1,31 @@
+package com.redis.om.spring.search.stream.actions;
+
+import java.lang.reflect.Field;
+import java.util.function.ToLongFunction;
+
+import com.redis.om.spring.ops.json.JSONOperations;
+import com.redis.om.spring.util.ObjectUtils;
+import com.redislabs.modules.rejson.Path;
+
+public class ArrayIndexOfAction<E> implements TakesJSONOperations, ToLongFunction<E> {
+  
+  private Field field;
+  private JSONOperations<String> json;
+  private Object element;
+
+  public ArrayIndexOfAction(Field field, Object element) {
+    this.field = field;
+    this.element = element;
+  }
+
+  @Override
+  public void setJSONOperations(JSONOperations<String> json) {
+    this.json = json;
+  }
+
+  @Override
+  public long applyAsLong(E value) {
+    String key = field.getDeclaringClass().getName() + ":" + ObjectUtils.getIdFieldForEntity(value).get().toString();
+    return json.arrIndex(key, Path.of("." + field.getName()), element);
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayIndexOfAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayIndexOfAction.java
@@ -1,6 +1,7 @@
 package com.redis.om.spring.search.stream.actions;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
 import java.util.function.ToLongFunction;
 
 import com.redis.om.spring.ops.json.JSONOperations;
@@ -25,7 +26,13 @@ public class ArrayIndexOfAction<E> implements TakesJSONOperations, ToLongFunctio
 
   @Override
   public long applyAsLong(E value) {
-    String key = field.getDeclaringClass().getName() + ":" + ObjectUtils.getIdFieldForEntity(value).get().toString();
-    return json.arrIndex(key, Path.of("." + field.getName()), element);
+    Optional<?> maybeId = ObjectUtils.getIdFieldForEntity(value);
+    
+    if (maybeId.isPresent()) {
+      String key = field.getDeclaringClass().getName() + ":" + maybeId.get().toString();
+      return json.arrIndex(key, Path.of("." + field.getName()), element);
+    } else {
+      throw new IllegalArgumentException(value.getClass().getName() + " does not appear to have an ID field");
+    }
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayInsertAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayInsertAction.java
@@ -1,0 +1,37 @@
+package com.redis.om.spring.search.stream.actions;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import com.redis.om.spring.ops.json.JSONOperations;
+import com.redis.om.spring.util.ObjectUtils;
+import com.redislabs.modules.rejson.Path;
+
+public class ArrayInsertAction<E> implements TakesJSONOperations, Consumer<E> {
+  
+  private Field field;
+  private JSONOperations<String> json;
+  private Object value;
+  private Long index;
+
+  public ArrayInsertAction(Field field, Object value, Long index) {
+    this.field = field;
+    this.value = value;
+    this.index = index;
+  }
+
+  @Override
+  public void accept(E entity) {
+    Optional<?> maybeId = ObjectUtils.getIdFieldForEntity(entity);
+    
+    if (maybeId.isPresent()) {
+      json.arrInsert(entity.getClass().getName() + ":" + maybeId.get().toString(), Path.of("." + field.getName()), index, value);
+    }
+  }
+
+  @Override
+  public void setJSONOperations(JSONOperations<String> json) {
+    this.json = json;
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayLengthAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayLengthAction.java
@@ -1,0 +1,30 @@
+package com.redis.om.spring.search.stream.actions;
+
+import java.lang.reflect.Field;
+import java.util.function.ToLongFunction;
+
+import com.redis.om.spring.ops.json.JSONOperations;
+import com.redis.om.spring.util.ObjectUtils;
+import com.redislabs.modules.rejson.Path;
+
+public class ArrayLengthAction<E> implements TakesJSONOperations, ToLongFunction<E> {
+
+  private Field field;
+  private JSONOperations<String> json;
+
+  public ArrayLengthAction(Field field) {
+    this.field = field;
+  }
+
+  @Override
+  public long applyAsLong(E value) {
+    String key = field.getDeclaringClass().getName() + ":" + ObjectUtils.getIdFieldForEntity(value).get().toString();
+    return json.arrLen(key, Path.of("." + field.getName()));
+  }
+  
+  @Override
+  public void setJSONOperations(JSONOperations<String> json) {
+    this.json = json;
+  }
+
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayLengthAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayLengthAction.java
@@ -1,6 +1,7 @@
 package com.redis.om.spring.search.stream.actions;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
 import java.util.function.ToLongFunction;
 
 import com.redis.om.spring.ops.json.JSONOperations;
@@ -18,8 +19,14 @@ public class ArrayLengthAction<E> implements TakesJSONOperations, ToLongFunction
 
   @Override
   public long applyAsLong(E value) {
-    String key = field.getDeclaringClass().getName() + ":" + ObjectUtils.getIdFieldForEntity(value).get().toString();
-    return json.arrLen(key, Path.of("." + field.getName()));
+    Optional<?> maybeId = ObjectUtils.getIdFieldForEntity(value);
+    
+    if (maybeId.isPresent()) {
+      String key = field.getDeclaringClass().getName() + ":" + maybeId.get().toString();
+      return json.arrLen(key, Path.of("." + field.getName()));
+    } else {
+      throw new IllegalArgumentException(value.getClass().getName() + " does not appear to have an ID field");
+    }
   }
   
   @Override

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayPopAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayPopAction.java
@@ -1,0 +1,40 @@
+package com.redis.om.spring.search.stream.actions;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.redis.om.spring.ops.json.JSONOperations;
+import com.redis.om.spring.util.ObjectUtils;
+import com.redislabs.modules.rejson.Path;
+
+public class ArrayPopAction<E,R> implements TakesJSONOperations, Function<E,R> {
+  
+  private Field field;
+  private JSONOperations<String> json;
+  private Long index;
+
+  public ArrayPopAction(Field field, Long index) {
+    this.field = field;
+    this.index = index;
+  }
+
+  @Override
+  public void setJSONOperations(JSONOperations<String> json) {
+    this.json = json;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public R apply(E entity) {
+    Optional<?> maybeId = ObjectUtils.getIdFieldForEntity(entity);
+    
+    if (maybeId.isPresent()) {
+      Optional<Class<?>> maybeClass = ObjectUtils.getCollectionElementType(field);
+      if (maybeClass.isPresent()) {
+        return (R) json.arrPop(entity.getClass().getName() + ":" + maybeId.get().toString(), maybeClass.get(), Path.of("." + field.getName()), index); 
+      }
+    }
+    return null;
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayPopAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayPopAction.java
@@ -33,8 +33,11 @@ public class ArrayPopAction<E,R> implements TakesJSONOperations, Function<E,R> {
       Optional<Class<?>> maybeClass = ObjectUtils.getCollectionElementType(field);
       if (maybeClass.isPresent()) {
         return (R) json.arrPop(entity.getClass().getName() + ":" + maybeId.get().toString(), maybeClass.get(), Path.of("." + field.getName()), index); 
+      } else {
+        throw new RuntimeException("Cannot determine contain element type for collection " + field.getName());
       }
+    } else {
+      throw new IllegalArgumentException(entity.getClass().getName() + " does not appear to have an ID field");
     }
-    return null;
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayTrimAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayTrimAction.java
@@ -34,7 +34,11 @@ public class ArrayTrimAction<E> implements TakesJSONOperations, Consumer<E> {
       Optional<Class<?>> maybeClass = ObjectUtils.getCollectionElementType(field);
       if (maybeClass.isPresent()) {
         json.arrTrim(entity.getClass().getName() + ":" + maybeId.get().toString(), Path.of("." + field.getName()), begin, end); 
+      } else {
+        throw new RuntimeException("Cannot determine contain element type for collection " + field.getName());
       }
+    } else {
+      throw new IllegalArgumentException(entity.getClass().getName() + " does not appear to have an ID field");
     }
     
   }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayTrimAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ArrayTrimAction.java
@@ -1,0 +1,41 @@
+package com.redis.om.spring.search.stream.actions;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import com.redis.om.spring.ops.json.JSONOperations;
+import com.redis.om.spring.util.ObjectUtils;
+import com.redislabs.modules.rejson.Path;
+
+public class ArrayTrimAction<E> implements TakesJSONOperations, Consumer<E> {
+  
+  private Field field;
+  private JSONOperations<String> json;
+  private Long begin;
+  private Long end;
+
+  public ArrayTrimAction(Field field, Long begin, Long end) {
+    this.field = field;
+    this.begin = begin;
+    this.end = end;
+  }
+
+  @Override
+  public void setJSONOperations(JSONOperations<String> json) {
+    this.json = json;
+  }
+
+  @Override
+  public void accept(E entity) {
+    Optional<?> maybeId = ObjectUtils.getIdFieldForEntity(entity);
+    
+    if (maybeId.isPresent()) {
+      Optional<Class<?>> maybeClass = ObjectUtils.getCollectionElementType(field);
+      if (maybeClass.isPresent()) {
+        json.arrTrim(entity.getClass().getName() + ":" + maybeId.get().toString(), Path.of("." + field.getName()), begin, end); 
+      }
+    }
+    
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/NumIncrByAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/NumIncrByAction.java
@@ -8,7 +8,7 @@ import com.redis.om.spring.ops.json.JSONOperations;
 import com.redis.om.spring.util.ObjectUtils;
 import com.redislabs.modules.rejson.Path;
 
-public class NumIncrByAction<E> implements Consumer<E> {
+public class NumIncrByAction<E> implements TakesJSONOperations, Consumer<E> {
   
   private Field field;
   private JSONOperations<String> json;
@@ -28,6 +28,7 @@ public class NumIncrByAction<E> implements Consumer<E> {
     }
   }
 
+  @Override
   public void setJSONOperations(JSONOperations<String> json) {
     this.json = json;
   }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/StrLengthAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/StrLengthAction.java
@@ -7,7 +7,7 @@ import com.redis.om.spring.ops.json.JSONOperations;
 import com.redis.om.spring.util.ObjectUtils;
 import com.redislabs.modules.rejson.Path;
 
-public class StrLengthAction<E> implements ToLongFunction<E> {
+public class StrLengthAction<E> implements TakesJSONOperations, ToLongFunction<E> {
 
   private Field field;
   private JSONOperations<String> json;
@@ -22,6 +22,7 @@ public class StrLengthAction<E> implements ToLongFunction<E> {
     return json.strLen(key, Path.of("." + field.getName()));
   }
   
+  @Override
   public void setJSONOperations(JSONOperations<String> json) {
     this.json = json;
   }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/StrLengthAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/StrLengthAction.java
@@ -1,6 +1,7 @@
 package com.redis.om.spring.search.stream.actions;
 
 import java.lang.reflect.Field;
+import java.util.Optional;
 import java.util.function.ToLongFunction;
 
 import com.redis.om.spring.ops.json.JSONOperations;
@@ -18,8 +19,14 @@ public class StrLengthAction<E> implements TakesJSONOperations, ToLongFunction<E
 
   @Override
   public long applyAsLong(E value) {
-    String key = field.getDeclaringClass().getName() + ":" + ObjectUtils.getIdFieldForEntity(value).get().toString();
-    return json.strLen(key, Path.of("." + field.getName()));
+    Optional<?> maybeId = ObjectUtils.getIdFieldForEntity(value);
+    
+    if (maybeId.isPresent()) {
+      String key = field.getDeclaringClass().getName() + ":" + maybeId.get().toString();
+      return json.strLen(key, Path.of("." + field.getName()));
+    } else {
+      throw new IllegalArgumentException(value.getClass().getName() + " does not appear to have an ID field");
+    }
   }
   
   @Override

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/StringAppendAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/StringAppendAction.java
@@ -8,7 +8,7 @@ import com.redis.om.spring.ops.json.JSONOperations;
 import com.redis.om.spring.util.ObjectUtils;
 import com.redislabs.modules.rejson.Path;
 
-public class StringAppendAction<E> implements Consumer<E> {
+public class StringAppendAction<E> implements TakesJSONOperations, Consumer<E> {
   
   private Field field;
   private JSONOperations<String> json;
@@ -28,6 +28,7 @@ public class StringAppendAction<E> implements Consumer<E> {
     }
   }
 
+  @Override
   public void setJSONOperations(JSONOperations<String> json) {
     this.json = json;
   }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/TakesJSONOperations.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/TakesJSONOperations.java
@@ -1,0 +1,7 @@
+package com.redis.om.spring.search.stream.actions;
+
+import com.redis.om.spring.ops.json.JSONOperations;
+
+public interface TakesJSONOperations {
+  void setJSONOperations(JSONOperations<String> json);
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ToggleAction.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/actions/ToggleAction.java
@@ -8,7 +8,7 @@ import com.redis.om.spring.ops.json.JSONOperations;
 import com.redis.om.spring.util.ObjectUtils;
 import com.redislabs.modules.rejson.Path;
 
-public class ToggleAction<E> implements Consumer<E> {
+public class ToggleAction<E> implements TakesJSONOperations, Consumer<E> {
   
   private Field field;
   private JSONOperations<String> json;
@@ -26,6 +26,7 @@ public class ToggleAction<E> implements Consumer<E> {
     }
   }
 
+  @Override
   public void setJSONOperations(JSONOperations<String> json) {
     this.json = json;
   }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/User.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/User.java
@@ -1,0 +1,33 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Document
+public class User {
+  @Id
+  private String id;
+  
+  @NonNull
+  @Indexed
+  private String name;
+  
+  @Indexed
+  private List<String> roles = new ArrayList<String>();
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/UserRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/UserRepository.java
@@ -1,0 +1,9 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import java.util.Optional;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface UserRepository  extends RedisDocumentRepository<User, String> {
+  Optional<User> findFirstByName(String name);
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
@@ -806,6 +806,78 @@ public class EntityStreamTest extends AbstractBaseDocumentTest {
     assertThat(rolesLengths).containsExactly(2L);
   }
 
+  @Test
+  public void testArrayPopOnSimpleIndexedTagFieldInDocuments() {
+    List<Object> roles = entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .map(User$.ROLES.pop()) //
+        .collect(Collectors.toList());
+
+    // contains the last
+    assertThat(roles).containsExactly("guru");
+
+    Optional<User> maybeSteve = userRepository.findFirstByName("Steve Lorello");
+    assertTrue(maybeSteve.isPresent());
+    User steve = maybeSteve.get();
+    
+    // the rest remains
+    assertThat(steve.getRoles()).containsExactly("devrel", "educator");
+  }
+  
+  @Test
+  public void testArrayRemoveLastOnSimpleIndexedTagFieldInDocuments() {
+    List<Object> roles = entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .map(User$.ROLES.removeLast()) //
+        .collect(Collectors.toList());
+
+    // contains the last
+    assertThat(roles).containsExactly("guru");
+
+    Optional<User> maybeSteve = userRepository.findFirstByName("Steve Lorello");
+    assertTrue(maybeSteve.isPresent());
+    User steve = maybeSteve.get();
+    
+    // the first remains
+    assertThat(steve.getRoles()).containsExactly("devrel", "educator");
+  }
+  
+  @Test
+  public void testArrayPopFirstOnSimpleIndexedTagFieldInDocuments() {
+    List<Object> roles = entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .map(User$.ROLES.pop(0L)) //
+        .collect(Collectors.toList());
+
+    // contains the last
+    assertThat(roles).containsExactly("devrel");
+
+    Optional<User> maybeSteve = userRepository.findFirstByName("Steve Lorello");
+    assertTrue(maybeSteve.isPresent());
+    User steve = maybeSteve.get();
+    
+    // the rest remains
+    assertThat(steve.getRoles()).containsExactly("educator", "guru");
+  }
+  
+  @Test
+  public void testArrayRemoveFirstOnSimpleIndexedTagFieldInDocuments() {
+    List<Object> roles = entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .map(User$.ROLES.removeFirst()) //
+        .collect(Collectors.toList());
+
+    // contains the first
+    assertThat(roles).containsExactly("devrel");
+
+    Optional<User> maybeSteve = userRepository.findFirstByName("Steve Lorello");
+    assertTrue(maybeSteve.isPresent());
+    User steve = maybeSteve.get();
+    
+    // the rest remains
+    assertThat(steve.getRoles()).containsExactly("educator", "guru");
+  }
+  
   }
 
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
@@ -657,6 +657,7 @@ public class EntityStreamTest extends AbstractBaseDocumentTest {
 
     Optional<Company> maybeMicrosoft = repository.findFirstByEmail("research@microsoft.com");
     assertTrue(maybeMicrosoft.isPresent());
+    assertThat(maybeMicrosoft.get().getName()).isEqualTo("Microsoft Corp");
   }
 
   @Test

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
@@ -796,6 +796,16 @@ public class EntityStreamTest extends AbstractBaseDocumentTest {
     assertThat(rolesLengths).containsExactly(3L, 3L, 3L, 3L);
   }
 
+  @Test
+  public void testArrayIndexOfOnSimpleIndexedTagFieldInDocuments() {
+    List<Long> rolesLengths = entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .map(User$.ROLES.indexOf("guru")) //
+        .collect(Collectors.toList());
+    assertThat(rolesLengths).hasSize(1);
+    assertThat(rolesLengths).containsExactly(2L);
+  }
+
   }
 
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
@@ -878,6 +878,53 @@ public class EntityStreamTest extends AbstractBaseDocumentTest {
     assertThat(steve.getRoles()).containsExactly("educator", "guru");
   }
   
+  @Test
+  public void testArrayTrimToRangeOnSimpleIndexedTagFieldInDocuments() {
+    entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .forEach(User$.ROLES.trimToRange(1L, 1L));
+
+    Optional<User> maybeSteve = userRepository.findFirstByName("Steve Lorello");
+    assertTrue(maybeSteve.isPresent());
+    User steve = maybeSteve.get();
+    assertThat(steve.getRoles()).containsExactly("educator");
+  }
+  
+  @Test
+  public void testArrayTrimToRangeOnSimpleIndexedTagFieldInDocuments2() {
+    entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .forEach(User$.ROLES.trimToRange(0L, 0L));
+
+    Optional<User> maybeSteve = userRepository.findFirstByName("Steve Lorello");
+    assertTrue(maybeSteve.isPresent());
+    User steve = maybeSteve.get();
+    assertThat(steve.getRoles()).containsExactly("devrel");
+  }
+  
+  @Test
+  public void testArrayTrimToRangeOnSimpleIndexedTagFieldInDocuments3() {    
+    entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .forEach(User$.ROLES.trimToRange(1L, 2L));
+
+    Optional<User> maybeSteve = userRepository.findFirstByName("Steve Lorello");
+    assertTrue(maybeSteve.isPresent());
+    User steve = maybeSteve.get();
+    assertThat(steve.getRoles()).containsExactly("educator", "guru");
+  }
+  
+  @Test
+  public void testArrayTrimToRangeOnSimpleIndexedTagFieldInDocuments4() {   
+    // "devrel", "educator", "guru"
+    entityStream.of(User.class) //
+        .filter(User$.NAME.eq("Steve Lorello")) //
+        .forEach(User$.ROLES.trimToRange(1L, -1L));
+
+    Optional<User> maybeSteve = userRepository.findFirstByName("Steve Lorello");
+    assertTrue(maybeSteve.isPresent());
+    User steve = maybeSteve.get();
+    assertThat(steve.getRoles()).containsExactly("educator", "guru");
   }
 
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
@@ -787,6 +787,15 @@ public class EntityStreamTest extends AbstractBaseDocumentTest {
     assertThat(steve.getRoles()).containsExactly("devrel", "dotnet", "educator", "guru");
   }
 
+  @Test
+  public void testArrayLenToSimpleIndexedTagFieldInDocuments() {
+    List<Long> rolesLengths = entityStream.of(User.class) //
+        .map(User$.ROLES.length()) //
+        .collect(Collectors.toList());
+    assertThat(rolesLengths).hasSize(4);
+    assertThat(rolesLengths).containsExactly(3L, 3L, 3L, 3L);
+  }
+
   }
 
 }


### PR DESCRIPTION
Implements JSON.ARR* methods as terminal operations on Entity Streams, for example:

Entity Stream on a `Company` entity with a `tags` Set field, below we find the company "Microsoft" and add the String "gaming" to the Set of tags.

```
  @Test
  public void testArrayAppendToSimpleIndexedTagFieldInDocuments() {
    entityStream.of(Company.class) //
        .filter(Company$.NAME.eq("Microsoft")) //
        .forEach(Company$.TAGS.add("gaming"));

    Optional<Company> maybeMicrosoft = repository.findFirstByEmail("research@microsoft.com");
    assertTrue(maybeMicrosoft.isPresent());
    Company microsoft = maybeMicrosoft.get();
    assertThat(microsoft.getTags()).contains("innovative", "reliable", "os", "ai", "gaming");
  }
```

Addresses [Enhance Entity Streams with RedisJSON Array commands #44](https://github.com/redis/redis-om-spring/issues/44)