### PR TITLE
Support @TimeToLive on JSON-mapped objects #66

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Document.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Document.java
@@ -27,4 +27,11 @@ public @interface Document {
   String languageField() default "";
   String language() default "";
   double score() default 1.0; 
+  
+  /**
+   * Time before expire in seconds. Superseded by {@link TimeToLive}.
+   *
+   * @return positive number when expiration should be applied.
+   */
+  long timeToLive() default -1L;
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisDocumentRepository.java
@@ -26,4 +26,6 @@ public interface RedisDocumentRepository<T, ID> extends KeyValueRepository<T, ID
   void updateField(T entity, MetamodelField<T, ?> field, Object value);
   
   <F> Iterable<F> getFieldsByIds(Iterable<ID> ids, MetamodelField<T, F> field);
+  
+  Long getExpiration(ID id);
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -79,4 +79,11 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
     return (Iterable<F>) modulesOperations.opsForJSON().mget(Path.of("$." + field.getField().getName()), List.class, keys).stream().flatMap(List::stream).collect(Collectors.toList());
   }
 
+  @Override
+  public Long getExpiration(ID id) {
+    @SuppressWarnings("unchecked")
+    RedisTemplate<String, String> template = (RedisTemplate<String, String>) modulesOperations.getTemplate();
+    return template.getExpire(metadata.getJavaType().getName() + ":" + id.toString());
+  }
+
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseEnhancedRedisTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseEnhancedRedisTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractBaseEnhancedRedisTest {
   
   @SpringBootApplication
   @Configuration
-  @EnableRedisEnhancedRepositories("com.redis.om.spring.annotations.bloom.fixtures")
+  @EnableRedisEnhancedRepositories(basePackages = {"com.redis.om.spring.annotations.bloom.fixtures", "com.redis.om.spring.annotations.hash.fixtures"})
   static class Config {
     @Autowired
     Environment env;

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/DocumentTTLTests.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/DocumentTTLTests.java
@@ -15,7 +15,7 @@ import com.redis.om.spring.annotations.document.fixtures.ExpiringPersonRepositor
 import com.redis.om.spring.annotations.document.fixtures.ExpiringPersonWithDefault;
 import com.redis.om.spring.annotations.document.fixtures.ExpiringPersonWithDefaultRepository;
 
-public class TTLTests extends AbstractBaseDocumentTest {
+public class DocumentTTLTests extends AbstractBaseDocumentTest {
   @Autowired
   ExpiringPersonWithDefaultRepository withDefaultrepository;
   

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/TTLTests.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/TTLTests.java
@@ -1,0 +1,65 @@
+package com.redis.om.spring.annotations.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.annotations.document.fixtures.ExpiringPerson;
+import com.redis.om.spring.annotations.document.fixtures.ExpiringPersonDifferentTimeUnit;
+import com.redis.om.spring.annotations.document.fixtures.ExpiringPersonDifferentTimeUnitRepository;
+import com.redis.om.spring.annotations.document.fixtures.ExpiringPersonRepository;
+import com.redis.om.spring.annotations.document.fixtures.ExpiringPersonWithDefault;
+import com.redis.om.spring.annotations.document.fixtures.ExpiringPersonWithDefaultRepository;
+
+public class TTLTests extends AbstractBaseDocumentTest {
+  @Autowired
+  ExpiringPersonWithDefaultRepository withDefaultrepository;
+  
+  @Autowired
+  ExpiringPersonRepository withTTLAnnotationRepository;
+  
+  @Autowired
+  ExpiringPersonDifferentTimeUnitRepository withTTLwTimeUnitAnnotationRepository;
+  
+  @Autowired
+  RedisTemplate<String, String> template;
+  
+  @BeforeEach
+  public void cleanUp() {
+    withDefaultrepository.deleteAll();
+  }
+  
+  @Test
+  void testClassLevelDefaultTTL() {
+    ExpiringPersonWithDefault gordon = ExpiringPersonWithDefault.of("Gordon Welchman");
+    withDefaultrepository.save(gordon);
+    
+    Long expire = withDefaultrepository.getExpiration(gordon.getId());
+    
+    assertThat(expire).isEqualTo(5L);
+  }
+  
+  @Test
+  void testTimeToLiveAnnotation() {
+    ExpiringPerson mWoodger = ExpiringPerson.of("Mike Woodger", 15L);
+    withTTLAnnotationRepository.save(mWoodger);
+
+    Long expire = withTTLAnnotationRepository.getExpiration(mWoodger.getId());
+
+    assertThat(expire).isEqualTo(15L);
+  }
+  
+  @Test
+  void testTimeToLiveAnnotationWithDifferentTimeUnit() {
+    ExpiringPersonDifferentTimeUnit jWilkinson = ExpiringPersonDifferentTimeUnit.of("Jim Wilkinson", 7L);
+    withTTLwTimeUnitAnnotationRepository.save(jWilkinson);
+
+    Long expire = withTTLwTimeUnitAnnotationRepository.getExpiration(jWilkinson.getId());
+
+    assertThat(expire).isEqualTo(7L*24*60*60);
+  }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPerson.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPerson.java
@@ -1,0 +1,24 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.TimeToLive;
+
+import com.redis.om.spring.annotations.Document;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@Document(timeToLive = 5)
+public class ExpiringPerson {
+  @Id String id;
+  @NonNull
+  String name;
+  
+  @NonNull
+  @TimeToLive Long ttl;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonDifferentTimeUnit.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonDifferentTimeUnit.java
@@ -1,0 +1,26 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.TimeToLive;
+
+import com.redis.om.spring.annotations.Document;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@Document(timeToLive = 5)
+public class ExpiringPersonDifferentTimeUnit {
+  @Id String id;
+  @NonNull
+  String name;
+  
+  @NonNull
+  @TimeToLive(unit = TimeUnit.DAYS) Long ttl;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonDifferentTimeUnitRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonDifferentTimeUnitRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface ExpiringPersonDifferentTimeUnitRepository extends RedisDocumentRepository<ExpiringPersonDifferentTimeUnit, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface ExpiringPersonRepository extends RedisDocumentRepository<ExpiringPerson, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonWithDefault.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonWithDefault.java
@@ -1,0 +1,20 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@Document(timeToLive = 5)
+public class ExpiringPersonWithDefault {
+  @Id String id;
+  @NonNull
+  String name;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonWithDefaultRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonWithDefaultRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface ExpiringPersonWithDefaultRepository extends RedisDocumentRepository<ExpiringPersonWithDefault, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashTTLTests.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashTTLTests.java
@@ -1,0 +1,65 @@
+package com.redis.om.spring.annotations.hash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.annotations.hash.fixtures.ExpiringPerson;
+import com.redis.om.spring.annotations.hash.fixtures.ExpiringPersonDifferentTimeUnit;
+import com.redis.om.spring.annotations.hash.fixtures.ExpiringPersonDifferentTimeUnitRepository;
+import com.redis.om.spring.annotations.hash.fixtures.ExpiringPersonRepository;
+import com.redis.om.spring.annotations.hash.fixtures.ExpiringPersonWithDefault;
+import com.redis.om.spring.annotations.hash.fixtures.ExpiringPersonWithDefaultRepository;
+
+public class RedisHashTTLTests extends AbstractBaseEnhancedRedisTest {
+  @Autowired
+  ExpiringPersonWithDefaultRepository withDefaultrepository;
+  
+  @Autowired
+  ExpiringPersonRepository withTTLAnnotationRepository;
+  
+  @Autowired
+  ExpiringPersonDifferentTimeUnitRepository withTTLwTimeUnitAnnotationRepository;
+  
+  @Autowired
+  RedisTemplate<String, String> template;
+  
+  @BeforeEach
+  public void cleanUp() {
+    withDefaultrepository.deleteAll();
+  }
+  
+  @Test
+  void testClassLevelDefaultTTL() {
+    ExpiringPersonWithDefault gordon = ExpiringPersonWithDefault.of("Gordon Welchman");
+    withDefaultrepository.save(gordon);
+    
+    Long expire = template.getExpire(ExpiringPersonWithDefault.class.getName() + ":" + gordon.getId());
+    
+    assertThat(expire).isEqualTo(5L);
+  }
+  
+  @Test
+  void testTimeToLiveAnnotation() {
+    ExpiringPerson mWoodger = ExpiringPerson.of("Mike Woodger", 15L);
+    withTTLAnnotationRepository.save(mWoodger);
+ 
+    Long expire = template.getExpire(ExpiringPerson.class.getName() + ":" + mWoodger.getId());
+
+    assertThat(expire).isEqualTo(15L);
+  }
+  
+  @Test
+  void testTimeToLiveAnnotationWithDifferentTimeUnit() {
+    ExpiringPersonDifferentTimeUnit jWilkinson = ExpiringPersonDifferentTimeUnit.of("Jim Wilkinson", 7L);
+    withTTLwTimeUnitAnnotationRepository.save(jWilkinson);
+
+    Long expire = template.getExpire(ExpiringPersonDifferentTimeUnit.class.getName() + ":" + jWilkinson.getId());
+
+    assertThat(expire).isEqualTo(7L*24*60*60);
+  }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPerson.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPerson.java
@@ -1,0 +1,23 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@RedisHash(timeToLive = 5)
+public class ExpiringPerson {
+  @Id String id;
+  @NonNull
+  String name;
+  
+  @NonNull
+  @TimeToLive Long ttl;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonDifferentTimeUnit.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonDifferentTimeUnit.java
@@ -1,0 +1,25 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@RedisHash(timeToLive = 5)
+public class ExpiringPersonDifferentTimeUnit {
+  @Id String id;
+  @NonNull
+  String name;
+  
+  @NonNull
+  @TimeToLive(unit = TimeUnit.DAYS) Long ttl;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonDifferentTimeUnitRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonDifferentTimeUnitRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ExpiringPersonDifferentTimeUnitRepository extends CrudRepository<ExpiringPersonDifferentTimeUnit, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ExpiringPersonRepository extends CrudRepository<ExpiringPerson, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonWithDefault.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonWithDefault.java
@@ -1,0 +1,19 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@RedisHash(timeToLive = 5)
+public class ExpiringPersonWithDefault {
+  @Id String id;
+  @NonNull
+  String name;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonWithDefaultRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ExpiringPersonWithDefaultRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ExpiringPersonWithDefaultRepository extends CrudRepository<ExpiringPersonWithDefault, String> {
+}


### PR DESCRIPTION
Provides support for:
* Default TTL for entities using `@Document` just like `@RedisHash` supports https://docs.spring.io/spring-data/redis/docs/current/api/index.html?org/springframework/data/redis/core/TimeToLive.html
* Support for `@TimeToLive` field-level annotation