### PR TITLE
feature: adds convenience generated constants for nested fields in metamodel

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
@@ -189,7 +189,7 @@ public final class MetamodelGenerator extends AbstractProcessor {
           targetCls = ClassUtils.forName(cls, MetamodelGenerator.class.getClassLoader());
         } catch (ClassNotFoundException cnfe) {
           messager.printMessage(Diagnostic.Kind.WARNING,
-              "Processing class " + entityName + " could not resolve " + cls + " checking for nested indexables");
+              "Processing class " + entityName + " could not resolve " + cls + ".  Checking for nested indexables");
           List<Pair<FieldSpec, CodeBlock>> nestedFieldContants = extractNestedConstants(field);
           for (Pair<FieldSpec, CodeBlock> fieldConstants : nestedFieldContants) {
             nestedFieldsConstants.add(fieldConstants.getFirst());

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
@@ -113,7 +113,7 @@ public final class MetamodelGenerator extends AbstractProcessor {
       try {
         generateMetaModelClass(ae);
       } catch (IOException ioe) {
-        messager.printMessage(Diagnostic.Kind.ERROR, "Cannot generate metamodel calss for " + ae.getClass().getName() + " because " + ioe.getMessage());
+        messager.printMessage(Diagnostic.Kind.ERROR, "Cannot generate metamodel class for " + ae.getClass().getName() + " because " + ioe.getMessage());
       }
     });
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/Sort.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/Sort.java
@@ -1,0 +1,29 @@
+package com.redis.om.spring.repository.query;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.redis.om.spring.metamodel.MetamodelField;
+
+public class Sort extends org.springframework.data.domain.Sort {
+
+  protected Sort(List<Order> orders) {
+    super(orders);
+  }
+  
+  /**
+   * Creates a new {@link org.springframework.data.domain.Sort} for the given {@link Order}s
+   * use {@link com.redis.om.spring.metamodel.MetamodelField}
+   *
+   * @param direction must not be {@literal null}.
+   * @param fields must not be {@literal null}.
+   * @return
+   */
+  public static org.springframework.data.domain.Sort by(Direction direction, MetamodelField<?, ?>... fields) {
+    String[] properties = Arrays.asList(fields).stream().map(metamodel ->  metamodel.getField().getName()).toArray(String[]::new);
+    return org.springframework.data.domain.Sort.by(direction, properties);
+  }
+
+  private static final long serialVersionUID = 7789210988714363618L;
+
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/ComplexDocumentSearchTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/ComplexDocumentSearchTest.java
@@ -263,7 +263,7 @@ class ComplexDocumentSearchTest extends AbstractBaseDocumentTest {
 
     assertThat(result.getTotalPages()).isEqualTo(1);
     assertThat(result.getTotalElements()).isEqualTo(2);
-    assertThat(result.getContent()).containsExactly(permit2,permit1);
+    assertThat(result.getContent()).containsExactly(permit2, permit1);
   }
 
   /**

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/ComplexDocumentSearchTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/ComplexDocumentSearchTest.java
@@ -249,7 +249,7 @@ class ComplexDocumentSearchTest extends AbstractBaseDocumentTest {
 
     assertThat(result.getTotalPages()).isEqualTo(1);
     assertThat(result.getTotalElements()).isEqualTo(2);
-    assertThat(result.getContent()).containsExactly(permit1,permit2);
+    assertThat(result.getContent()).containsExactly(permit1, permit2);
   }
 
   /**

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/ComplexDocumentSearchTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/ComplexDocumentSearchTest.java
@@ -2,6 +2,7 @@ package com.redis.om.spring.annotations.document;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -11,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.geo.Point;
 
@@ -23,6 +23,7 @@ import com.redis.om.spring.annotations.document.fixtures.Order;
 import com.redis.om.spring.annotations.document.fixtures.Permit;
 import com.redis.om.spring.annotations.document.fixtures.Permit$;
 import com.redis.om.spring.annotations.document.fixtures.PermitRepository;
+import com.redis.om.spring.repository.query.Sort;
 
 class ComplexDocumentSearchTest extends AbstractBaseDocumentTest {
   Permit permit1;
@@ -53,6 +54,7 @@ class ComplexDocumentSearchTest extends AbstractBaseDocumentTest {
             List.of("started", "in_progress", "approved"), //
             attrList1
     );
+    permit1.setPermitTimestamp(LocalDateTime.of(2022, 8, 1, 10, 0));
 
     // # Document 2
     Address address2 = Address.of("Porto", "Av. da Liberdade");
@@ -71,6 +73,7 @@ class ComplexDocumentSearchTest extends AbstractBaseDocumentTest {
             List.of("started", "in_progress", "rejected"), //
             attrList2
     );
+    permit2.setPermitTimestamp(LocalDateTime.of(2022, 8, 2, 0, 0));
 
     // # Document 3
     Address address3 = Address.of("Lagos", "D. João");
@@ -91,6 +94,7 @@ class ComplexDocumentSearchTest extends AbstractBaseDocumentTest {
             List.of("started", "in_progress", "postponed"), //
             attrList3
     );
+    permit3.setPermitTimestamp(LocalDateTime.of(2022, 8, 25, 0, 0));
 
     repository.saveAll(List.of(permit1, permit2, permit3));
   }
@@ -135,7 +139,7 @@ class ComplexDocumentSearchTest extends AbstractBaseDocumentTest {
   @Test
   void testByTagsWithNullParams() {
     // # Document 4
-    List<Attribute> attrs = List.of(); 
+    List<Attribute> attrs = List.of();
     Address address4 = Address.of("Coimbra", "R. Serra 14");
     Permit permit4 = Permit.of( //
             address4, //
@@ -205,32 +209,116 @@ class ComplexDocumentSearchTest extends AbstractBaseDocumentTest {
     Iterable<Permit> permits = repository.search(q);
     assertThat(permits).containsExactly(permit1,permit2);
   }
-  
+
+  /**
+   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "To construct*" "SORTBY" "constructionValue" "DESC"
+   */
   @Test
-  void testFullTextSearchWithPaginationDesc() {
+  void testFullTextSearchWithSortByNumericFieldDesc() {
     String q = "To construct*";
-    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.DESC, Permit$.CONSTRUCTION_VALUE.getField().getName()));
-    
+    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.DESC, Permit$.CONSTRUCTION_VALUE));
     Page<Permit> result = repository.search(q, pageRequest);
-    
-    System.out.println(result.getContent());
-    
+
     assertThat(result.getTotalPages()).isEqualTo(1);
     assertThat(result.getTotalElements()).isEqualTo(2);
     assertThat(result.getContent()).containsExactly(permit2,permit1);
   }
-  
+
+  /**
+   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "To construct*" "SORTBY" "constructionValue" "ASC"
+   */
   @Test
-  void testFullTextSearchWithPaginationAsc() {
+  void testFullTextSearchWithSortByNumericFieldAsc() {
     String q = "To construct*";
-    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.ASC, Permit$.CONSTRUCTION_VALUE.getField().getName()));
-    
+    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.ASC, Permit$.CONSTRUCTION_VALUE));
     Page<Permit> result = repository.search(q, pageRequest);
-    
-    System.out.println(result.getContent());
-    
+
     assertThat(result.getTotalPages()).isEqualTo(1);
     assertThat(result.getTotalElements()).isEqualTo(2);
     assertThat(result.getContent()).containsExactly(permit1,permit2);
+  }
+
+  /**
+   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "To construct*" "SORTBY" "buildingType" "DESC"
+   */
+  @Test
+  void testFullTextSearchWithSortByTextFieldDesc() {
+    String q = "To construct*";
+    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.DESC, Permit$.BUILDING_TYPE));
+    Page<Permit> result = repository.search(q, pageRequest);
+
+    assertThat(result.getTotalPages()).isEqualTo(1);
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent()).containsExactly(permit1,permit2);
+  }
+
+  /**
+   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "To construct*" "SORTBY" "buildingType" "ASC"
+   */
+  @Test
+  void testFullTextSearchWithSortByTextFieldAsc() {
+    String q = "To construct*";
+    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.ASC, Permit$.BUILDING_TYPE));
+    Page<Permit> result = repository.search(q, pageRequest);
+
+    assertThat(result.getTotalPages()).isEqualTo(1);
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent()).containsExactly(permit2,permit1);
+  }
+
+  /**
+   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "house|loft" "SORTBY" "permitTimestamp" "DESC"
+   */
+  @Test
+  void testFullTextSearchWithSortByDateFieldDesc() {
+    String q = "house|loft";
+    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.DESC, Permit$.PERMIT_TIMESTAMP));
+    Page<Permit> result = repository.search(q, pageRequest);
+
+    assertThat(result.getTotalPages()).isEqualTo(1);
+    assertThat(result.getTotalElements()).isEqualTo(3);
+    assertThat(result.getContent()).containsExactly(permit3,permit2,permit1);
+  }
+
+  /**
+   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "house|loft" "SORTBY" "permitTimestamp" "ASC"
+   */
+  @Test
+  void testFullTextSearchWithSortByDateFieldAsc() {
+    String q = "house|loft";
+    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.ASC, Permit$.PERMIT_TIMESTAMP));
+    Page<Permit> result = repository.search(q, pageRequest);
+
+    assertThat(result.getTotalPages()).isEqualTo(1);
+    assertThat(result.getTotalElements()).isEqualTo(3);
+    assertThat(result.getContent()).containsExactly(permit1,permit2,permit3);
+  }
+
+  /**
+   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "house|loft" "SORTBY" "address_city" "DESC"
+   */
+  @Test
+  void testFullTextSearchWithSortByNestedTextTagFieldDesc() {
+    String q = "house|loft";
+    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.DESC, Permit$.ADDRESS_CITY));
+    Page<Permit> result = repository.search(q, pageRequest);
+
+    assertThat(result.getTotalPages()).isEqualTo(1);
+    assertThat(result.getTotalElements()).isEqualTo(3);
+    assertThat(result.getContent()).containsExactly(permit2,permit1,permit3);
+  }
+
+  /**
+   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "house|loft" "SORTBY" "address_city" "ASC"
+   */
+  @Test
+  void testFullTextSearchWithSortByNestedTextTagAsc() {
+    String q = "house|loft";
+    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.ASC, Permit$.ADDRESS_CITY));
+    Page<Permit> result = repository.search(q, pageRequest);
+
+    assertThat(result.getTotalPages()).isEqualTo(1);
+    assertThat(result.getTotalElements()).isEqualTo(3);
+    assertThat(result.getContent()).containsExactly(permit3,permit1,permit2);
   }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
@@ -219,8 +219,8 @@ class MetamodelGeneratorTest {
   void testValidDocumentIndexedNested(Results results) throws IOException {
     List<String> warnings = getWarningStrings(results);
     assertThat(warnings).hasSize(1);
-//    assertThat(warnings).containsOnly(
-//        "Processing class ValidDocumentIndexedNested could not resolve valid.Address checking for nested indexables");
+    assertThat(warnings).containsOnly(
+        "Processing class ValidDocumentIndexedNested could not resolve valid.Address checking for nested indexables");
 
     List<String> errors = getErrorStrings(results);
     assertAll( //
@@ -259,9 +259,9 @@ class MetamodelGeneratorTest {
         () -> assertThat(fileContents)
             .contains("ID = new NonIndexedTextField<ValidDocumentIndexedNested, String>(id,false);"), //
         () -> assertThat(fileContents)
-            .contains("ADDRESS = new MetamodelField<ValidDocumentIndexedNested, Address>(address,true);") //
-//    assertThat(fileContents).contains("ADDRESS_STREET = new String(\"address_street\");");
-//    assertThat(fileContents).contains("ADDRESS_CITY = new String(\"address_city\");");
+            .contains("ADDRESS = new MetamodelField<ValidDocumentIndexedNested, Address>(address,true);"), //
+        () -> assertThat(fileContents).contains("ADDRESS_STREET = new String(\"address_street\");"), //
+        () -> assertThat(fileContents).contains("ADDRESS_CITY = new String(\"address_city\");") //
     );
   }
 
@@ -287,12 +287,12 @@ class MetamodelGeneratorTest {
   void testValidDocumentInBadJavaBean(Results results) throws IOException {
     assertThat(results.generated).hasSize(1);
 
-    final String NO_PROPER_JAVABEAN_MSG = "Class BadBean is not a proper JavaBean because id has no standard getter. Fix the issue to ensure stability.";
+    final String NO_PROPER_JAVABEAN_MSG = "Class BadBean is not a proper JavaBean because id has no standard getter.";
 
-    List<String> warnings = getWarningStrings(results);
+    List<String> errors = getErrorStrings(results);
     assertAll( //
-        () -> assertThat(warnings).hasSize(3), //
-        () -> assertThat(warnings).contains(NO_PROPER_JAVABEAN_MSG) //
+        () -> assertThat(errors).hasSize(3), //
+        () -> assertThat(errors).contains(NO_PROPER_JAVABEAN_MSG) //
     );
   }
 


### PR DESCRIPTION
In the example below, the `Permit` class has an `Address`, and the address has a `City`. This PR the code generator now generates nested field constants like `Permit$.ADDRESS_CITY`, which corresponds to the search field `address_city` in the schema which in turn corresponds to the (assuming a `Permit p`) to  `p.getAddress().getCity()` code structure.

```
  /**
   * "FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.PermitIdx" "house|loft" "SORTBY" "address_city" "DESC"
   */
  @Test
  void testFullTextSearchWithSortByNestedTextTagFieldDesc() {
    String q = "house|loft";
    Pageable pageRequest = PageRequest.of(0, 10).withSort(Sort.by(Direction.DESC, Permit$.ADDRESS_CITY));
    Page<Permit> result = repository.search(q, pageRequest);

    assertThat(result.getTotalPages()).isEqualTo(1);
    assertThat(result.getTotalElements()).isEqualTo(3);
    assertThat(result.getContent()).containsExactly(permit2,permit1,permit3);
  }
```