### PR TITLE
fix: honor indexing annotations 'aliases' when querying (resolves gh-97)

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
@@ -119,8 +119,6 @@ public class RedisEnhancedQuery implements RepositoryQuery {
     bloomQueryExecutor = new BloomQueryExecutor(this, modulesOperations);
     autoCompleteQueryExecutor = new AutoCompleteQueryExecutor(this, modulesOperations);
 
-    // mappingConverter.afterPropertiesSet();
-
     Class<?> repoClass = metadata.getRepositoryInterface();
     @SuppressWarnings("rawtypes")
     Class[] params = queryMethod.getParameters().stream().map(p -> p.getType()).toArray(Class[]::new);
@@ -194,44 +192,58 @@ public class RedisEnhancedQuery implements RepositoryQuery {
     try {
       field = type.getDeclaredField(property);
 
-      if (field.isAnnotationPresent(TextIndexed.class) || field.isAnnotationPresent(Searchable.class)) {
-        qf.add(Pair.of(key, QueryClause.get(FieldType.FullText, part.getType())));
+      if (field.isAnnotationPresent(TextIndexed.class)) {
+        TextIndexed indexAnnotation = field.getAnnotation(TextIndexed.class);
+        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
+      } else if (field.isAnnotationPresent(Searchable.class)) {
+        Searchable indexAnnotation = field.getAnnotation(Searchable.class);
+        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
       } else if (field.isAnnotationPresent(TagIndexed.class)) {
-        qf.add(Pair.of(key, QueryClause.get(FieldType.Tag, part.getType())));
+        TagIndexed indexAnnotation = field.getAnnotation(TagIndexed.class);
+        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
       } else if (field.isAnnotationPresent(GeoIndexed.class)) {
-        qf.add(Pair.of(key, QueryClause.get(FieldType.Geo, part.getType())));
+        GeoIndexed indexAnnotation = field.getAnnotation(GeoIndexed.class);
+        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
       } else if (field.isAnnotationPresent(NumericIndexed.class)) {
-        qf.add(Pair.of(key, QueryClause.get(FieldType.Numeric, part.getType())));
+        NumericIndexed indexAnnotation = field.getAnnotation(NumericIndexed.class);
+        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
       } else if (field.isAnnotationPresent(Indexed.class)) {
+        Indexed indexAnnotation = field.getAnnotation(Indexed.class);
+        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
         Class<?> fieldType = ClassUtils.resolvePrimitiveIfNecessary(field.getType());
         //
         // Any Character class or Boolean -> Tag Search Field
         //
         if (CharSequence.class.isAssignableFrom(fieldType) || (fieldType == Boolean.class)) {
-          qf.add(Pair.of(key, QueryClause.get(FieldType.Tag, part.getType())));
+          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
         }
         //
         // Any Numeric class -> Numeric Search Field
         //
         else if (Number.class.isAssignableFrom(fieldType) || (fieldType == LocalDateTime.class)
             || (field.getType() == LocalDate.class) || (field.getType() == Date.class)) {
-          qf.add(Pair.of(key, QueryClause.get(FieldType.Numeric, part.getType())));
+          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
         }
         //
         // Set / List
         //
         else if (Set.class.isAssignableFrom(fieldType) || List.class.isAssignableFrom(fieldType)) {
           if (isANDQuery) {
-            qf.add(Pair.of(key, QueryClause.Tag_CONTAINING_ALL));
+            qf.add(Pair.of(actualKey, QueryClause.Tag_CONTAINING_ALL));
           } else {
-            qf.add(Pair.of(key, QueryClause.get(FieldType.Tag, part.getType())));
+            qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
           }
         }
         //
         // Point
         //
         else if (fieldType == Point.class) {
-          qf.add(Pair.of(key, QueryClause.get(FieldType.Geo, part.getType())));
+          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
         }
         //
         // Recursively explore the fields for @Indexed annotated fields

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RedisDocumentWithAliasTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RedisDocumentWithAliasTest.java
@@ -1,0 +1,80 @@
+package com.redis.om.spring.annotations.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.geo.Point;
+
+import com.google.gson.JsonObject;
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.annotations.document.fixtures.Direccion;
+import com.redis.om.spring.annotations.document.fixtures.WithAlias;
+import com.redis.om.spring.annotations.document.fixtures.WithAliasRepository;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.ops.json.JSONOperations;
+
+class RedisDocumentWithAliasTest extends AbstractBaseDocumentTest {
+  @Autowired
+  WithAliasRepository repository;
+
+  @Autowired
+  RedisModulesOperations<String> modulesOperations;
+
+  String id1;
+  String id2;
+
+  @BeforeEach
+  void loadTestData() {
+    Point point1 = new Point(-122.124500, 47.640160);
+    Set<String> tags = new HashSet<String>();
+    tags.add("news");
+    tags.add("article");
+
+    WithAlias doc1 = WithAlias.of("Oye man", tags, point1, 42, Direccion.of("David", "Called F. Sur"));
+    doc1 = repository.save(doc1);
+
+    id1 = doc1.getId();
+
+    Point point2 = new Point(-122.066540, 37.377690);
+    Set<String> tags2 = new HashSet<String>();
+    tags2.add("noticias");
+    tags2.add("articulo");
+
+    WithAlias doc2 = WithAlias.of("Epa chamo", tags2, point2, 99, Direccion.of("Valencia", "Called Libra"));
+    doc2 = repository.save(doc2);
+
+    id2 = doc2.getId();
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void testBasicCrudOperations() {
+    JSONOperations<String> ops = modulesOperations.opsForJSON();
+
+    Optional<WithAlias> maybeDoc1 = repository.findById(id1);
+    assertTrue(maybeDoc1.isPresent());
+    WithAlias doc1 = maybeDoc1.get();
+
+    JsonObject rawJSON = ops.get(WithAlias.class.getName() + ":" + id1, JsonObject.class);
+    System.out.println(rawJSON.toString());
+
+    Optional<WithAlias> alsoMaybeDoc1 = repository.findFirstByNumber(42);
+    assertTrue(alsoMaybeDoc1.isPresent());
+    WithAlias alsoDoc1 = alsoMaybeDoc1.get();
+
+    assertThat(alsoDoc1.getText()).isEqualTo(doc1.getText());
+  }
+
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Direccion.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Direccion.java
@@ -1,0 +1,20 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.annotations.TagIndexed;
+import com.redis.om.spring.annotations.TextIndexed;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class Direccion {
+  @NonNull
+  @TagIndexed(alias = "ciudad")
+  private String city;
+
+  @NonNull
+  @TextIndexed(alias = "calle", nostem = true)
+  private String street;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/WithAlias.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/WithAlias.java
@@ -1,0 +1,50 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import java.util.Set;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.geo.Point;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.GeoIndexed;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.NumericIndexed;
+import com.redis.om.spring.annotations.TagIndexed;
+import com.redis.om.spring.annotations.TextIndexed;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Document
+public class WithAlias {
+  @Id
+  private String id;
+
+  @NonNull
+  @TextIndexed(alias = "texto")
+  private String text;
+
+  @NonNull
+  @TagIndexed(alias = "etiquetas")
+  private Set<String> tags;
+
+  @NonNull
+  @GeoIndexed(alias = "coordinadas")
+  private Point location;
+
+  @NonNull
+  @NumericIndexed(alias = "numero")
+  private Integer number;
+
+  @NonNull
+  @Indexed(alias = "direccion")
+  private Direccion address;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/WithAliasRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/WithAliasRepository.java
@@ -1,0 +1,9 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import java.util.Optional;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface WithAliasRepository extends RedisDocumentRepository<WithAlias, String> {
+  Optional<WithAlias> findFirstByNumber(Integer number);
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashWithAliasTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashWithAliasTest.java
@@ -1,0 +1,69 @@
+package com.redis.om.spring.annotations.hash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.geo.Point;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.annotations.hash.fixtures.Direccion;
+import com.redis.om.spring.annotations.hash.fixtures.WithAlias;
+import com.redis.om.spring.annotations.hash.fixtures.WithAliasRepository;
+
+class RedisHashWithAliasTest extends AbstractBaseEnhancedRedisTest {
+  @Autowired
+  WithAliasRepository repository;
+
+  String id1;
+  String id2;
+
+  @BeforeEach
+  void loadTestData() {
+    Point point1 = new Point(-122.124500, 47.640160);
+    Set<String> tags = new HashSet<String>();
+    tags.add("news");
+    tags.add("article");
+
+    WithAlias doc1 = WithAlias.of("Oye man", tags, point1, 42, Direccion.of("David", "Called F. Sur"));
+    doc1 = repository.save(doc1);
+
+    id1 = doc1.getId();
+
+    Point point2 = new Point(-122.066540, 37.377690);
+    Set<String> tags2 = new HashSet<String>();
+    tags2.add("noticias");
+    tags2.add("articulo");
+
+    WithAlias doc2 = WithAlias.of("Epa chamo", tags2, point2, 99, Direccion.of("Valencia", "Called Libra"));
+    doc2 = repository.save(doc2);
+
+    id2 = doc2.getId();
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void testBasicCrudOperations() {
+    Optional<WithAlias> maybeDoc1 = repository.findById(id1);
+    assertTrue(maybeDoc1.isPresent());
+    WithAlias doc1 = maybeDoc1.get();
+
+    Optional<WithAlias> alsoMaybeDoc1 = repository.findFirstByNumber(42);
+    assertTrue(alsoMaybeDoc1.isPresent());
+    WithAlias alsoDoc1 = alsoMaybeDoc1.get();
+
+    assertThat(alsoDoc1.getText()).isEqualTo(doc1.getText());
+  }
+
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/Direccion.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/Direccion.java
@@ -1,0 +1,20 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.annotations.TagIndexed;
+import com.redis.om.spring.annotations.TextIndexed;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+public class Direccion {
+  @NonNull
+  @TagIndexed(alias = "ciudad")
+  private String city;
+
+  @NonNull
+  @TextIndexed(alias = "calle", nostem = true)
+  private String street;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/WithAlias.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/WithAlias.java
@@ -1,0 +1,50 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import java.util.Set;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.core.RedisHash;
+
+import com.redis.om.spring.annotations.GeoIndexed;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.NumericIndexed;
+import com.redis.om.spring.annotations.TagIndexed;
+import com.redis.om.spring.annotations.TextIndexed;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash
+public class WithAlias {
+  @Id
+  private String id;
+
+  @NonNull
+  @TextIndexed(alias = "texto")
+  private String text;
+
+  @NonNull
+  @TagIndexed(alias = "etiquetas")
+  private Set<String> tags;
+
+  @NonNull
+  @GeoIndexed(alias = "coordinadas")
+  private Point location;
+
+  @NonNull
+  @NumericIndexed(alias = "numero")
+  private Integer number;
+
+  @NonNull
+  @Indexed(alias = "direccion")
+  private Direccion address;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/WithAliasRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/WithAliasRepository.java
@@ -1,0 +1,9 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import java.util.Optional;
+
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface WithAliasRepository extends RedisEnhancedRepository<WithAlias, String> {
+  Optional<WithAlias> findFirstByNumber(Integer number);
+}


### PR DESCRIPTION
Scenario: If there is a `@Document` or `@RedisHash` annotated object using aliases for its field, as shown below, the index is build correctly but the queries attempt to use the object field names rather than the aliases.

```
@Document
public class WithAlias {
  @Id
  private String id;

  @NonNull
  @TextIndexed(alias = "texto")
  private String text;

  @NonNull
  @TagIndexed(alias = "etiquetas")
  private Set<String> tags;

  @NonNull
  @GeoIndexed(alias = "coordinadas")
  private Point location;

  @NonNull
  @NumericIndexed(alias = "numero")
  private Integer number;

  @NonNull
  @Indexed(alias = "direccion")
  private Direccion address;
}
```

Produces:

```
"FT.CREATE" "com.redis.om.spring.annotations.document.fixtures.WithAliasIdx" "ON" "JSON" 
  "PREFIX" "1" "com.redis.om.spring.annotations.document.fixtures.WithAlias:" 
  "SCHEMA" 
    "$.text" "AS" "texto" "TEXT" 
    "$.tags[*]" "AS" "etiquetas" "TAG" "SEPARATOR" "|" 
    "$.location" "AS" "coordinadas" "GEO" 
    "$.number" "AS" "numero" "NUMERIC" 
    "$.address.city" "AS" "ciudad" "TAG" "SEPARATOR" "|" 
    "$.address.street" "AS" "calle" "TEXT" "NOSTEM"
```

The object gets serialized correctly:

```
{
  "id": "01GBQV3WENXKRWTD1MEBGJA3QX",
  "text": "Epa chamo",
  "tags": [
    "noticias",
    "articulo"
  ],
  "location": "-122.06654,37.37769",
  "number": 99,
  "address": {
    "city": "Valencia",
    "street": "Called Libra"
  }
}
```

The following query:

```
Optional<WithAlias> alsoMaybeDoc1 = repository.findFirstByNumber(42);
```

currently produces:

````
"FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.WithAliasIdx" "@number:[42 42]"
````

But it **SHOULD BE**:

```
"FT.SEARCH" "com.redis.om.spring.annotations.document.fixtures.WithAliasIdx" "@numero:[42 42]"
```