### PR TITLE
build: skip demo project during deploys (maven.deploy.skip in POM)

### DIFF
--- a/demos/roms-documents/pom.xml
+++ b/demos/roms-documents/pom.xml
@@ -23,6 +23,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.test.source>11</maven.test.source>
     <maven.test.target>11</maven.test.target>
+    <maven.deploy.skip>true</maven.deploy.skip>
     <testcontainers.redis.version>1.5.2</testcontainers.redis.version>
     <testcontainers.redis.junit.version>1.4.6</testcontainers.redis.junit.version>
   </properties>

--- a/demos/roms-hashes/pom.xml
+++ b/demos/roms-hashes/pom.xml
@@ -23,6 +23,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.test.source>11</maven.test.source>
     <maven.test.target>11</maven.test.target>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <dependencies>

--- a/demos/roms-permits/pom.xml
+++ b/demos/roms-permits/pom.xml
@@ -23,6 +23,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <maven.test.source>11</maven.test.source>
     <maven.test.target>11</maven.test.target>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Enable releases and draft releases by skipping the demo project which should not be released