### PR TITLE
fix: addresses null key prefix when indices already created (resolves…

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RediSearchIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RediSearchIndexer.java
@@ -171,8 +171,9 @@ public class RediSearchIndexer {
 
       index.setPrefixes(entityPrefix);
       IndexOptions ops = Client.IndexOptions.defaultOptions().setDefinition(index);
-      opsForSearch.createIndex(schema, ops);
       addKeySpaceMapping(entityPrefix, cl);
+      opsForSearch.createIndex(schema, ops);
+      
 
       // TTL
       if (cl.isAnnotationPresent(Document.class)) {


### PR DESCRIPTION
… gh-122)

Addresses https://github.com/redis/redis-om-spring/issues/122

The issue is the create index call will throw an exception if the index already exists, and that was happening before we added the class to the Indexer. Therefore there was no way to get the prefix to construct the key.