### PR TITLE
Bsb/moar cleanup

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RediSearchIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RediSearchIndexer.java
@@ -121,14 +121,17 @@ public class RediSearchIndexer {
       Optional<java.lang.reflect.Field> maybeIdField = getIdFieldForEntityClass(cl);
       if (maybeIdField.isPresent()) {
         java.lang.reflect.Field idField = maybeIdField.get();
-        if (!fields.stream().anyMatch(f -> f.name.equals(idField.getName()))) {
-          if (Number.class.isAssignableFrom(idField.getType())) {
-            fields
-                .add(indexAsNumericFieldFor(maybeIdField.get(), idxType == IndexDefinition.Type.JSON, "", true, false));
-          } else {
-            fields.add(
-                indexAsTagFieldFor(maybeIdField.get(), idxType == IndexDefinition.Type.JSON, "", false, ",",
-                    Integer.MIN_VALUE));
+        // Only auto-index the @Id if not already indexed by the user (gh-135)
+        if (!idField.isAnnotationPresent(Indexed.class) && !idField.isAnnotationPresent(Searchable.class)) {
+          if (!fields.stream().anyMatch(f -> f.name.equals(idField.getName()))) {
+            if (Number.class.isAssignableFrom(idField.getType())) {
+              fields
+                  .add(indexAsNumericFieldFor(maybeIdField.get(), idxType == IndexDefinition.Type.JSON, "", true, false));
+            } else {
+              fields.add(
+                  indexAsTagFieldFor(maybeIdField.get(), idxType == IndexDefinition.Type.JSON, "", false, ",",
+                      Integer.MIN_VALUE));
+            }
           }
         }
       }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisJSONKeyValueAdapter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisJSONKeyValueAdapter.java
@@ -14,7 +14,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.beans.PropertyAccessor;
 import org.springframework.beans.PropertyAccessorFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.redis.core.RedisCallback;
@@ -29,6 +28,7 @@ import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.redis.om.spring.convert.RedisOMCustomConversions;
 import com.redis.om.spring.ops.RedisModulesOperations;
 import com.redis.om.spring.ops.json.JSONOperations;
@@ -48,8 +48,6 @@ public class RedisJSONKeyValueAdapter extends RedisKeyValueAdapter {
   private @Nullable String keyspaceNotificationsConfigParameter = null;
   private RedisModulesOperations<String> modulesOperations;
   private RediSearchIndexer indexer;
-
-  @Autowired
   private Gson gson;
 
   /**
@@ -63,13 +61,14 @@ public class RedisJSONKeyValueAdapter extends RedisKeyValueAdapter {
    */
   @SuppressWarnings("unchecked")
   public RedisJSONKeyValueAdapter(RedisOperations<?, ?> redisOps, RedisModulesOperations<?> rmo,
-      RedisMappingContext mappingContext, RediSearchIndexer keyspaceToIndexMap) {
+      RedisMappingContext mappingContext, RediSearchIndexer keyspaceToIndexMap, GsonBuilder gsonBuilder) {
     super(redisOps, mappingContext, new RedisOMCustomConversions());
     this.modulesOperations = (RedisModulesOperations<String>) rmo;
     this.redisJSONOperations = modulesOperations.opsForJSON();
     this.redisOperations = redisOps;
     this.mappingContext = mappingContext;
     this.indexer = keyspaceToIndexMap;
+    this.gson = gsonBuilder.create();
   }
 
   /*

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -120,16 +120,18 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
   @Bean(name = "redisJSONKeyValueAdapter")
   RedisJSONKeyValueAdapter getRedisJSONKeyValueAdapter(RedisOperations<?, ?> redisOps,
       RedisModulesOperations<?> redisModulesOperations, RedisMappingContext mappingContext,
-      RediSearchIndexer keyspaceToIndexMap) {
-    return new RedisJSONKeyValueAdapter(redisOps, redisModulesOperations, mappingContext, keyspaceToIndexMap);
+      RediSearchIndexer keyspaceToIndexMap,
+      GsonBuilder gsonBuilder) {
+    return new RedisJSONKeyValueAdapter(redisOps, redisModulesOperations, mappingContext, keyspaceToIndexMap, gsonBuilder);
   }
 
   @Bean(name = "redisJSONKeyValueTemplate")
   public CustomRedisKeyValueTemplate getRedisJSONKeyValueTemplate(RedisOperations<?, ?> redisOps,
       RedisModulesOperations<?> redisModulesOperations, RedisMappingContext mappingContext,
-      RediSearchIndexer keyspaceToIndexMap) {
+      RediSearchIndexer keyspaceToIndexMap,
+      GsonBuilder gsonBuilder) {
     return new CustomRedisKeyValueTemplate(
-        getRedisJSONKeyValueAdapter(redisOps, redisModulesOperations, mappingContext, keyspaceToIndexMap),
+        getRedisJSONKeyValueAdapter(redisOps, redisModulesOperations, mappingContext, keyspaceToIndexMap, gsonBuilder),
         mappingContext);
   }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Query.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Query.java
@@ -12,21 +12,8 @@ import java.lang.annotation.Target;
 public @interface Query {
   String value() default "*";
   String[] returnFields() default {};
-  
-  //returnFields(returnFields);
-  //limit(null, null)
-  //addFilter(null)
-  //highlightFields(null)
-  //limitFields(String...)
-  //limitKeys()
-  //returnFields()
-  //setLanguage()
-  //setNoContent()
-  //setNoStopwords()
-  //setPayload()
-  //setScorer()
-  //setSortBy(, )
-  //setVerbatim()
-  //setWithPayload()
-  //setWithScores()
+  int offset() default Integer.MIN_VALUE;
+  int limit() default Integer.MIN_VALUE;
+  String sortBy() default "";
+  boolean sortAscending() default true;
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisDocumentRepository.java
@@ -12,20 +12,21 @@ import com.redislabs.modules.rejson.Path;
 public interface RedisDocumentRepository<T, ID> extends KeyValueRepository<T, ID> {
 
   Iterable<ID> getIds();
-  
+
   /**
-   * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.
+   * Returns a {@link Page} of ids meeting the paging restriction provided in
+   * the {@code Pageable} object.
    *
    * @param pageable encapsulates pagination information
-   * @return a page of entities
+   * @return a page of ids
    */
   Page<ID> getIds(Pageable pageable);
-  
+
   void deleteById(ID id, Path path);
-  
+
   void updateField(T entity, MetamodelField<T, ?> field, Object value);
-  
+
   <F> Iterable<F> getFieldsByIds(Iterable<ID> ids, MetamodelField<T, F> field);
-  
+
   Long getExpiration(ID id);
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisEnhancedRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisEnhancedRepository.java
@@ -11,18 +11,19 @@ import com.redis.om.spring.metamodel.MetamodelField;
 public interface RedisEnhancedRepository<T, ID> extends KeyValueRepository<T, ID> {
 
   Iterable<ID> getIds();
-  
+
   /**
-   * Returns a {@link Page} of entities meeting the paging restriction provided in the {@code Pageable} object.
+   * Returns a {@link Page} of ids meeting the paging restriction provided in
+   * the {@code Pageable} object.
    *
    * @param pageable encapsulates pagination information
-   * @return a page of entities
+   * @return a page of ids
    */
   Page<ID> getIds(Pageable pageable);
-  
+
   void updateField(T entity, MetamodelField<T, ?> field, Object value);
-  
+
   <F> Iterable<F> getFieldsByIds(Iterable<ID> ids, MetamodelField<T, F> field);
-  
+
   Long getExpiration(ID id);
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -359,7 +359,8 @@ public class RediSearchQuery implements RepositoryQuery {
     } else if (queryMethod.isQueryForEntity() && !queryMethod.isCollectionQuery()) {
       if (!searchResult.docs.isEmpty()) {
         Document doc = searchResult.docs.get(0);
-        String jsonResult = doc != null ? doc.get("$").toString() : "";
+        Object json = doc != null ? doc.get("$") : "";
+        String jsonResult = json != null ? json.toString() : "";
         result = gson.fromJson(jsonResult, queryMethod.getReturnedObjectType());
       } else {
         result = null;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -74,6 +74,10 @@ public class RediSearchQuery implements RepositoryQuery {
 
   // query fields
   private String[] returnFields;
+  private Integer offset;
+  private Integer limit;
+  private String sortBy;
+  private Boolean sortAscending;
 
   // aggregation fields
   private String[] load;
@@ -130,6 +134,10 @@ public class RediSearchQuery implements RepositoryQuery {
         this.type = RediSearchQueryType.QUERY;
         this.value = queryAnnotation.value();
         this.returnFields = queryAnnotation.returnFields();
+        this.offset = queryAnnotation.offset();
+        this.limit = queryAnnotation.limit();
+        this.sortBy = queryAnnotation.sortBy();
+        this.sortAscending = queryAnnotation.sortAscending();
       } else if (method.isAnnotationPresent(Aggregation.class)) {
         Aggregation aggregation = method.getAnnotation(Aggregation.class);
         this.type = RediSearchQueryType.AGGREGATION;
@@ -309,6 +317,14 @@ public class RediSearchQuery implements RepositoryQuery {
           }
         }
       }
+    }
+    
+    if ((limit != null && limit != Integer.MIN_VALUE) || (offset != null && offset != Integer.MIN_VALUE)) {
+      query.limit(offset != null ? offset : 10, limit != null ? limit : 0);
+    }
+    
+    if ((sortBy != null && !sortBy.isBlank())) {
+      query.setSortBy(sortBy, sortAscending);
     }
 
     // Intercept TAG collection queries with empty parameters and use an

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -53,6 +53,7 @@ import com.redis.om.spring.repository.query.clause.QueryClause;
 import com.redis.om.spring.util.ObjectUtils;
 
 import io.redisearch.AggregationResult;
+import io.redisearch.Document;
 import io.redisearch.Query;
 import io.redisearch.Schema.FieldType;
 import io.redisearch.SearchResult;
@@ -341,7 +342,8 @@ public class RediSearchQuery implements RepositoryQuery {
 
     } else if (queryMethod.isQueryForEntity() && !queryMethod.isCollectionQuery()) {
       if (!searchResult.docs.isEmpty()) {
-        String jsonResult = searchResult.docs.get(0).get("$").toString();
+        Document doc = searchResult.docs.get(0);
+        String jsonResult = doc != null ? doc.get("$").toString() : "";
         result = gson.fromJson(jsonResult, queryMethod.getReturnedObjectType());
       } else {
         result = null;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
@@ -75,6 +75,10 @@ public class RedisEnhancedQuery implements RepositoryQuery {
 
   // query fields
   private String[] returnFields;
+  private Integer offset;
+  private Integer limit;
+  private String sortBy;
+  private Boolean sortAscending;
 
   // aggregation fields
   private String[] load;
@@ -130,6 +134,10 @@ public class RedisEnhancedQuery implements RepositoryQuery {
         this.type = RediSearchQueryType.QUERY;
         this.value = queryAnnotation.value();
         this.returnFields = queryAnnotation.returnFields();
+        this.offset = queryAnnotation.offset();
+        this.limit = queryAnnotation.limit();
+        this.sortBy = queryAnnotation.sortBy();
+        this.sortAscending = queryAnnotation.sortAscending();
       } else if (method.isAnnotationPresent(com.redis.om.spring.annotations.Aggregation.class)) {
         Aggregation aggregation = method.getAnnotation(Aggregation.class);
         this.type = RediSearchQueryType.AGGREGATION;
@@ -309,6 +317,14 @@ public class RedisEnhancedQuery implements RepositoryQuery {
           }
         }
       }
+    }
+    
+    if ((limit != null && limit != Integer.MIN_VALUE) || (offset != null && offset != Integer.MIN_VALUE)) {
+      query.limit(offset != null ? offset : 10, limit != null ? limit : 0);
+    }
+    
+    if ((sortBy != null && !sortBy.isBlank())) {
+      query.setSortBy(sortBy, sortAscending);
     }
 
     // Intercept TAG collection queries with empty parameters and use an

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RedisDocumentSearchTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RedisDocumentSearchTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -196,6 +197,48 @@ class RedisDocumentSearchTest extends AbstractBaseDocumentTest {
 
     MyDoc doc1 = result.getContent().get(0);
     assertEquals("hello world", doc1.getTitle());
+  }
+
+  @Test
+  void testQueryAnnotationWithReturnFieldsAndLimitAndOffset() {
+    repository.deleteAll();
+    Point point = new Point(-122.066540, 37.377690);
+    repository.saveAll(List.of(
+        MyDoc.of("predisposition", point, point, 4), //
+        MyDoc.of("predestination", point, point, 8), //
+        MyDoc.of("prepublication", point, point, 15), //
+        MyDoc.of("predestinarian", point, point, 16), //
+        MyDoc.of("preadolescence", point, point, 23), //
+        MyDoc.of("premillenarian", point, point, 42), //
+        MyDoc.of("precipitinogen", point, point, 4), //
+        MyDoc.of("precipitations", point, point, 8), //
+        MyDoc.of("precociousness", point, point, 15), //
+        MyDoc.of("precombustions", point, point, 16), //
+        MyDoc.of("preconditioned", point, point, 23), //
+        MyDoc.of("preconceptions", point, point, 42), //
+        MyDoc.of("precipitancies", point, point, 4), //
+        MyDoc.of("preciousnesses", point, point, 8), //
+        MyDoc.of("precentorships", point, point, 15), //
+        MyDoc.of("preceptorships", point, point, 16) //
+    ));
+
+    SearchResult result = repository.customFindAllByTitleStartingWithReturnFieldsAndLimit("pre");
+
+    assertEquals(16, result.totalResults);
+    assertThat(result.totalResults).isEqualTo(16);
+    assertThat(result.docs).hasSize(12);
+    assertThat(result.docs.get(0).get("title")).isEqualTo("precentorships");
+    assertThat(result.docs.get(1).get("title")).isEqualTo("preceptorships");
+    assertThat(result.docs.get(2).get("title")).isEqualTo("preciousnesses");
+    assertThat(result.docs.get(3).get("title")).isEqualTo("precipitancies");
+    assertThat(result.docs.get(4).get("title")).isEqualTo("precipitations");
+    assertThat(result.docs.get(5).get("title")).isEqualTo("precipitinogen");
+    assertThat(result.docs.get(6).get("title")).isEqualTo("precociousness");
+    assertThat(result.docs.get(7).get("title")).isEqualTo("precombustions");
+    assertThat(result.docs.get(8).get("title")).isEqualTo("preconceptions");
+    assertThat(result.docs.get(9).get("title")).isEqualTo("preconditioned");
+    assertThat(result.docs.get(10).get("title")).isEqualTo("predestinarian");
+    assertThat(result.docs.get(11).get("title")).isEqualTo("predestination");
   }
 
   @Test

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPerson.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPerson.java
@@ -4,6 +4,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.TimeToLive;
 
 import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -16,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 @Document(timeToLive = 5)
 public class ExpiringPerson {
   @Id String id;
-  @NonNull
+  @NonNull @Indexed
   String name;
   
   @NonNull

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/ExpiringPersonRepository.java
@@ -1,6 +1,9 @@
 package com.redis.om.spring.annotations.document.fixtures;
 
+import java.util.Optional;
+
 import com.redis.om.spring.repository.RedisDocumentRepository;
 
 public interface ExpiringPersonRepository extends RedisDocumentRepository<ExpiringPerson, String> {
+  Optional<ExpiringPerson> findOneByName(String name);
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/MyDoc.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/MyDoc.java
@@ -29,7 +29,7 @@ public class MyDoc {
   @Id
   private String id;
   @NonNull
-  @TextIndexed(alias = "title")
+  @TextIndexed(alias = "title", sortable = true)
   private String title;
   
   @NonNull

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/MyDocRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/MyDocRepository.java
@@ -66,6 +66,14 @@ public interface MyDocRepository extends RedisDocumentRepository<MyDoc, String>,
   
   /**
    * <pre>
+   * > FT.SEARCH idx @title:pre* SORTBY title ASC LIMIT 1 12 RETURN 2 title aNumber
+   * </pre>
+   */
+  @Query(value="@title:$prefix*", returnFields={"title", "aNumber"}, limit = 12, offset = 1, sortBy = "title")
+  SearchResult customFindAllByTitleStartingWithReturnFieldsAndLimit(@Param("prefix") String prefix);
+  
+  /**
+   * <pre>
    * > FT.TAGVALS idx tags
    * </pre>
    */

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashSearchTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashSearchTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
@@ -28,6 +29,8 @@ import org.springframework.data.redis.core.RedisTemplate;
 import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
 import com.redis.om.spring.annotations.hash.fixtures.MyHash;
 import com.redis.om.spring.annotations.hash.fixtures.MyHashRepository;
+
+import io.redisearch.SearchResult;
 
 class RedisHashSearchTest extends AbstractBaseEnhancedRedisTest {
   @Autowired
@@ -244,6 +247,48 @@ class RedisHashSearchTest extends AbstractBaseEnhancedRedisTest {
     MyHash doc = results.iterator().next();
     assertEquals("hello world", doc.getTitle());
     assertThat(doc.getTag()).containsExactlyInAnyOrder("news", "article");
+  }
+  
+  @Test
+  void testQueryAnnotationWithReturnFieldsAndLimitAndOffset() {
+    repository.deleteAll();
+    Point point = new Point(-122.066540, 37.377690);
+    repository.saveAll(List.of(
+        MyHash.of("predisposition", point, point, 4), //
+        MyHash.of("predestination", point, point, 8), //
+        MyHash.of("prepublication", point, point, 15), //
+        MyHash.of("predestinarian", point, point, 16), //
+        MyHash.of("preadolescence", point, point, 23), //
+        MyHash.of("premillenarian", point, point, 42), //
+        MyHash.of("precipitinogen", point, point, 4), //
+        MyHash.of("precipitations", point, point, 8), //
+        MyHash.of("precociousness", point, point, 15), //
+        MyHash.of("precombustions", point, point, 16), //
+        MyHash.of("preconditioned", point, point, 23), //
+        MyHash.of("preconceptions", point, point, 42), //
+        MyHash.of("precipitancies", point, point, 4), //
+        MyHash.of("preciousnesses", point, point, 8), //
+        MyHash.of("precentorships", point, point, 15), //
+        MyHash.of("preceptorships", point, point, 16) //
+    ));
+
+    SearchResult result = repository.customFindAllByTitleStartingWithReturnFieldsAndLimit("pre");
+
+    assertEquals(16, result.totalResults);
+    assertThat(result.totalResults).isEqualTo(16);
+    assertThat(result.docs).hasSize(12);
+    assertThat(result.docs.get(0).get("title")).isEqualTo("precentorships");
+    assertThat(result.docs.get(1).get("title")).isEqualTo("preceptorships");
+    assertThat(result.docs.get(2).get("title")).isEqualTo("preciousnesses");
+    assertThat(result.docs.get(3).get("title")).isEqualTo("precipitancies");
+    assertThat(result.docs.get(4).get("title")).isEqualTo("precipitations");
+    assertThat(result.docs.get(5).get("title")).isEqualTo("precipitinogen");
+    assertThat(result.docs.get(6).get("title")).isEqualTo("precociousness");
+    assertThat(result.docs.get(7).get("title")).isEqualTo("precombustions");
+    assertThat(result.docs.get(8).get("title")).isEqualTo("preconceptions");
+    assertThat(result.docs.get(9).get("title")).isEqualTo("preconditioned");
+    assertThat(result.docs.get(10).get("title")).isEqualTo("predestinarian");
+    assertThat(result.docs.get(11).get("title")).isEqualTo("predestination");
   }
 
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/MyHash.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/MyHash.java
@@ -30,7 +30,7 @@ public class MyHash {
   private String id;
   
   @NonNull
-  @TextIndexed(alias = "title")
+  @TextIndexed(alias = "title", sortable = true)
   private String title;
   
   @NonNull

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/MyHashRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/MyHashRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 import com.redis.om.spring.annotations.Query;
 import com.redis.om.spring.repository.RedisEnhancedRepository;
 
+import io.redisearch.SearchResult;
+
 public interface MyHashRepository extends RedisEnhancedRepository<MyHash, String>, MyHashQueries {
   /**
    * <pre>
@@ -38,6 +40,14 @@ public interface MyHashRepository extends RedisEnhancedRepository<MyHash, String
    */
   @Query("@title:$prefix*")
   Page<MyHash> customFindAllByTitleStartingWith(@Param("prefix") String prefix, Pageable pageable);
+  
+  /**
+   * <pre>
+   * > FT.SEARCH idx @title:pre* SORTBY title ASC LIMIT 1 12 RETURN 2 title aNumber
+   * </pre>
+   */
+  @Query(value="@title:$prefix*", returnFields={"title", "aNumber"}, limit = 12, offset = 1, sortBy = "title")
+  SearchResult customFindAllByTitleStartingWithReturnFieldsAndLimit(@Param("prefix") String prefix);
   
   /**
    * <pre>


### PR DESCRIPTION
```
* 914ac2c - fix: remove @Autowired in favor of constructor injection (resolved gh-133) Brian Sam-Bodden (55 seconds ago)
* 7d48b47 - fix: Only autoindex @Id field when not explicitely indexed by the user (resolves gh-135) Brian Sam-Bodden (25 minutes ago)
* c767424 - fix: NPE when querying an expired (TTL) JSON document - check .get($) (resolves gh-131) Brian Sam-Bodden (25 hours ago)
* 91f2c31 - feature: Add limit/offset support to @Query (resolves gh-125) Brian Sam-Bodden (5 days ago)
* d5a4895 - fix: NPE when querying an expired (TTL) JSON document (resolves gh-131) Brian Sam-Bodden (5 days ago)
* 1b9b76c - docs: fix Javadoc for getIds methods Brian Sam-Bodden (5 days ago)
* 63fd4c4 - (upstream/main, upstream/HEAD, origin/main, origin/HEAD, main) release: 0.6.3 Brian Sam-Bodden (5 days ago)
```

Addresses #125, #131, #133 and #135