### PR TITLE
build: add <distributionManagement> element parent pom - bump version…

### DIFF
--- a/demos/roms-documents/pom.xml
+++ b/demos/roms-documents/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.6.3</version>
+      <version>0.6.4</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/demos/roms-hashes/pom.xml
+++ b/demos/roms-hashes/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.6.3</version>
+      <version>0.6.4</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/demos/roms-permits/pom.xml
+++ b/demos/roms-permits/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.6.3</version>
+      <version>0.6.4</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring-parent</artifactId>
-  <version>0.6.3</version>
+  <version>0.6.4</version>
   <name>redis-om-spring-parent</name>
   <packaging>pom</packaging>
 
@@ -18,6 +18,17 @@
     <maven.test.target>11</maven.test.target>
     <java.version>11</java.version>
   </properties>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 
   <modules>
     <!-- Main Project -->

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring</artifactId>
-  <version>0.6.3</version>
+  <version>0.6.4</version>
   <packaging>jar</packaging>
 
   <name>redis-om-spring</name>
@@ -242,6 +242,10 @@
       <id>ossrh</id>
       <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
   </distributionManagement>
 
   <build>


### PR DESCRIPTION
… to 0.6.4

@chayim based on our chat:

```
Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.7:deploy (default-deploy) on project redis-om-spring-parent: Deployment failed: repository element was not specified in the POM inside distributionManagement element or in -DaltDeploymentRepository=id::layout::url parameter -
```

I've added the distributionManagement element to the parent POM. After approval I'll try a SNAPSHOT deployment via the GH actions and then in a couple of weeks we can try a RELEASE.