### PR TITLE
shortcut aggregations for Streams min/max

### DIFF
--- a/demos/roms-documents/pom.xml
+++ b/demos/roms-documents/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.7</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -24,8 +24,6 @@
     <maven.test.source>11</maven.test.source>
     <maven.test.target>11</maven.test.target>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <testcontainers.redis.version>1.5.2</testcontainers.redis.version>
-    <testcontainers.redis.junit.version>1.4.6</testcontainers.redis.junit.version>
   </properties>
 
   <dependencies>
@@ -68,18 +66,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.redis.testcontainers</groupId>
-      <artifactId>testcontainers-redis</artifactId>
-      <version>${testcontainers.redis.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.redis.testcontainers</groupId>
-      <artifactId>testcontainers-redis-junit-jupiter</artifactId>
-      <version>${testcontainers.redis.junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/demos/roms-hashes/pom.xml
+++ b/demos/roms-hashes/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.7</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/demos/roms-permits/pom.xml
+++ b/demos/roms-permits/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.7</version>
     <relativePath />
     <!-- lookup parent from repository -->
   </parent>

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -57,8 +57,8 @@
     <maven.test.source>11</maven.test.source>
     <maven.test.target>11</maven.test.target>
     <java.version>11</java.version>
-    <spring.version>2.7.4</spring.version>
-    <sdr.version>2.7.3</sdr.version>
+    <spring.version>2.7.7</spring.version>
+    <sdr.version>2.7.6</sdr.version>
     <jredisjson.version>1.5.0</jredisjson.version>
     <jredisearch.version>2.2.0</jredisearch.version>
     <jredisbloom.version>2.2.0</jredisbloom.version>

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelField.java
@@ -1,5 +1,7 @@
 package com.redis.om.spring.metamodel;
 
+import org.springframework.data.domain.Sort.Order;
+
 import java.util.Comparator;
 import java.util.function.Function;
 
@@ -45,5 +47,13 @@ public class MetamodelField<E, T> implements Comparator<E>, Function<E,T> {
 
   public Class<?> getTargetClass() {
     return searchFieldAccessor != null ? searchFieldAccessor.getTargetClass() : String.class;
+  }
+
+  public Order asc() {
+    return Order.asc("@" + getSearchAlias());
+  }
+
+  public Order desc() {
+    return Order.desc("@" + getSearchAlias());
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/ReturnFieldsSearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/ReturnFieldsSearchStreamImpl.java
@@ -2,6 +2,7 @@ package com.redis.om.spring.search.stream;
 
 import com.google.gson.Gson;
 import com.redis.om.spring.metamodel.MetamodelField;
+import com.redis.om.spring.metamodel.indexed.NumericField;
 import com.redis.om.spring.search.stream.predicates.SearchFieldPredicate;
 import com.redis.om.spring.tuple.Tuple;
 import com.redis.om.spring.tuple.Tuples;
@@ -357,6 +358,14 @@ public class ReturnFieldsSearchStreamImpl<E, T> implements SearchStream<T> {
 
   @Override public <R> AggregationStream<R> load(MetamodelField<T, ?>... fields) {
     throw new UnsupportedOperationException("load is not supported on a ReturnFieldSearchStream");
+  }
+
+  @Override public Optional<T> min(NumericField<T, ?> field) {
+    throw new UnsupportedOperationException("min is not supported on a ReturnFieldSearchStream");
+  }
+
+  @Override public Optional<T> max(NumericField<T, ?> field) {
+    throw new UnsupportedOperationException("max is not supported on a ReturnFieldSearchStream");
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStream.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStream.java
@@ -1,6 +1,7 @@
 package com.redis.om.spring.search.stream;
 
 import com.redis.om.spring.metamodel.MetamodelField;
+import com.redis.om.spring.metamodel.indexed.NumericField;
 import com.redis.om.spring.search.stream.predicates.SearchFieldPredicate;
 import io.redisearch.aggregation.SortedField.SortOrder;
 
@@ -87,4 +88,8 @@ public interface SearchStream<E> extends BaseStream<E, SearchStream<E>> {
   <R> AggregationStream<R> apply(String expression, String alias);
 
   <R> AggregationStream<R> load(MetamodelField<E, ?>... fields);
+
+  Optional<E> min(NumericField<E, ?> field);
+
+  Optional<E> max(NumericField<E, ?> field);
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/WrapperSearchStream.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/WrapperSearchStream.java
@@ -1,6 +1,7 @@
 package com.redis.om.spring.search.stream;
 
 import com.redis.om.spring.metamodel.MetamodelField;
+import com.redis.om.spring.metamodel.indexed.NumericField;
 import com.redis.om.spring.search.stream.predicates.SearchFieldPredicate;
 import io.redisearch.aggregation.SortedField.SortOrder;
 
@@ -252,6 +253,14 @@ public class WrapperSearchStream<E> implements SearchStream<E> {
 
   @Override public <R> AggregationStream<R> load(MetamodelField<E, ?>... fields) {
     throw new UnsupportedOperationException("load is not supported on a WrappedSearchStream");
+  }
+
+  @Override public Optional<E> min(NumericField<E, ?> field) {
+    throw new UnsupportedOperationException("min is not supported on a WrappedSearchStream");
+  }
+
+  @Override public Optional<E> max(NumericField<E, ?> field) {
+    throw new UnsupportedOperationException("max is not supported on a WrappedSearchStream");
   }
 
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsAggregationsTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsAggregationsTest.java
@@ -543,7 +543,7 @@ class EntityStreamsAggregationsTest extends AbstractBaseDocumentTest {
     List<Pair<String, Double>> sumPrice = entityStream
         .of(Game.class) //
         .load(Game$.TITLE) //
-        .sorted(Order.asc("@price")) //
+        .sorted(Game$.PRICE.asc()) //
         .limit(2) //
         .toList(String.class, Double.class);
 
@@ -575,7 +575,7 @@ class EntityStreamsAggregationsTest extends AbstractBaseDocumentTest {
     List<Triple<String, Double, String>> loadWithDocId = entityStream
         .of(Game.class) //
         .load(Game$.BRAND, Game$.PRICE, Game$._KEY) //
-        .sorted(4, Order.desc("@price")) //
+        .sorted(4, Game$.PRICE.desc()) //
         .toList(String.class, Double.class, String.class);
 
     IntStream.range(0, expectedData.size() - 1).forEach(i -> {
@@ -592,7 +592,7 @@ class EntityStreamsAggregationsTest extends AbstractBaseDocumentTest {
     // The long way...
     List<Pair<String, Double>> minAggregation = entityStream.of(Game.class) //
         .load(Game$._KEY) //
-        .sorted(Order.asc("@price"))
+        .sorted(Game$.PRICE.asc())
         .limit(1) //
         .toList(String.class, Double.class);
 
@@ -615,7 +615,7 @@ class EntityStreamsAggregationsTest extends AbstractBaseDocumentTest {
     // The long way...
     List<Pair<String, Double>> maxAggregation = entityStream.of(Game.class) //
         .load(Game$._KEY) //
-        .sorted(Order.desc("@price"))
+        .sorted(Game$.PRICE.desc())
         .limit(1) //
         .toList(String.class, Double.class);
 
@@ -633,7 +633,4 @@ class EntityStreamsAggregationsTest extends AbstractBaseDocumentTest {
         .map(Game::getPrice)
         .hasValue(expected.getSecond());
   }
-
-
-
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsAggregationsTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsAggregationsTest.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Sort.Order;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -585,6 +586,52 @@ class EntityStreamsAggregationsTest extends AbstractBaseDocumentTest {
       assertEquals(expected.getSecond(), actual.getSecond());
       assertEquals(expected.getThird(), actual.getThird());
     });
+  }
+
+  @Test void testEntityStreamMin() {
+    // The long way...
+    List<Pair<String, Double>> minAggregation = entityStream.of(Game.class) //
+        .load(Game$._KEY) //
+        .sorted(Order.asc("@price"))
+        .limit(1) //
+        .toList(String.class, Double.class);
+
+    Pair<String,Double> expected = minAggregation.get(0);
+
+    // The short way...
+    Optional<Game> actual = entityStream.of(Game.class).min(Game$.PRICE);
+
+    assertThat(actual) //
+        .isPresent() //
+        .map(Game::getAsin) //
+        .hasValue(expected.getFirst().split(":")[1]);
+
+    assertThat(actual) //
+        .map(Game::getPrice)
+        .hasValue(expected.getSecond());
+  }
+
+  @Test void testEntityStreamMax() {
+    // The long way...
+    List<Pair<String, Double>> maxAggregation = entityStream.of(Game.class) //
+        .load(Game$._KEY) //
+        .sorted(Order.desc("@price"))
+        .limit(1) //
+        .toList(String.class, Double.class);
+
+    Pair<String,Double> expected = maxAggregation.get(0);
+
+    // The short way...
+    Optional<Game> actual = entityStream.of(Game.class).max(Game$.PRICE);
+
+    assertThat(actual) //
+        .isPresent() //
+        .map(Game::getAsin) //
+        .hasValue(expected.getFirst().split(":")[1]);
+
+    assertThat(actual) //
+        .map(Game::getPrice)
+        .hasValue(expected.getSecond());
   }
 
 


### PR DESCRIPTION
Implements `min` and `max` methods for `SearchStream` using aggregations:

```java
    // The wrong way... pulling everything and using Java
    Optional<Game> minPriceGame1 = entityStream //
        .of(Company.class) //
        .min((g1, g2) -> g1.getPrice().compareTo(g2.getPrice()));

    // The long way... using aggregations streams
    List<Pair<String, Double>> minAggregation = entityStream.of(Game.class) //
        .load(Game$._KEY) //
        .sorted(Game$.PRICE.asc())
        .limit(1) //
        .toList(String.class, Double.class);

    Pair<String,Double> expected = minAggregation.get(0);

    // The short way...
    Optional<Game> minPriceGame2 = entityStream.of(Game.class).min(Game$.PRICE);
```