### PR TITLE
feature: enable repository queries on nested Set/List entity members

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -303,12 +303,14 @@ public class RediSearchQuery implements RepositoryQuery {
               } else {
                 qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
               }
-            } else { // String or Boolean
+            } else if (CharSequence.class.isAssignableFrom(collectionType) || (collectionType == Boolean.class)) {
               if (isANDQuery) {
                 qf.add(Pair.of(actualKey, QueryClause.Tag_CONTAINING_ALL));
               } else {
                 qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
               }
+            } else {
+              qf.addAll(extractQueryFields(collectionType, part, path, level + 1));
             }
           }
         }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/RedisJSONKeyValueAdapterTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/RedisJSONKeyValueAdapterTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.geo.Point;
 
 import com.redis.om.spring.annotations.document.fixtures.Company;
+import com.redis.om.spring.annotations.document.fixtures.CompanyMeta;
 import com.redis.om.spring.annotations.document.fixtures.CompanyRepository;
 
 public class RedisJSONKeyValueAdapterTest extends AbstractBaseDocumentTest {
@@ -28,10 +30,14 @@ public class RedisJSONKeyValueAdapterTest extends AbstractBaseDocumentTest {
   @BeforeEach
   void createData() {
     repository.deleteAll();
-    redis = repository.save(
-        Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690), "stack@redis.com"));
-    microsoft = repository.save(Company.of("Microsoft", 1975, LocalDate.of(2022, 8, 15),
-        new Point(-122.124500, 47.640160), "research@microsoft.com"));
+    
+    redis = Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690), "stack@redis.com");
+    redis.setMetaList(Set.of(CompanyMeta.of("Redis", 100, Set.of("RedisTag"))));
+    
+    microsoft = Company.of("Microsoft", 1975, LocalDate.of(2022, 8, 15), new Point(-122.124500, 47.640160), "research@microsoft.com");
+    microsoft.setMetaList(Set.of(CompanyMeta.of("MS", 50, Set.of("MsTag"))));
+    
+    repository.saveAll(List.of(redis, microsoft));
   }
 
   @Test

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/BasicRedisDocumentMappingTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/BasicRedisDocumentMappingTest.java
@@ -47,10 +47,14 @@ class BasicRedisDocumentMappingTest extends AbstractBaseDocumentTest {
 
   @Test
   void testBasicCrudOperations() {
-    Company redis = repository.save(
-        Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690), "stack@redis.com"));
-    Company microsoft = repository.save(Company.of("Microsoft", 1975, LocalDate.of(2022, 8, 15),
-        new Point(-122.124500, 47.640160), "research@microsoft.com"));
+    Company redis = Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690), "stack@redis.com");
+    redis.setMetaList(Set.of(CompanyMeta.of("Redis", 100, Set.of("RedisTag"))));
+    
+    Company microsoft = Company.of("Microsoft", 1975, LocalDate.of(2022, 8, 15),
+        new Point(-122.124500, 47.640160), "research@microsoft.com");
+    microsoft.setMetaList(Set.of(CompanyMeta.of("MS", 50, Set.of("MsTag"))));
+    
+    repository.saveAll(List.of(redis, microsoft));
 
     assertEquals(2, repository.count());
 
@@ -451,5 +455,73 @@ class BasicRedisDocumentMappingTest extends AbstractBaseDocumentTest {
 
     var docs = docWithSetsRepository.findByTheLocationsContainingAll(Set.of(point1, point2));
     assertThat(docs).containsOnly(doc1, doc2);
+  }
+  
+  @Test
+  void testFindByTagsInNestedField() {
+    Company redis = Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690), "stack@redis.com");
+    redis.setMetaList(Set.of(CompanyMeta.of("Redis", 100, Set.of("RedisTag", "CommonTag"))));
+    
+    Company microsoft = Company.of("Microsoft", 1975, LocalDate.of(2022, 8, 15),
+        new Point(-122.124500, 47.640160), "research@microsoft.com");
+    microsoft.setMetaList(Set.of(CompanyMeta.of("MS", 50, Set.of("MsTag", "CommonTag"))));
+    
+    repository.saveAll(List.of(redis, microsoft));
+
+    assertEquals(2, repository.count());
+
+    List<Company> shouldBeOnlyRedis = repository.findByMetaList_tagValues(Set.of("RedisTag"));
+    List<Company> shouldBeOnlyMS = repository.findByMetaList_tagValues(Set.of("MsTag"));
+    List<Company> shouldBeBoth = repository.findByMetaList_tagValues(Set.of("CommonTag"));
+
+    assertAll( //
+        () -> assertThat(shouldBeOnlyRedis).hasSize(1).allSatisfy(c -> c.getName().equalsIgnoreCase("RedisInc")), //
+        () -> assertThat(shouldBeOnlyMS).hasSize(1).allSatisfy(c -> c.getName().equalsIgnoreCase("Microsoft")), //
+        () -> assertThat(shouldBeBoth).hasSize(2).map(Company::getName).containsExactlyInAnyOrder("RedisInc", "Microsoft") //
+    );
+  }
+  
+  @Test
+  void testFindByStringValueInNestedField() {
+    Company redis = Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690), "stack@redis.com");
+    redis.setMetaList(Set.of(CompanyMeta.of("RD", 100, Set.of("RedisTag", "CommonTag"))));
+    
+    Company microsoft = Company.of("Microsoft", 1975, LocalDate.of(2022, 8, 15),
+        new Point(-122.124500, 47.640160), "research@microsoft.com");
+    microsoft.setMetaList(Set.of(CompanyMeta.of("MS", 50, Set.of("MsTag", "CommonTag"))));
+    
+    repository.saveAll(List.of(redis, microsoft));
+
+    assertEquals(2, repository.count());
+
+    List<Company> shouldBeOnlyRedis = repository.findByMetaList_stringValue("RD");
+    List<Company> shouldBeOnlyMS = repository.findByMetaList_stringValue("MS");
+
+    assertAll( //
+        () -> assertThat(shouldBeOnlyRedis).hasSize(1).allSatisfy(c -> c.getName().equalsIgnoreCase("RedisInc")), //
+        () -> assertThat(shouldBeOnlyMS).hasSize(1).allSatisfy(c -> c.getName().equalsIgnoreCase("Microsoft")) //
+    );
+  }
+  
+  @Test
+  void testFindByNumericValueInNestedField() {
+    Company redis = Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690), "stack@redis.com");
+    redis.setMetaList(Set.of(CompanyMeta.of("RD", 100, Set.of("RedisTag", "CommonTag"))));
+    
+    Company microsoft = Company.of("Microsoft", 1975, LocalDate.of(2022, 8, 15),
+        new Point(-122.124500, 47.640160), "research@microsoft.com");
+    microsoft.setMetaList(Set.of(CompanyMeta.of("MS", 50, Set.of("MsTag", "CommonTag"))));
+    
+    repository.saveAll(List.of(redis, microsoft));
+
+    assertEquals(2, repository.count());
+
+    List<Company> shouldBeOnlyRedis = repository.findByMetaList_numberValue(100);
+    List<Company> shouldBeOnlyMS = repository.findByMetaList_numberValue(50);
+
+    assertAll( //
+        () -> assertThat(shouldBeOnlyRedis).hasSize(1).allSatisfy(c -> c.getName().equalsIgnoreCase("RedisInc")), //
+        () -> assertThat(shouldBeOnlyMS).hasSize(1).allSatisfy(c -> c.getName().equalsIgnoreCase("Microsoft")) //
+    );
   }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Company.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Company.java
@@ -45,11 +45,14 @@ public class Company {
 
   @Indexed
   private Set<String> tags = new HashSet<String>();
-
+  
   @NonNull
   @Indexed
   @Bloom(name = "bf_company_email", capacity = 100000, errorRate = 0.001)
   private String email;
+  
+  @Indexed
+  private Set<CompanyMeta> metaList;
 
   @Indexed
   private boolean publiclyListed;

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/CompanyMeta.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/CompanyMeta.java
@@ -1,4 +1,4 @@
-package com.redis.om.documents.domain;
+package com.redis.om.spring.annotations.document.fixtures;
 
 import java.util.Set;
 

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/CompanyRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/CompanyRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Point;
+
 import com.redis.om.spring.repository.RedisDocumentRepository;
 
 public interface CompanyRepository extends RedisDocumentRepository<Company, String> {
@@ -20,4 +23,18 @@ public interface CompanyRepository extends RedisDocumentRepository<Company, Stri
   List<Company> findByPubliclyListed(boolean publiclyListed);
 
   List<Company> findByTags(Set<String> tags);
+  
+  // find one by property
+  Optional<Company> findOneByName(String name);
+  
+  // geospatial query
+  Iterable<Company> findByLocationNear(Point point, Distance distance);     
+  
+  // starting with/ending with
+  Iterable<Company> findByNameStartingWith(String prefix);
+  
+  List<Company> findByMetaList_stringValue(String value);
+  List<Company> findByMetaList_numberValue(Integer value);
+  List<Company> findByMetaList_tagValues(Set<String> tags);
+  
 }


### PR DESCRIPTION
Enables repository queries like:

```java
List<Company> findByMetaList_stringValue(String value);
List<Company> findByMetaList_numberValue(Integer value);
List<Company> findByMetaList_tagValues(Set<String> tags);
```

Given an entity with an Set/List like:

```java
@Document
public class Company {
  @Indexed
  private Set<CompanyMeta> metaList;
}

@Data
public class CompanyMeta {
  @Indexed
  @NonNull
  private String stringValue;

  @Indexed
  @NonNull
  private Integer numberValue;

  @Indexed
  @NonNull
  private Set<String> tagValues;
}
```
