### PR TITLE
Remove cast to a String as the ID can be other types other than a String

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -161,7 +161,7 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
         KeyValuePersistentEntity<?, ?> keyValueEntity = mappingConverter.getMappingContext()
             .getRequiredPersistentEntity(ClassUtils.getUserClass(entity));
         Object id = isNew ? generator.generateIdentifierOfType(keyValueEntity.getIdProperty().getTypeInformation())
-            : (String) keyValueEntity.getPropertyAccessor(entity).getProperty(keyValueEntity.getIdProperty());
+            : keyValueEntity.getPropertyAccessor(entity).getProperty(keyValueEntity.getIdProperty());
         keyValueEntity.getPropertyAccessor(entity).setProperty(keyValueEntity.getIdProperty(), id);
 
         String keyspace = keyValueEntity.getKeySpace();


### PR DESCRIPTION
Remove cast to a String as the ID can be other types other than a String.

NonStandardDocumentSearchTest should cover this case

relates to https://github.com/redis/redis-om-spring/issues/172