### PR TITLE
Remove CachingConfigurer interface in `RedisModulesConfiguration`

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -20,7 +20,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.boot.autoconfigure.gson.GsonBuilderCustomizer;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.*;
 import org.springframework.context.event.ContextRefreshedEvent;
@@ -49,7 +48,7 @@ import static com.redis.om.spring.util.ObjectUtils.getBeanDefinitionsFor;
 @ComponentScan("com.redis.om.spring.bloom")
 @ComponentScan("com.redis.om.spring.autocomplete")
 @ComponentScan("com.redis.om.spring.metamodel")
-public class RedisModulesConfiguration implements CachingConfigurer {
+public class RedisModulesConfiguration {
 
   private static final Log logger = LogFactory.getLog(RedisModulesConfiguration.class);
 


### PR DESCRIPTION
The `RedisModulesConfiguration` class implements the `CachingConfigurer` interface, but neither overrides nor uses a method from it. However, the implementation of the interface in a configuration class registeres a bean that may clash with an other caching configuration in an application. This PR therefore simply removes the interface declaration.