### PR TITLE
fix: resolve .filter(freetext) order independent (resolves gh-176)

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -93,7 +93,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
       public String toString(Parenthesize mode) {
         return switch(mode) {
           case NEVER -> toString();
-          case ALWAYS, DEFAULT -> String.format("%s%s%s", "(", toString(), ")");
+          case ALWAYS, DEFAULT -> String.format("(%s)", toString());
         };
       }
     };

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -83,7 +83,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @Override
   public SearchStream<E> filter(String freeText) {
-    rootNode = new Node() {
+    Node freeTextNode = new Node() {
       @Override
       public String toString() {
         return freeText;
@@ -91,9 +91,13 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
       @Override
       public String toString(Parenthesize mode) {
-        return freeText;
+        return switch(mode) {
+          case NEVER -> toString();
+          case ALWAYS, DEFAULT -> String.format("%s%s%s", "(", toString(), ")");
+        };
       }
     };
+    rootNode = (rootNode.toString().isBlank()) ? freeTextNode : QueryBuilders.intersect(rootNode, freeTextNode);
     return this;
   }
 

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Doc.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Doc.java
@@ -1,0 +1,24 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Searchable;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Document
+public class Doc {
+  @Id
+  private String id;
+
+  @NonNull
+  @Searchable(sortable = true)
+  private String first;
+
+  @NonNull
+  @Searchable(sortable = true)
+  private String second;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DocRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DocRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+@SuppressWarnings("unused") public interface DocRepository extends RedisDocumentRepository<Doc, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsIssuesTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsIssuesTest.java
@@ -5,16 +5,21 @@ import com.redis.om.spring.annotations.document.fixtures.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.geo.Point;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SuppressWarnings("SpellCheckingInspection") class EntityStreamsIssuesTest extends AbstractBaseDocumentTest {
   @Autowired SomeDocumentRepository someDocumentRepository;
   @Autowired DeepNestRepository deepNestRepository;
+  @Autowired DocRepository docRepository;
 
   @Autowired EntityStream entityStream;
 
@@ -58,5 +63,30 @@ import static org.assertj.core.api.Assertions.assertThat;
         .map(DeepNest$.NAME) //
         .collect(Collectors.toList());
     assertThat(results).containsOnly("dn-3");
+  }
+
+  // issue gh-176
+  @Test
+  void testFreeFormTextSearchOrderIssue() {
+    docRepository.deleteAll();
+    Doc redis1 = docRepository.save(Doc.of("Redis", "wwwabccom"));
+    Doc redis2 = docRepository.save(Doc.of("Redis", "wwwxyznet"));
+    Doc microsoft1 = docRepository.save(Doc.of("Microsoft", "wwwabcnet"));
+    Doc microsoft2 = docRepository.save(Doc.of("Microsoft", "wwwxyzcom"));
+
+    var withFreeTextFirst = entityStream.of(Doc.class)
+        .filter("*co*")
+        .filter(Doc$.FIRST.eq("Microsoft"))
+        .collect(Collectors.toList());
+
+    var withFreeTextLast = entityStream.of(Doc.class)
+        .filter(Doc$.FIRST.eq("Microsoft"))
+        .filter("*co*")
+        .collect(Collectors.toList());
+
+    assertAll( //
+        () -> assertThat(withFreeTextLast).containsExactly(microsoft2),
+        () -> assertThat(withFreeTextFirst).containsExactly(microsoft2)
+    );
   }
 }


### PR DESCRIPTION
Fixes issue with dependency on the order of `.filter(freeText)` method in EntityStream searches - see gh-176
CC @rjdkolb 