### PR TITLE
Vector Similarity Search

### DIFF
--- a/demos/roms-documents/pom.xml
+++ b/demos/roms-documents/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.1</version>
+    <version>3.0.2</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/DistanceMetric.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/DistanceMetric.java
@@ -1,0 +1,5 @@
+package com.redis.om.spring;
+
+public enum DistanceMetric {
+  L2, IP, COSINE
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/VectorType.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/VectorType.java
@@ -1,5 +1,5 @@
 package com.redis.om.spring;
 
 public enum VectorType {
-  FLOAT32, FLOAT64;
+  FLOAT32, FLOAT64
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/VectorType.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/VectorType.java
@@ -1,0 +1,5 @@
+package com.redis.om.spring;
+
+public enum VectorType {
+  FLOAT32, FLOAT64;
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Indexed.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Indexed.java
@@ -1,5 +1,9 @@
 package com.redis.om.spring.annotations;
 
+import com.redis.om.spring.DistanceMetric;
+import com.redis.om.spring.VectorType;
+import redis.clients.jedis.search.Schema.VectorField.VectorAlgo;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -10,6 +14,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
 public @interface Indexed {
+  // by default, attempt to determine the schema field type from the Java datatype
+  SchemaFieldType schemaFieldType() default SchemaFieldType.AUTODETECT;
+
   String fieldName() default "";
 
   String alias() default "";
@@ -27,4 +34,54 @@ public @interface Indexed {
   String separator() default "|";
 
   int arrayIndex() default Integer.MIN_VALUE;
+
+  // -----------------
+  // VECTOR properties
+  // -----------------
+
+  // Indexing methods
+  VectorAlgo algorithm() default VectorAlgo.FLAT;
+
+  // Vector type. Current supported types are FLOAT32 and FLOAT64.
+  VectorType type() default VectorType.FLOAT32;
+
+  // Specifies the number of attributes for the index. Must be specified.
+  // Counts the total number of attributes passed for the index in the command,
+  // although algorithm parameters should be submitted as named arguments.
+  int count() default Integer.MIN_VALUE;
+
+  // Vector dimension specified as a positive integer
+  int dimension() default Integer.MIN_VALUE;
+
+  // Supported distance metric, one of {L2, IP, COSINE}.
+  DistanceMetric distanceMetric() default DistanceMetric.L2;
+
+  // Initial vector capacity in the index affecting memory allocation size of the index.
+  int initialCapacity() default Integer.MIN_VALUE;
+
+  // For FLAT
+
+  // Block size to hold BLOCK_SIZE amount of vectors in a contiguous array. This is useful when the index is dynamic
+  // with respect to addition and deletion. Defaults to 1024
+  int blockSize() default 1024;
+
+  // For HNSW
+  // M - Number of maximum allowed outgoing edges for each node in the graph in each layer.
+  // on layer zero the maximal number of outgoing edges will be 2M. Default is 16.
+  int m() default 16;
+
+  // EF_CONSTRUCTION - Number of maximum allowed potential outgoing edges candidates for each node
+  // in the graph, during the graph building. Default is 200.
+  int efConstruction() default 200;
+
+  // EF_RUNTIME - Number of maximum top candidates to hold during the KNN search.
+  // Higher values of EF_RUNTIME lead to more accurate results at the expense of a longer runtime.
+  // Default is 10.
+  int efRuntime() default 10;
+
+  // EPSILON - Relative factor that sets the boundaries in which a range query may search for candidates.
+  // That is, vector candidates whose distance from the query vector is radius*(1 + EPSILON)
+  // are potentially scanned, allowing more extensive search and more accurate results
+  // (on the expense of runtime). Default is 0.01.
+  double epsilon() default 0.01;
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/SchemaFieldType.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/SchemaFieldType.java
@@ -1,0 +1,10 @@
+package com.redis.om.spring.annotations;
+
+public enum SchemaFieldType {
+  AUTODETECT,
+  TAG,
+  NUMERIC,
+  GEO,
+  VECTOR,
+  NESTED
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/VectorIndexed.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/VectorIndexed.java
@@ -1,0 +1,63 @@
+package com.redis.om.spring.annotations;
+
+import com.redis.om.spring.DistanceMetric;
+import com.redis.om.spring.VectorType;
+import redis.clients.jedis.search.Schema.VectorField.VectorAlgo;
+import redis.clients.jedis.search.schemafields.VectorField.VectorAlgorithm;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+public @interface VectorIndexed {
+  String fieldName() default "";
+
+  String alias() default "";
+
+  // Indexing methods
+  VectorAlgo algorithm() default VectorAlgo.FLAT;
+
+  // Vector type. Current supported types are FLOAT32 and FLOAT64.
+  VectorType type() default VectorType.FLOAT32;
+
+  // Specifies the number of attributes for the index. Must be specified.
+  // Counts the total number of attributes passed for the index in the command,
+  // although algorithm parameters should be submitted as named arguments.
+  int count() default Integer.MIN_VALUE;
+
+  // Vector dimension specified as a positive integer
+  int dimension() default Integer.MIN_VALUE;
+
+  // Supported distance metric, one of {L2, IP, COSINE}.
+  DistanceMetric distanceMetric() default DistanceMetric.L2;
+
+  // Initial vector capacity in the index affecting memory allocation size of the index.
+  int initialCapacity() default Integer.MIN_VALUE;
+
+  // For FLAT
+
+  // Block size to hold BLOCK_SIZE amount of vectors in a contiguous array. This is useful when the index is dynamic
+  // with respect to addition and deletion. Defaults to 1024
+  int blockSize() default 1024;
+
+  // For HNSW
+  // M - Number of maximum allowed outgoing edges for each node in the graph in each layer.
+  // on layer zero the maximal number of outgoing edges will be 2M. Default is 16.
+  int m() default 16;
+
+  // EF_CONSTRUCTION - Number of maximum allowed potential outgoing edges candidates for each node
+  // in the graph, during the graph building. Default is 200.
+  int efConstruction() default 200;
+
+  // EF_RUNTIME - Number of maximum top candidates to hold during the KNN search.
+  // Higher values of EF_RUNTIME lead to more accurate results at the expense of a longer runtime.
+  // Default is 10.
+  int efRuntime() default 10;
+
+  // EPSILON - Relative factor that sets the boundaries in which a range query may search for candidates.
+  // That is, vector candidates whose distance from the query vector is radius*(1 + EPSILON)
+  // are potentially scanned, allowing more extensive search and more accurate results
+  // (on the expense of runtime). Default is 0.01.
+  double epsilon() default 0.01;
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/VectorIndexed.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/VectorIndexed.java
@@ -3,7 +3,6 @@ package com.redis.om.spring.annotations;
 import com.redis.om.spring.DistanceMetric;
 import com.redis.om.spring.VectorType;
 import redis.clients.jedis.search.Schema.VectorField.VectorAlgo;
-import redis.clients.jedis.search.schemafields.VectorField.VectorAlgorithm;
 
 import java.lang.annotation.*;
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelField.java
@@ -10,6 +10,7 @@ public class MetamodelField<E, T> implements Comparator<E>, Function<E,T> {
   protected final SearchFieldAccessor searchFieldAccessor;
   protected final boolean indexed;
   protected final String alias;
+  protected Class<?> targetClass;
   
   public MetamodelField(SearchFieldAccessor searchFieldAccessor, boolean indexed) {
     this.searchFieldAccessor = searchFieldAccessor;
@@ -17,10 +18,18 @@ public class MetamodelField<E, T> implements Comparator<E>, Function<E,T> {
     this.alias = null;
   }
 
-  public MetamodelField(String alias) {
+  public MetamodelField(String alias, Class targetClass, boolean indexed) {
+    this.searchFieldAccessor = null;
+    this.indexed = indexed;
+    this.alias = alias;
+    this.targetClass = targetClass;
+  }
+
+  public MetamodelField(String alias, Class targetClass) {
     this.searchFieldAccessor = null;
     this.indexed = false;
     this.alias = alias;
+    this.targetClass = targetClass;
   }
   
   public SearchFieldAccessor getSearchFieldAccessor() {
@@ -46,7 +55,7 @@ public class MetamodelField<E, T> implements Comparator<E>, Function<E,T> {
   }
 
   public Class<?> getTargetClass() {
-    return searchFieldAccessor != null ? searchFieldAccessor.getTargetClass() : String.class;
+    return searchFieldAccessor != null ? searchFieldAccessor.getTargetClass() : targetClass;
   }
 
   public Order asc() {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/VectorField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/VectorField.java
@@ -2,9 +2,17 @@ package com.redis.om.spring.metamodel.indexed;
 
 import com.redis.om.spring.metamodel.MetamodelField;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
+import com.redis.om.spring.search.stream.predicates.geo.NearPredicate;
+import com.redis.om.spring.search.stream.predicates.vector.KNNPredicate;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Point;
 
 public class VectorField <E, T> extends MetamodelField<E, T> {
   public VectorField(SearchFieldAccessor field, boolean indexed) {
     super(field, indexed);
+  }
+
+  public KNNPredicate<? super E,T> knn(int k, byte[] blobAttribute) {
+    return new KNNPredicate<>(searchFieldAccessor,k, blobAttribute);
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/VectorField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/VectorField.java
@@ -1,0 +1,10 @@
+package com.redis.om.spring.metamodel.indexed;
+
+import com.redis.om.spring.metamodel.MetamodelField;
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+
+public class VectorField <E, T> extends MetamodelField<E, T> {
+  public VectorField(SearchFieldAccessor field, boolean indexed) {
+    super(field, indexed);
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/vector/KNNPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/vector/KNNPredicate.java
@@ -1,0 +1,52 @@
+package com.redis.om.spring.search.stream.predicates.vector;
+
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import com.redis.om.spring.util.ObjectUtils;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Point;
+import redis.clients.jedis.search.querybuilder.GeoValue;
+import redis.clients.jedis.search.querybuilder.Node;
+import redis.clients.jedis.search.querybuilder.QueryBuilders;
+
+public class KNNPredicate<E, T> extends BaseAbstractPredicate<E, T> {
+
+  private final int k;
+  private final byte[] blobAttribute;
+
+  public KNNPredicate(SearchFieldAccessor field, int k, byte[] blobAttribute) {
+    super(field);
+    this.k = k;
+    this.blobAttribute = blobAttribute;
+  }
+
+  public int getK() {
+    return k;
+  }
+
+  public byte[] getBlobAttribute() {
+    return blobAttribute;
+  }
+
+  public String getBlobAttributeName() {
+    return String.format("%s_blob", getSearchAlias());
+  }
+
+  @Override
+  public Node apply(Node root) {
+    String query = String.format("(%s)=>[KNN $K @%s $%s]", root.toString().isBlank() ? "*" : root.toString(), getSearchAlias(), getBlobAttributeName());
+
+    return new Node() {
+      @Override
+      public String toString() {
+        return query;
+      }
+
+      @Override
+      public String toString(Parenthesize mode) {
+        return query;
+      }
+    };
+  }
+
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseOMTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseOMTest.java
@@ -35,7 +35,7 @@ public abstract class AbstractBaseOMTest {
   protected CustomRedisKeyValueTemplate kvTemplate;
 
   @Autowired
-  protected RediSearchIndexer indexer; // = (RediSearchIndexer) ac.getBean("rediSearchIndexer");
+  protected RediSearchIndexer indexer;
 
   @DynamicPropertySource
   static void properties(DynamicPropertyRegistry registry) {

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/DocRepositoriesAutoDiscoveryTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/DocRepositoriesAutoDiscoveryTest.java
@@ -2,6 +2,7 @@ package com.redis.om.spring.annotations;
 
 import com.redis.om.spring.AbstractBaseOMTest;
 import com.redis.om.spring.TestConfig;
+import com.redis.om.spring.annotations.DocRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashVSSTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashVSSTest.java
@@ -1,0 +1,68 @@
+package com.redis.om.spring.annotations.hash;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.annotations.hash.fixtures.HashWithVectors;
+import com.redis.om.spring.annotations.hash.fixtures.HashWithVectorsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.UnifiedJedis;
+import redis.clients.jedis.args.SortingOrder;
+import redis.clients.jedis.search.Document;
+import redis.clients.jedis.search.FTSearchParams;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RedisHashVSSTest extends AbstractBaseEnhancedRedisTest {
+  @Autowired HashWithVectorsRepository repository;
+
+  @Autowired JedisConnectionFactory jedisConnectionFactory;
+
+  private UnifiedJedis jedis;
+
+  private static String INDEX = "com.redis.om.spring.annotations.hash.fixtures.HashWithVectorsIdx";
+  private HashWithVectors hwv1;
+  private HashWithVectors hwv2;
+  private HashWithVectors hwv3;
+
+  @BeforeEach
+  void cleanUp() {
+    repository.deleteAll();
+    hwv1 = repository.save(HashWithVectors.of("aaaaaaaa", "aaaaaaaa"));
+    hwv2 = repository.save(HashWithVectors.of("aaaabaaa", "aaaabaaa"));
+    hwv3 = repository.save(HashWithVectors.of("aaaaabaa", "aaaaabaa"));
+
+    jedis = new JedisPooled(Objects.requireNonNull(jedisConnectionFactory.getPoolConfig()),
+        jedisConnectionFactory.getHostName(), jedisConnectionFactory.getPort());
+  }
+
+  @Test void testFlatVectorFieldIndexCreation() {
+    FTSearchParams searchParams = FTSearchParams.searchParams()
+        .addParam("vec", "aaaaaaaa")
+        .sortBy("__flat_score", SortingOrder.ASC)
+        .returnFields("__flat_score")
+        .dialect(2);
+
+    Document doc1 = jedis.ftSearch(INDEX, "*=>[KNN 2 @flat $vec]", searchParams).getDocuments().get(0);
+
+    assertThat(doc1.getId()).isEqualTo("com.redis.om.spring.annotations.hash.fixtures.HashWithVectors:"+hwv1.getId());
+    assertThat(doc1.get("__flat_score")).isEqualTo("0");
+  }
+
+  @Test void testHNSWVectorFieldIndexCreation() {
+    FTSearchParams searchParams = FTSearchParams.searchParams()
+        .addParam("vec", "aaaaaaaa")
+        .sortBy("__hnsw_score", SortingOrder.ASC)
+        .returnFields("__hnsw_score")
+        .dialect(2);
+
+    Document doc1 = jedis.ftSearch(INDEX, "*=>[KNN 2 @hnsw $vec]", searchParams).getDocuments().get(0);
+
+    assertThat(doc1.getId()).isEqualTo("com.redis.om.spring.annotations.hash.fixtures.HashWithVectors:"+hwv1.getId());
+    assertThat(doc1.get("__hnsw_score")).isEqualTo("0");
+  }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithByteArrayFlatVector.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithByteArrayFlatVector.java
@@ -1,0 +1,37 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.DistanceMetric;
+import com.redis.om.spring.VectorType;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.SchemaFieldType;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import redis.clients.jedis.search.Schema.VectorField.VectorAlgo;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@RedisHash
+public class HashWithByteArrayFlatVector {
+  @Id
+  @NonNull
+  private String id;
+
+  @Indexed(//
+      schemaFieldType = SchemaFieldType.VECTOR, //
+      algorithm = VectorAlgo.FLAT, //
+      type = VectorType.FLOAT32, //
+      dimension = 100, //
+      distanceMetric = DistanceMetric.L2, //
+      initialCapacity = 300,
+      m = 40
+  )
+  @NonNull
+  private byte[] vector;
+
+  @Indexed
+  @NonNull
+  private int number;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithByteArrayFlatVectorRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithByteArrayFlatVectorRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface HashWithByteArrayFlatVectorRepository extends RedisEnhancedRepository<HashWithByteArrayFlatVector, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithByteArrayHNSWVector.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithByteArrayHNSWVector.java
@@ -1,0 +1,37 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.DistanceMetric;
+import com.redis.om.spring.VectorType;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.SchemaFieldType;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import redis.clients.jedis.search.Schema.VectorField.VectorAlgo;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@RedisHash
+public class HashWithByteArrayHNSWVector {
+  @Id
+  @NonNull
+  private String id;
+
+  @Indexed(//
+      schemaFieldType = SchemaFieldType.VECTOR, //
+      algorithm = VectorAlgo.HNSW, //
+      type = VectorType.FLOAT32, //
+      dimension = 100, //
+      distanceMetric = DistanceMetric.L2, //
+      initialCapacity = 300,
+      m = 40
+  )
+  @NonNull
+  private byte[] vector;
+
+  @Indexed
+  @NonNull
+  private int number;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithByteArrayHNSWVectorRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithByteArrayHNSWVectorRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface HashWithByteArrayHNSWVectorRepository extends RedisEnhancedRepository<HashWithByteArrayHNSWVector, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithVectors.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithVectors.java
@@ -1,0 +1,27 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.DistanceMetric;
+import com.redis.om.spring.VectorType;
+import com.redis.om.spring.annotations.VectorIndexed;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import redis.clients.jedis.search.Schema.VectorField.VectorAlgo;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@NoArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@RedisHash
+public class HashWithVectors {
+  @Id
+  private String id;
+
+  @NonNull
+  @VectorIndexed(algorithm = VectorAlgo.FLAT, type = VectorType.FLOAT32, dimension = 2, distanceMetric = DistanceMetric.L2)
+  private String flat;
+
+  @NonNull
+  @VectorIndexed(algorithm = VectorAlgo.HNSW, type = VectorType.FLOAT32, dimension = 2, distanceMetric = DistanceMetric.L2)
+  private String hnsw;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithVectors.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithVectors.java
@@ -2,6 +2,8 @@ package com.redis.om.spring.annotations.hash.fixtures;
 
 import com.redis.om.spring.DistanceMetric;
 import com.redis.om.spring.VectorType;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.SchemaFieldType;
 import com.redis.om.spring.annotations.VectorIndexed;
 import lombok.*;
 import org.springframework.data.annotation.Id;
@@ -24,4 +26,12 @@ public class HashWithVectors {
   @NonNull
   @VectorIndexed(algorithm = VectorAlgo.HNSW, type = VectorType.FLOAT32, dimension = 2, distanceMetric = DistanceMetric.L2)
   private String hnsw;
+
+  @NonNull
+  @Indexed(schemaFieldType = SchemaFieldType.VECTOR, algorithm = VectorAlgo.FLAT, type = VectorType.FLOAT32, dimension = 2, distanceMetric = DistanceMetric.L2)
+  private String flat2;
+
+  @NonNull
+  @Indexed(schemaFieldType = SchemaFieldType.VECTOR, algorithm = VectorAlgo.HNSW, type = VectorType.FLOAT32, dimension = 2, distanceMetric = DistanceMetric.L2)
+  private String hnsw2;
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithVectorsRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithVectorsRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface HashWithVectorsRepository extends RedisEnhancedRepository<HashWithVectors, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamTest.java
@@ -37,6 +37,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
   @Autowired EntityStream entityStream;
 
+  String redisId;
+  String microsoftId;
+  String teslaId;
+
   @BeforeEach void cleanUp() {
     if (repository.count() == 0) {
       Company redis = repository.save(Company.of( //
@@ -66,6 +70,11 @@ import static org.junit.jupiter.api.Assertions.*;
 
       repository.saveAll(List.of(redis, microsoft, tesla));
     }
+
+    List<Company> saved = repository.findAll();
+    redisId = saved.get(0).getId();
+    microsoftId = saved.get(1).getId();
+    teslaId = saved.get(2).getId();
 
     // users
     if (userRepository.count() == 0) {
@@ -2318,5 +2327,15 @@ import static org.junit.jupiter.api.Assertions.*;
         .containsEntry("name", "Microsoft") //
         .containsEntry("yearFounded", 1975) //
         .containsEntry("location", new Point(-122.124500, 47.640160));
+  }
+
+  @Test void testMapToIdProperty() {
+    List<String> ids = entityStream //
+        .of(Company.class) //
+        .sorted(Company$.NAME, SortOrder.DESC) //
+        .map(Company$.ID) //
+        .collect(Collectors.toList());
+
+    assertThat(ids).containsExactly(teslaId, redisId, microsoftId);
   }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsHashVSSTests.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsHashVSSTests.java
@@ -1,0 +1,164 @@
+package com.redis.om.spring.search.stream;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.annotations.hash.fixtures.*;
+import com.redis.om.spring.tuple.Fields;
+import com.redis.om.spring.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SuppressWarnings("SpellCheckingInspection") class EntityStreamsHashVSSTests extends AbstractBaseEnhancedRedisTest {
+  @Autowired HashWithByteArrayHNSWVectorRepository hnswRepository;
+  @Autowired HashWithByteArrayFlatVectorRepository flatRepository;
+
+  @Autowired EntityStream entityStream;
+  
+  @BeforeEach
+  void cleanUp() {
+    if (hnswRepository.count() == 0 && flatRepository.count() == 0) {
+      int amount = 300;
+      int dimension = 100;
+
+      List<HashWithByteArrayHNSWVector> hashWithByteArrayHNSWVectors = new ArrayList<>();
+      List<HashWithByteArrayFlatVector> hashWithByteArrayFlatVectors = new ArrayList<>();
+
+      for (int i = 0; i < amount; i++) {
+        // hash key
+        float[] vec = new float[dimension];
+        float val = (float) i / (dimension + i);
+        Arrays.fill(vec, val);
+        hashWithByteArrayHNSWVectors.add(HashWithByteArrayHNSWVector.of("doc:" + i, floatToByte(vec), i));
+        hashWithByteArrayFlatVectors.add(HashWithByteArrayFlatVector.of("doc:" + i, floatToByte(vec), i));
+      }
+      hnswRepository.saveAll(hashWithByteArrayHNSWVectors);
+      flatRepository.saveAll(hashWithByteArrayFlatVectors);
+    }
+  }
+
+  /**
+   * A simple FT.SEARCH (only vector similarity)
+   * Get top 4 documents where the vector field is closest to [1.4e-30f, 1.4e-30f,...]
+   *
+   * FT.SEARCH QUERY = `"(*)=>[KNN $K @vector $vector_blob]"`
+   */
+  @Test
+  void testPureKNNSearchWithHNSWVectorIndex() {
+    float[] e = new float[100];
+    Arrays.fill(e, 1.4e-30f);
+
+    int K = 4;
+
+    SearchStream<HashWithByteArrayHNSWVector> stream = entityStream.of(HashWithByteArrayHNSWVector.class);
+
+    List<HashWithByteArrayHNSWVector> results = stream //
+        .filter(HashWithByteArrayHNSWVector$.VECTOR.knn(K, floatToByte(e))) //
+        .sorted(HashWithByteArrayHNSWVector$._VECTOR_SCORE)
+        .limit(K)
+        .collect(Collectors.toList());
+
+    assertThat(results).hasSize(4).map(HashWithByteArrayHNSWVector::getId).containsExactly("doc:132", "doc:12", "doc:75", "doc:240");
+  }
+
+  /**
+   * A simple FT.SEARCH (only vector similarity)
+   * Get top 4 documents where the vector field is closest to [1.4e-30f, 1.4e-30f,...]
+   *
+   * FT.SEARCH QUERY = `"(*)=>[KNN $K @vector $vector_blob]"`
+   */
+  @Test
+  void testPureKNNSearchWithHNSWVectorIndexOnlyNumberAndDistances() {
+    float[] e = new float[100];
+    Arrays.fill(e, 1.4e-30f);
+
+    int K = 4;
+
+    SearchStream<HashWithByteArrayHNSWVector> stream = entityStream.of(HashWithByteArrayHNSWVector.class);
+
+    List<Pair<Integer,Double>> results = stream //
+        .filter(HashWithByteArrayHNSWVector$.VECTOR.knn(K, floatToByte(e))) //
+        .sorted(HashWithByteArrayHNSWVector$._VECTOR_SCORE) //
+        .limit(K) //
+        .map(Fields.of(HashWithByteArrayHNSWVector$.NUMBER, HashWithByteArrayHNSWVector$._VECTOR_SCORE)) //
+        .collect(Collectors.toList());
+
+    assertAll( //
+        () -> assertThat(results).hasSize(4), //
+        () -> assertThat(results).map(Pair::getFirst).containsExactly(132, 12, 75, 240), //
+        () -> assertThat(results).map(Pair::getSecond).containsExactly(1.08511912913e-05, 4.01816287194e-05, 4.01816287194e-05, 4.18252566305e-05) //
+    );
+  }
+
+  /**
+   * Another Hybrid Query FT.SEARCH (vector and non-vector search criteria)
+   * Get top 5 articles with
+   * number value is between 0 and 20
+   * OR
+   * number value is between indexsize-20 and indexsize
+   */
+  @Test
+  void testHybridKNNSearch() {
+    float[] e = new float[100];
+    Arrays.fill(e, 1.4e-30f);
+
+    int K = 5;
+    int NUMBER_ARTICLES = 300;
+
+    SearchStream<HashWithByteArrayHNSWVector> stream = entityStream.of(HashWithByteArrayHNSWVector.class);
+
+    List<Pair<Integer,Double>> results = stream //
+        .filter(HashWithByteArrayFlatVector$.NUMBER.between(0, 20) //
+            .or(HashWithByteArrayFlatVector$.NUMBER.between(NUMBER_ARTICLES - 20, NUMBER_ARTICLES))) //
+        .filter(HashWithByteArrayHNSWVector$.VECTOR.knn(K, floatToByte(e))) //
+        .sorted(HashWithByteArrayHNSWVector$._VECTOR_SCORE) //
+        .limit(K) //
+        .map(Fields.of(HashWithByteArrayHNSWVector$.NUMBER, HashWithByteArrayHNSWVector$._VECTOR_SCORE)) //
+        .collect(Collectors.toList());
+
+    assertAll( //
+        () -> assertThat(results).hasSize(5), //
+        () -> assertThat(results).map(Pair::getFirst).containsExactly(12, 289, 15, 280, 2), //
+        () -> assertThat(results).map(Pair::getSecond).containsExactly(4.01816287194e-05, 4.19937859988e-05, 4.19969328505e-05, 4.19990610681e-05, 4.19991047238e-05) //
+    );
+  }
+
+  /**
+   * Get top 5 documents with number value is between 0 and 100
+   * FT.SEARCH QUERY = @number:[0 100]=>[KNN $K @my_vector $BLOB AS scores]
+   */
+  @Test
+  void testHybridKNNSearchWithFlatVectorIndex() {
+    float[] e = new float[100];
+    Arrays.fill(e, 1.4e-30f);
+
+    int K = 5;
+
+    SearchStream<HashWithByteArrayFlatVector> stream = entityStream.of(HashWithByteArrayFlatVector.class);
+
+    List<HashWithByteArrayFlatVector> results = stream //
+        .filter(HashWithByteArrayFlatVector$.NUMBER.between(0, 100)) //
+        .filter(HashWithByteArrayFlatVector$.VECTOR.knn(K, floatToByte(e))) //
+        .sorted(HashWithByteArrayFlatVector$._VECTOR_SCORE)
+        .limit(K)
+        .collect(Collectors.toList());
+
+    assertThat(results).hasSize(5).map(HashWithByteArrayFlatVector::getId).containsExactly("doc:12", "doc:75", "doc:71", "doc:15", "doc:2");
+  }
+
+  private byte[] floatToByte(float[] input) {
+    byte[] ret = new byte[input.length*4];
+    for (int x = 0; x < input.length; x++) {
+      ByteBuffer.wrap(ret, x*4, 4).putFloat(input[x]);
+    }
+    return ret;
+  }
+}


### PR DESCRIPTION
# VSS API for Redis OM Spring

I'm putting together the API for VSS as part of Redis OM Spring EntityStreams API, I'm working on an example-driven basis, starting with the demo 
at https://github.com/RedisAI/Java-VSS-demo which uses Jedis 4.x, current example I'm trying to reproduce it using Hashes:

## Pure Jedis - Index Creation - HNSW

Creates an index with 2 fields, the vector `"my_vector"` and a numeric `"number"`:

```java
public void create_hnsw_index (UnifiedJedis redis_conn, String vector_field_name, int number_of_vectors, int vector_dimensions, String distance_metric, int m, int ef) {
    Map<String, Object> attr = new HashMap<>();
    attr.put("TYPE", "FLOAT32");
    attr.put("DIM", vector_dimensions);
    attr.put("DISTANCE_METRIC", distance_metric);
    attr.put("INITIAL_CAP", number_of_vectors);
    attr.put("M", m);
    attr.put("EF_CONSTRUCTION", ef);
    Schema schema = new Schema().addHNSWVectorField(vector_field_name, attr).addNumericField("number");
    redis_conn.ftCreate("my_index", IndexOptions.defaultOptions(), schema);
}

int NUMBER_ARTICLES = 300;
String VECTOR_FIELD_NAME = "my_vector";
String DISTANCE_METRIC = "L2";
int DIMENSIONS = 100;

create_hnsw_index(redis_conn,VECTOR_FIELD_NAME,NUMBER_ARTICLES,DIMENSIONS,DISTANCE_METRIC,40,200);
```

## Redis OM Spring - Index Creation

In Spring, we create an entity such as `HashWithByteArrayVector` containing a `byte[]` field and using the `@Indexed` annotation:

```java
@RedisHash
public class HashWithByteArrayVector {
  @Id
  @NonNull
  private String id;

  @Indexed(//
      schemaFieldType = SchemaFieldType.VECTOR, //
      algorithm = VectorAlgo.HNSW, //
      type = VectorType.FLOAT32, //
      dimension = 100, //
      distanceMetric = DistanceMetric.L2, //
      initialCapacity = 300,
      m = 40
  )
  @NonNull
  private byte[] vector;

  @Indexed
  @NonNull
  private int number;
}
```

The indexed annotation creates an index similar to the one with pure Jedis, with the addition of an schema field for the `id` property.

## Resulting RediSearch Indices

### `FT.CREATE`

- Pure Jedis:

```
"FT.CREATE" "my_index" 
  "SCHEMA" 
    "my_vector" "VECTOR" "HNSW" "12" 
      "EF_CONSTRUCTION" "200" 
      "DIM" "100" 
      "DISTANCE_METRIC" "L2" 
      "TYPE" "FLOAT32" 
      "INITIAL_CAP" "300" 
      "M" "40" 
    "number" "NUMERIC"
```

- Redis OM Spring:

```
"FT.CREATE" "com.redis.om.spring.annotations.hash.fixtures.HashWithByteArrayVectorIdx" "ON" "HASH" 
  "PREFIX" "1" "com.redis.om.spring.annotations.hash.fixtures.HashWithByteArrayVector:" 
  "SCHEMA" 
    "vector" "AS" "vector" "VECTOR" "HNSW" "12" 
      "EF_CONSTRUCTION" "200" 
      "DIM" "100" 
      "DISTANCE_METRIC" "L2" 
      "TYPE" "FLOAT32" 
      "INITIAL_CAP" "300" 
      "M" "40" 
    "number" "AS" "number" "NUMERIC" 
    "id" "AS" "id" "TAG" "SEPARATOR" "|"
```

## Querying

With pure Jedis:

A simple FT.SEARCH (only vector similarity)
Get top 4 documents with thier vector field is the closest to [1.4e-30f, 1.4e-30f,...]
`FT.SEARCH QUERY = *=>[KNN 4 @my_vector $QUERY_BLOB]`

```java
// query for similarity

float[] e = new float[DIMENSIONS];
for (int j = 0; j < e.length; j++) {
    e[j] = 1.4e-30f;
}

int K = 4;
Query q = new Query("*=>[KNN $K @my_vector $BLOB]").setSortBy("__my_vector_score", true).addParam("K", K).addParam("BLOB", floatToByte(e)).limit(0,K).dialect(2);

// parameters to be passed into search
List<Document> docs = redis_conn.ftSearch("my_index", q).getDocuments();

System.out.println("Got " + docs.size() + " results.");
for (Document doc : docs) {
    printDoc(doc);
}
```

The test below shows a few examples of the VSS similarity search API for Entity Streams:

```java
  /**
   * A simple FT.SEARCH (only vector similarity)
   * Get top 4 documents where the vector field is closest to [1.4e-30f, 1.4e-30f,...]
   *
   * FT.SEARCH QUERY = `"(*)=>[KNN $K @vector $vector_blob]"`
   */
  @Test
  void testPureKNNSearchWithHNSWVectorIndex() {
    float[] e = new float[100];
    Arrays.fill(e, 1.4e-30f);

    int K = 4;

    SearchStream<HashWithByteArrayHNSWVector> stream = entityStream.of(HashWithByteArrayHNSWVector.class);

    List<HashWithByteArrayHNSWVector> results = stream //
        .filter(HashWithByteArrayHNSWVector$.VECTOR.knn(K, floatToByte(e))) //
        .sorted(HashWithByteArrayHNSWVector$._VECTOR_SCORE)
        .limit(K)
        .collect(Collectors.toList());

    assertThat(results).hasSize(4).map(HashWithByteArrayHNSWVector::getId).containsExactly("doc:132", "doc:12", "doc:75", "doc:240");
  }

  /**
   * A simple FT.SEARCH (only vector similarity)
   * Get top 4 documents where the vector field is closest to [1.4e-30f, 1.4e-30f,...]
   *
   * FT.SEARCH QUERY = `"(*)=>[KNN $K @vector $vector_blob]"`
   */
  @Test
  void testPureKNNSearchWithHNSWVectorIndexOnlyNumberAndDistances() {
    float[] e = new float[100];
    Arrays.fill(e, 1.4e-30f);

    int K = 4;

    SearchStream<HashWithByteArrayHNSWVector> stream = entityStream.of(HashWithByteArrayHNSWVector.class);

    List<Pair<Integer,Double>> results = stream //
        .filter(HashWithByteArrayHNSWVector$.VECTOR.knn(K, floatToByte(e))) //
        .sorted(HashWithByteArrayHNSWVector$._VECTOR_SCORE) //
        .limit(K) //
        .map(Fields.of(HashWithByteArrayHNSWVector$.NUMBER, HashWithByteArrayHNSWVector$._VECTOR_SCORE)) //
        .collect(Collectors.toList());

    assertAll( //
        () -> assertThat(results).hasSize(4), //
        () -> assertThat(results).map(Pair::getFirst).containsExactly(132, 12, 75, 240), //
        () -> assertThat(results).map(Pair::getSecond).containsExactly(1.08511912913e-05, 4.01816287194e-05, 4.01816287194e-05, 4.18252566305e-05) //
    );
  }

  /**
   * Another Hybrid Query FT.SEARCH (vector and non-vector search criteria)
   * Get top 5 articles with
   * number value is between 0 and 20
   * OR
   * number value is between indexsize-20 and indexsize
   */
  @Test
  void testHybridKNNSearch() {
    float[] e = new float[100];
    Arrays.fill(e, 1.4e-30f);

    int K = 5;
    int NUMBER_ARTICLES = 300;

    SearchStream<HashWithByteArrayHNSWVector> stream = entityStream.of(HashWithByteArrayHNSWVector.class);

    List<Pair<Integer,Double>> results = stream //
        .filter(HashWithByteArrayFlatVector$.NUMBER.between(0, 20) //
            .or(HashWithByteArrayFlatVector$.NUMBER.between(NUMBER_ARTICLES - 20, NUMBER_ARTICLES))) //
        .filter(HashWithByteArrayHNSWVector$.VECTOR.knn(K, floatToByte(e))) //
        .sorted(HashWithByteArrayHNSWVector$._VECTOR_SCORE) //
        .limit(K) //
        .map(Fields.of(HashWithByteArrayHNSWVector$.NUMBER, HashWithByteArrayHNSWVector$._VECTOR_SCORE)) //
        .collect(Collectors.toList());

    assertAll( //
        () -> assertThat(results).hasSize(5), //
        () -> assertThat(results).map(Pair::getFirst).containsExactly(12, 289, 15, 280, 2), //
        () -> assertThat(results).map(Pair::getSecond).containsExactly(4.01816287194e-05, 4.19937859988e-05, 4.19969328505e-05, 4.19990610681e-05, 4.19991047238e-05) //
    );
  }

  /**
   * Get top 5 documents with number value is between 0 and 100
   * FT.SEARCH QUERY = @number:[0 100]=>[KNN $K @my_vector $BLOB AS scores]
   */
  @Test
  void testHybridKNNSearchWithFlatVectorIndex() {
    float[] e = new float[100];
    Arrays.fill(e, 1.4e-30f);

    int K = 5;

    SearchStream<HashWithByteArrayFlatVector> stream = entityStream.of(HashWithByteArrayFlatVector.class);

    List<HashWithByteArrayFlatVector> results = stream //
        .filter(HashWithByteArrayFlatVector$.NUMBER.between(0, 100)) //
        .filter(HashWithByteArrayFlatVector$.VECTOR.knn(K, floatToByte(e))) //
        .sorted(HashWithByteArrayFlatVector$._VECTOR_SCORE)
        .limit(K)
        .collect(Collectors.toList());

    assertThat(results).hasSize(5).map(HashWithByteArrayFlatVector::getId).containsExactly("doc:12", "doc:75", "doc:71", "doc:15", "doc:2");
  }
```