### PR TITLE
fix: handles parameters that share a prefix in queries (resolves gh-187)

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -49,7 +49,6 @@ public class RediSearchQuery implements RepositoryQuery {
   private final QueryMethod queryMethod;
   private final String searchIndex;
 
-
   private RediSearchQueryType type;
   private String value;
 
@@ -594,7 +593,8 @@ public class RediSearchQuery implements RepositoryQuery {
             v = parameters[index].toString();
           }
 
-          preparedQuery = new StringBuilder(preparedQuery.toString().replace("$" + key, v));
+          var regex = "(\\$" + key + ")(\\W+|\\*|\\+)(.*)";
+          preparedQuery = new StringBuilder(preparedQuery.toString().replaceAll(regex, v + "$2$3"));
         }
         index++;
       }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
@@ -594,7 +594,8 @@ public class RedisEnhancedQuery implements RepositoryQuery {
             v = ObjectUtils.asString(parameters[index], mappingConverter);
           }
 
-          preparedQuery = new StringBuilder(preparedQuery.toString().replace("$" + key, v));
+          var regex = "(\\$" + key + ")(\\W+|\\*|\\+)(.*)";
+          preparedQuery = new StringBuilder(preparedQuery.toString().replaceAll(regex, v+"$2$3"));
         }
         index++;
       }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RepositoryIssuesTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RepositoryIssuesTest.java
@@ -1,0 +1,42 @@
+package com.redis.om.spring.annotations.document;
+
+import com.google.common.collect.Sets;
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.annotations.document.fixtures.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.RedisGeoCommands;
+import redis.clients.jedis.json.Path;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SuppressWarnings("SpellCheckingInspection")
+class RepositoryIssuesTest extends AbstractBaseDocumentTest {
+  @Autowired
+  User2Repository repository;
+
+  @BeforeEach
+  void cleanUp() {
+    repository.deleteAll();
+    repository.save(User2.of("Doe", "Paris", "12 rue Rivoli"));
+  }
+
+  // RediSearchQuery wrong preparedQuery #187
+  @Test
+  void testIncorrectParameterInjection() {
+    Iterable<User2> results = repository.findUser("Doe", "Paris", "12 rue Rivoli");
+
+    assertThat(results).extracting("name").containsExactly("Doe");
+  }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/User2.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/User2.java
@@ -1,0 +1,29 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Document
+public class User2{
+  @Id
+  @Indexed
+  private String id;
+
+  @NonNull
+  @Indexed
+  private String name;
+
+  @NonNull
+  @Indexed
+  private String address;
+
+  @NonNull
+  @Indexed
+  private String addressComplement;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/User2Repository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/User2Repository.java
@@ -1,0 +1,15 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.annotations.Query;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+import org.springframework.data.repository.query.Param;
+
+@SuppressWarnings("unused") public interface User2Repository extends RedisDocumentRepository<User2, String> {
+
+  @Query("(@name:{$name}) (@address:{$address}) (@addressComplement:{$addressComp})")
+  Iterable<User2> findUser( //
+      @Param("name") String name, //
+      @Param("address") String strAdd, //
+      @Param("addressComp") String strAddComp //
+  );
+}


### PR DESCRIPTION
Handles param substitution in queries when params share a prefix using a regex to replace rather than just a simple string matching.

For example ` @Query("(@name:{$name}) (@address:{$address}) (@addressComplement:{$addressComp})")`

Replacing with `String.replace` the value `$address` would also partially replace `$addressComp`, instead use `String.replaceAll(regex, val)`
