### PR TITLE
Support annotations on private fields of superclasses of documents

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -163,7 +163,7 @@ public class RedisModulesConfiguration {
     for (BeanDefinition beanDef : beanDefs) {
       try {
         Class<?> cl = Class.forName(beanDef.getBeanClassName());
-        for (java.lang.reflect.Field field : cl.getDeclaredFields()) {
+        for (java.lang.reflect.Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(cl)) {
           // Text
           if (field.isAnnotationPresent(Bloom.class)) {
             Bloom bloom = field.getAnnotation(Bloom.class);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/bloom/BloomAspect.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/bloom/BloomAspect.java
@@ -40,7 +40,7 @@ public class BloomAspect implements Ordered {
 
   @AfterReturning("inSaveOperation() && args(entity,..)")
   public void addToBloom(JoinPoint jp, Object entity) {
-    for (Field field : entity.getClass().getDeclaredFields()) {
+    for (Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(entity.getClass())) {
       if (field.isAnnotationPresent(Bloom.class)) {
         Bloom bloom = field.getAnnotation(Bloom.class);
         String filterName = !ObjectUtils.isEmpty(bloom.name()) ? bloom.name() : String.format("bf:%s:%s", entity.getClass().getSimpleName(), field.getName());
@@ -66,7 +66,7 @@ public class BloomAspect implements Ordered {
   @AfterReturning("inSaveAllOperation() && args(entities,..)")
   public void addAllToBloom(JoinPoint jp, List<Object> entities) {
     for (Object entity : entities) {
-      for (Field field : entity.getClass().getDeclaredFields()) {
+      for (Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(entity.getClass())) {
         if (field.isAnnotationPresent(Bloom.class)) {
           Bloom bloom = field.getAnnotation(Bloom.class);
           String filterName = !ObjectUtils.isEmpty(bloom.name()) ? bloom.name() : String.format("bf:%s:%s", entity.getClass().getSimpleName(), field.getName());

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/MappingRedisOMConverter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/MappingRedisOMConverter.java
@@ -59,6 +59,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.comparator.NullSafeComparator;
 
@@ -688,15 +689,17 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
     Indexed indexed = null;
     TagIndexed tagIndexed = null;
     try {
-      field = entityClass.getDeclaredField(path);
-      Optional<Class<?>> maybeCollectionElementType = com.redis.om.spring.util.ObjectUtils.getCollectionElementType(field);
-      collectionElementType = maybeCollectionElementType.orElse(null);
-      if (field.isAnnotationPresent(Indexed.class)) {
-        indexed = entityClass.getDeclaredField(path).getAnnotation(Indexed.class);
-      } else if (field.isAnnotationPresent(TagIndexed.class)) {
-        tagIndexed = entityClass.getDeclaredField(path).getAnnotation(TagIndexed.class);
+      field = ReflectionUtils.findField(entityClass, path);
+      if (field != null) {
+        Optional<Class<?>> maybeCollectionElementType = com.redis.om.spring.util.ObjectUtils.getCollectionElementType(field);
+        collectionElementType = maybeCollectionElementType.orElse(null);
+        if (field.isAnnotationPresent(Indexed.class)) {
+          indexed = field.getAnnotation(Indexed.class);
+        } else if (field.isAnnotationPresent(TagIndexed.class)) {
+          tagIndexed = field.getAnnotation(TagIndexed.class);
+        }
       }
-    } catch (NoSuchFieldException | SecurityException | NoSuchElementException e1) {
+    } catch (SecurityException | NoSuchElementException e1) {
       // it's ok, move on!
     }
 
@@ -776,15 +779,17 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
     Indexed indexed = null;
     TagIndexed tagIndexed = null;
     try {
-      field = entityClass.getDeclaredField(path);
-      Optional<Class<?>> maybeCollectionElementType = com.redis.om.spring.util.ObjectUtils.getCollectionElementType(field);
-      collectionElementType = maybeCollectionElementType.orElse(null);
-      if (field.isAnnotationPresent(Indexed.class)) {
-        indexed = entityClass.getDeclaredField(path).getAnnotation(Indexed.class);
-      } else if (field.isAnnotationPresent(TagIndexed.class)) {
-        tagIndexed = entityClass.getDeclaredField(path).getAnnotation(TagIndexed.class);
+      field = ReflectionUtils.findField(entityClass, path);
+      if (field != null) {
+        Optional<Class<?>> maybeCollectionElementType = com.redis.om.spring.util.ObjectUtils.getCollectionElementType(field);
+        collectionElementType = maybeCollectionElementType.orElse(null);
+        if (field.isAnnotationPresent(Indexed.class)) {
+          indexed = field.getAnnotation(Indexed.class);
+        } else if (field.isAnnotationPresent(TagIndexed.class)) {
+          tagIndexed = field.getAnnotation(TagIndexed.class);
+        }
       }
-    } catch (NoSuchFieldException | SecurityException | NoSuchElementException e) {
+    } catch (SecurityException | NoSuchElementException e) {
       // it's ok, move on!
     }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -36,6 +36,7 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import org.springframework.util.ReflectionUtils;
 import redis.clients.jedis.search.aggr.*;
 import redis.clients.jedis.search.Document;
 import redis.clients.jedis.search.Query;
@@ -228,91 +229,90 @@ public class RediSearchQuery implements RepositoryQuery {
     String property = path.get(level).getSegment();
     String key = part.getProperty().toDotPath().replace(".", "_");
 
-    Field field;
-    try {
-      field = type.getDeclaredField(property);
-      if (field.isAnnotationPresent(TextIndexed.class)) {
-        TextIndexed indexAnnotation = field.getAnnotation(TextIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TEXT, part.getType())));
-      } else if (field.isAnnotationPresent(Searchable.class)) {
-        Searchable indexAnnotation = field.getAnnotation(Searchable.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TEXT, part.getType())));
-      } else if (field.isAnnotationPresent(TagIndexed.class)) {
-        TagIndexed indexAnnotation = field.getAnnotation(TagIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+    Field field = ReflectionUtils.findField(type, property);
+    if (field == null) {
+      logger.info(String.format("Did not find a field named %s", key));
+      return qf;
+    }
+    if (field.isAnnotationPresent(TextIndexed.class)) {
+      TextIndexed indexAnnotation = field.getAnnotation(TextIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TEXT, part.getType())));
+    } else if (field.isAnnotationPresent(Searchable.class)) {
+      Searchable indexAnnotation = field.getAnnotation(Searchable.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TEXT, part.getType())));
+    } else if (field.isAnnotationPresent(TagIndexed.class)) {
+      TagIndexed indexAnnotation = field.getAnnotation(TagIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TAG, part.getType())));
+    } else if (field.isAnnotationPresent(GeoIndexed.class)) {
+      GeoIndexed indexAnnotation = field.getAnnotation(GeoIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.GEO, part.getType())));
+    } else if (field.isAnnotationPresent(NumericIndexed.class)) {
+      NumericIndexed indexAnnotation = field.getAnnotation(NumericIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.NUMERIC, part.getType())));
+    } else if (field.isAnnotationPresent(Indexed.class)) {
+      Indexed indexAnnotation = field.getAnnotation(Indexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      Class<?> fieldType = ClassUtils.resolvePrimitiveIfNecessary(field.getType());
+      //
+      // Any Character class or Boolean -> Tag Search Field
+      //
+      if (CharSequence.class.isAssignableFrom(fieldType) || (fieldType == Boolean.class)) {
         qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TAG, part.getType())));
-      } else if (field.isAnnotationPresent(GeoIndexed.class)) {
-        GeoIndexed indexAnnotation = field.getAnnotation(GeoIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.GEO, part.getType())));
-      } else if (field.isAnnotationPresent(NumericIndexed.class)) {
-        NumericIndexed indexAnnotation = field.getAnnotation(NumericIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      }
+      //
+      // Any Numeric class -> Numeric Search Field
+      //
+      else if (Number.class.isAssignableFrom(fieldType) || (fieldType == LocalDateTime.class)
+          || (field.getType() == LocalDate.class) || (field.getType() == Date.class)) {
         qf.add(Pair.of(actualKey, QueryClause.get(FieldType.NUMERIC, part.getType())));
-      } else if (field.isAnnotationPresent(Indexed.class)) {
-        Indexed indexAnnotation = field.getAnnotation(Indexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        Class<?> fieldType = ClassUtils.resolvePrimitiveIfNecessary(field.getType());
-        //
-        // Any Character class or Boolean -> Tag Search Field
-        //
-        if (CharSequence.class.isAssignableFrom(fieldType) || (fieldType == Boolean.class)) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TAG, part.getType())));
-        }
-        //
-        // Any Numeric class -> Numeric Search Field
-        //
-        else if (Number.class.isAssignableFrom(fieldType) || (fieldType == LocalDateTime.class)
-            || (field.getType() == LocalDate.class) || (field.getType() == Date.class)) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.NUMERIC, part.getType())));
-        }
-        //
-        // Set / List
-        //
-        else if (Set.class.isAssignableFrom(fieldType) || List.class.isAssignableFrom(fieldType)) {
-          Optional<Class<?>> maybeCollectionType = ObjectUtils.getCollectionElementType(field);
-          if (maybeCollectionType.isPresent()) {
-            Class<?> collectionType = maybeCollectionType.get();
-            if (Number.class.isAssignableFrom(collectionType)) {
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.NUMERIC_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.NUMERIC, part.getType())));
-              }
-            } else if (collectionType == Point.class) {
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.GEO_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.GEO, part.getType())));
-              }
-            } else if (CharSequence.class.isAssignableFrom(collectionType) || (collectionType == Boolean.class)) {
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.TAG_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TAG, part.getType())));
-              }
+      }
+      //
+      // Set / List
+      //
+      else if (Set.class.isAssignableFrom(fieldType) || List.class.isAssignableFrom(fieldType)) {
+        Optional<Class<?>> maybeCollectionType = ObjectUtils.getCollectionElementType(field);
+        if (maybeCollectionType.isPresent()) {
+          Class<?> collectionType = maybeCollectionType.get();
+          if (Number.class.isAssignableFrom(collectionType)) {
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.NUMERIC_CONTAINING_ALL));
             } else {
-              qf.addAll(extractQueryFields(collectionType, part, path, level + 1));
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.NUMERIC, part.getType())));
             }
+          } else if (collectionType == Point.class) {
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.GEO_CONTAINING_ALL));
+            } else {
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.GEO, part.getType())));
+            }
+          } else if (CharSequence.class.isAssignableFrom(collectionType) || (collectionType == Boolean.class)) {
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.TAG_CONTAINING_ALL));
+            } else {
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.TAG, part.getType())));
+            }
+          } else {
+            qf.addAll(extractQueryFields(collectionType, part, path, level + 1));
           }
         }
-        //
-        // Point
-        //
-        else if (fieldType == Point.class) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.GEO, part.getType())));
-        }
-        //
-        // Recursively explore the fields for @Indexed annotated fields
-        //
-        else {
-          qf.addAll(extractQueryFields(fieldType, part, path, level + 1));
-        }
       }
-    } catch (NoSuchFieldException e) {
-      logger.info(String.format("Did not find a field named %s", key));
+      //
+      // Point
+      //
+      else if (fieldType == Point.class) {
+        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.GEO, part.getType())));
+      }
+      //
+      // Recursively explore the fields for @Indexed annotated fields
+      //
+      else {
+        qf.addAll(extractQueryFields(fieldType, part, path, level + 1));
+      }
     }
 
     return qf;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/autocomplete/AutoCompleteQueryExecutor.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/autocomplete/AutoCompleteQueryExecutor.java
@@ -8,6 +8,7 @@ import com.redis.om.spring.util.ObjectUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.data.repository.query.RepositoryQuery;
+import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -37,13 +38,16 @@ public class AutoCompleteQueryExecutor {
       Class<?> entityClass = query.getQueryMethod().getEntityInformation().getJavaType();
 
       try {
-        Field field = entityClass.getDeclaredField(targetProperty);
+        Field field = ReflectionUtils.findField(entityClass, targetProperty);
+        if (field == null) {
+          return Optional.empty();
+        }
         if (field.isAnnotationPresent(AutoComplete.class)) {
           AutoComplete bloom = field.getAnnotation(AutoComplete.class);
           return Optional.of(!org.apache.commons.lang3.ObjectUtils.isEmpty(bloom.name()) ? bloom.name()
               : String.format(Suggestion.KEY_FORMAT_STRING, entityClass.getSimpleName(), field.getName()));
         }
-      } catch (NoSuchFieldException | SecurityException e) {
+      } catch (SecurityException e) {
         return Optional.empty();
       }
     }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
@@ -44,8 +44,8 @@ public class ObjectUtils {
   }
 
   public static List<Field> getFieldsWithAnnotation(Class<?> clazz, Class<? extends Annotation> annotationClass) {
-    return Arrays //
-        .stream(clazz.getDeclaredFields()) //
+    return getDeclaredFieldsTransitively(clazz) //
+        .stream() //
         .filter(f -> f.isAnnotationPresent(annotationClass)) //
         .toList();
   }
@@ -88,7 +88,7 @@ public class ObjectUtils {
   }
 
   public static Optional<Field> getIdFieldForEntityClass(Class<?> cl) {
-    return Arrays.stream(cl.getDeclaredFields()).filter(f -> f.isAnnotationPresent(Id.class)).findFirst();
+    return getDeclaredFieldsTransitively(cl).stream().filter(f -> f.isAnnotationPresent(Id.class)).findFirst();
   }
 
   public static Optional<?> getIdFieldForEntity(Object entity) {
@@ -230,9 +230,12 @@ public class ObjectUtils {
       Class<? extends Annotation> annotationClass) {
     Field field;
     try {
-      field = cls.getDeclaredField(property);
+      field = ReflectionUtils.findField(cls, property);
+      if (field == null) {
+        return false;
+      }
       return field.isAnnotationPresent(annotationClass);
-    } catch (NoSuchFieldException | SecurityException e) {
+    } catch (SecurityException e) {
       return false;
     }
 
@@ -335,6 +338,23 @@ public class ObjectUtils {
     }
     
     return erers;
+  }
+
+  public static List<Field> getDeclaredFieldsTransitively(Class<?> clazz) {
+    List<Field> fields = new ArrayList<>();
+    while (clazz != null) {
+      fields.addAll(Arrays.stream(clazz.getDeclaredFields()).toList());
+      clazz = clazz.getSuperclass();
+    }
+    return fields;
+  }
+
+  public static Field getDeclaredFieldTransitively(Class<?> clazz, String fieldName) throws NoSuchFieldException {
+    Field field = ReflectionUtils.findField(clazz, fieldName);
+    if (field == null) {
+      throw new NoSuchFieldException(fieldName);
+    }
+    return field;
   }
 
   private ObjectUtils() {}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
@@ -55,21 +55,21 @@ class MetamodelGeneratorTest {
 
         // test fields initialization
         () -> assertThat(fileContents)
-            .contains("createdDate = ValidDocumentIndexed.class.getDeclaredField(\"createdDate\");"), //
+            .contains("createdDate = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"createdDate\");"), //
         () -> assertThat(fileContents)
-            .contains("lastModifiedDate = ValidDocumentIndexed.class.getDeclaredField(\"lastModifiedDate\");"), //
-        () -> assertThat(fileContents).contains("email = ValidDocumentIndexed.class.getDeclaredField(\"email\");"), //
+            .contains("lastModifiedDate = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"lastModifiedDate\");"), //
+        () -> assertThat(fileContents).contains("email = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"email\");"), //
         () -> assertThat(fileContents)
-            .contains("publiclyListed = ValidDocumentIndexed.class.getDeclaredField(\"publiclyListed\");"), //
+            .contains("publiclyListed = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"publiclyListed\");"), //
         () -> assertThat(fileContents)
-            .contains("lastValuation = ValidDocumentIndexed.class.getDeclaredField(\"lastValuation\");"), //
-        () -> assertThat(fileContents).contains("id = ValidDocumentIndexed.class.getDeclaredField(\"id\");"), //
+            .contains("lastValuation = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"lastValuation\");"), //
+        () -> assertThat(fileContents).contains("id = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"id\");"), //
         () -> assertThat(fileContents)
-            .contains("yearFounded = ValidDocumentIndexed.class.getDeclaredField(\"yearFounded\");"), //
-        () -> assertThat(fileContents).contains("name = ValidDocumentIndexed.class.getDeclaredField(\"name\");"), //
+            .contains("yearFounded = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"yearFounded\");"), //
+        () -> assertThat(fileContents).contains("name = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"name\");"), //
         () -> assertThat(fileContents)
-            .contains("location = ValidDocumentIndexed.class.getDeclaredField(\"location\");"), //
-        () -> assertThat(fileContents).contains("tags = ValidDocumentIndexed.class.getDeclaredField(\"tags\");"), //
+            .contains("location = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"location\");"), //
+        () -> assertThat(fileContents).contains("tags = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"tags\");"), //
 
         // test Metamodel Field generation
         () -> assertThat(fileContents)
@@ -143,24 +143,24 @@ class MetamodelGeneratorTest {
         () -> assertThat(fileContents).contains("public static Field bool;"), //
 
         // test fields initialization
-        () -> assertThat(fileContents).contains("id = ValidDocumentUnindexed.class.getDeclaredField(\"id\");"), //
+        () -> assertThat(fileContents).contains("id = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"id\");"), //
         () -> assertThat(fileContents)
-            .contains("setThings = ValidDocumentUnindexed.class.getDeclaredField(\"setThings\");"), //
+            .contains("setThings = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"setThings\");"), //
         () -> assertThat(fileContents)
-            .contains("localDateTime = ValidDocumentUnindexed.class.getDeclaredField(\"localDateTime\");"), //
-        () -> assertThat(fileContents).contains("point = ValidDocumentUnindexed.class.getDeclaredField(\"point\");"), //
+            .contains("localDateTime = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"localDateTime\");"), //
+        () -> assertThat(fileContents).contains("point = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"point\");"), //
         () -> assertThat(fileContents)
-            .contains("listThings = ValidDocumentUnindexed.class.getDeclaredField(\"listThings\");"), //
-        () -> assertThat(fileContents).contains("date = ValidDocumentUnindexed.class.getDeclaredField(\"date\");"), //
+            .contains("listThings = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"listThings\");"), //
+        () -> assertThat(fileContents).contains("date = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"date\");"), //
         () -> assertThat(fileContents)
-            .contains("localDate = ValidDocumentUnindexed.class.getDeclaredField(\"localDate\");"), //
-        () -> assertThat(fileContents).contains("ulid = ValidDocumentUnindexed.class.getDeclaredField(\"ulid\");"), //
+            .contains("localDate = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"localDate\");"), //
+        () -> assertThat(fileContents).contains("ulid = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"ulid\");"), //
         () -> assertThat(fileContents)
-            .contains("integerWrapper = ValidDocumentUnindexed.class.getDeclaredField(\"integerWrapper\");"), //
+            .contains("integerWrapper = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"integerWrapper\");"), //
         () -> assertThat(fileContents)
-            .contains("integerPrimitive = ValidDocumentUnindexed.class.getDeclaredField(\"integerPrimitive\");"), //
-        () -> assertThat(fileContents).contains("string = ValidDocumentUnindexed.class.getDeclaredField(\"string\");"), //
-        () -> assertThat(fileContents).contains("bool = ValidDocumentUnindexed.class.getDeclaredField(\"bool\");"), //
+            .contains("integerPrimitive = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"integerPrimitive\");"), //
+        () -> assertThat(fileContents).contains("string = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"string\");"), //
+        () -> assertThat(fileContents).contains("bool = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"bool\");"), //
 
         // test Metamodel Field generation
         () -> assertThat(fileContents)
@@ -244,11 +244,12 @@ class MetamodelGeneratorTest {
         () -> assertThat(fileContents).contains("public static Field address_city;"), //
 
         // test fields initialization
-        () -> assertThat(fileContents).contains("id = ValidDocumentIndexedNested.class.getDeclaredField(\"id\");"), //
         () -> assertThat(fileContents)
-            .contains("address_street = ValidDocumentIndexedNested.class.getDeclaredField(\"address\").getType().getDeclaredField(\"street\");"), //
+            .contains("id = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexedNested.class, \"id\");"), //
         () -> assertThat(fileContents)
-            .contains("address_city = ValidDocumentIndexedNested.class.getDeclaredField(\"address\").getType().getDeclaredField(\"city\");"), //
+            .contains("address_street = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexedNested.class, \"address\").getType(), \"street\");"), //
+        () -> assertThat(fileContents)
+            .contains("address_city = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexedNested.class, \"address\").getType(), \"city\");"), //
 
         // test Metamodel Field generation
         () -> assertThat(fileContents)

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/AbstractDocument.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/AbstractDocument.java
@@ -1,0 +1,35 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.annotations.Indexed;
+import org.springframework.data.annotation.Id;
+
+import java.util.UUID;
+
+public abstract class AbstractDocument {
+    @Id
+    private String id;
+
+    @Indexed
+    private String inherited;
+
+    protected AbstractDocument() {
+        this.id = UUID.randomUUID().toString();
+        this.inherited = "inherited";
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getInherited() {
+        return inherited;
+    }
+
+    public void setInherited(String inherited) {
+        this.inherited = inherited;
+    }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocument.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocument.java
@@ -1,0 +1,23 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+
+@Document
+public class InheritingDocument extends AbstractDocument {
+    @Indexed
+    private String notInherited;
+
+    public InheritingDocument() {
+        super();
+        this.notInherited = "notInherited";
+    }
+
+    public String getNotInherited() {
+        return notInherited;
+    }
+
+    public void setNotInherited(String notInherited) {
+        this.notInherited = notInherited;
+    }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocumentRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocumentRepository.java
@@ -1,0 +1,4 @@
+package com.redis.om.spring.repository;
+
+public interface InheritingDocumentRepository extends RedisDocumentRepository<InheritingDocument, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocumentTest.java
@@ -1,0 +1,74 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.ops.search.SearchOperations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+class InheritingDocumentTest extends AbstractBaseDocumentTest {
+    private static final int SIZE = 20;
+
+    private final InheritingDocumentRepository inheritingDocumentRepository;
+    private final SearchOperations<?> searchOperations;
+
+    @Autowired
+    InheritingDocumentTest(InheritingDocumentRepository inheritingDocumentRepository, RedisModulesOperations<String> redisModulesOperations) {
+        this.inheritingDocumentRepository = inheritingDocumentRepository;
+        this.searchOperations = redisModulesOperations.opsForSearch(InheritingDocument.class.getName() + "Idx");
+    }
+
+    @BeforeEach
+    void setUp() {
+        for (int i = 0; i < SIZE; ++i) {
+            inheritingDocumentRepository.save(new InheritingDocument());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testIndexCreatedCorrectly() {
+        Map<String, Object> info = searchOperations.getInfo();
+        Object rawAttributes = info.get("attributes");
+        assertThat(rawAttributes).isNotNull().isInstanceOf(List.class);
+        List<?> attributes = (List<?>) rawAttributes;
+        assertThat(attributes).hasSize(3)
+                .allSatisfy(element -> {
+                    assertThat(element).isInstanceOf(List.class);
+                    assertThat((List<?>) element).allSatisfy(item -> assertThat(item).isInstanceOf(String.class));
+                })
+                .map(element -> (List<String>) element) // cast is checked through assertion
+                .extracting((List<String> attribute) -> {
+                    for (int i = 0; i < attribute.size(); i++) {
+                        String value = attribute.get(i);
+                        if ("attribute".equals(value)) {
+                            return attribute.get(i + 1);
+                        }
+                    }
+                    return null;
+                })
+                .doesNotContain((String) null)
+                .containsExactlyInAnyOrderElementsOf(List.of("id", "inherited", "notInherited"));
+    }
+
+    @Test
+    void testAllInheritedDocumentsReturned() {
+        assumeThat(inheritingDocumentRepository.count()).isEqualTo(SIZE);
+
+        List<InheritingDocument> documents = inheritingDocumentRepository.findAll();
+        assertThat(documents).isNotNull().hasSize(SIZE);
+    }
+
+    @AfterEach
+    void tearDown() {
+        inheritingDocumentRepository.deleteAll();
+    }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/util/ObjectUtilsTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/util/ObjectUtilsTest.java
@@ -32,6 +32,7 @@ import com.redis.om.spring.annotations.document.fixtures.CompanyRepository;
 import com.redis.om.spring.annotations.document.fixtures.DocWithCustomNameId;
 import com.redis.om.spring.annotations.document.fixtures.DocWithCustomNameIdRepository;
 
+import org.springframework.util.ReflectionUtils;
 import redis.clients.jedis.args.GeoUnit;
 
 @SuppressWarnings({ "ConstantConditions", "SpellCheckingInspection" }) class ObjectUtilsTest extends AbstractBaseDocumentTest {
@@ -103,10 +104,12 @@ import redis.clients.jedis.args.GeoUnit;
   }
 
   @Test
-  void testGetTargetClassName() throws NoSuchFieldException, SecurityException {
+  void testGetTargetClassName() throws SecurityException {
     @SuppressWarnings("MismatchedQueryAndUpdateOfCollection") List<String> lofs = new ArrayList<>();
     int[] inta = new int[] {};
-    String typeName = Company.class.getDeclaredField("publiclyListed").getType().getName();
+    Field field = ReflectionUtils.findField(Company.class, "publiclyListed");
+    assertThat(field).isNotNull();
+    String typeName = field.getType().getName();
 
     assertThat(ObjectUtils.getTargetClassName(String.class.getTypeName())).isEqualTo(String.class.getTypeName());
     assertThat(ObjectUtils.getTargetClassName(lofs.getClass().getTypeName())).isEqualTo(ArrayList.class.getTypeName());
@@ -132,10 +135,14 @@ import redis.clients.jedis.args.GeoUnit;
   }
 
   @Test
-  void testGetCollectionElementType() throws NoSuchFieldException, SecurityException {
-    Field lofsField = BunchOfCollections.class.getDeclaredField("lofs");
-    Field soisField = BunchOfCollections.class.getDeclaredField("sois");
-    Field iocField = BunchOfCollections.class.getDeclaredField("ioc");
+  void testGetCollectionElementType() throws SecurityException {
+    Field lofsField = ReflectionUtils.findField(BunchOfCollections.class, "lofs");
+    Field soisField = ReflectionUtils.findField(BunchOfCollections.class, "sois");
+    Field iocField = ReflectionUtils.findField(BunchOfCollections.class, "ioc");
+
+    assertThat(lofsField).isNotNull();
+    assertThat(soisField).isNotNull();
+    assertThat(iocField).isNotNull();
 
     Optional<Class<?>> maybeContentsOfLofs = ObjectUtils.getCollectionElementType(lofsField);
     Optional<Class<?>> maybeContentsOfSois = ObjectUtils.getCollectionElementType(soisField);


### PR DESCRIPTION
As described in #203, currently only fields in the `@Document` annotated class can have `@Id` or `@Indexed` annotations and annotations on fields from superclasses are not processed.

This PR attempts to resolve this issue. Therefore all fields are retrieved through the class hierarchy up to the `Object` class. To properly retrieve `private` fields, the JDK's reflection method `getFields()` can't be used. For now, recursion is used to traverse the class hierarchy and all `private` fields are retrieved via `getDeclaredFields()`.