### PR TITLE
Support annotations on private fields of superclasses of documents

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RediSearchIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RediSearchIndexer.java
@@ -112,9 +112,11 @@ public class RediSearchIndexer {
       indexName = cl.getName() + "Idx";
       logger.info(String.format("Found @%s annotated class: %s", idxType, cl.getName()));
 
+      final List<java.lang.reflect.Field> allClassFields = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(cl);
+
       List<Field> fields = new ArrayList<>();
 
-      for (java.lang.reflect.Field field : cl.getDeclaredFields()) {
+      for (java.lang.reflect.Field field : allClassFields) {
         fields.addAll(findIndexFields(field, null, idxType == IndexDefinition.Type.JSON));
 
         // @DocumentScore
@@ -193,7 +195,7 @@ public class RediSearchIndexer {
           setting.setTimeToLive(document.timeToLive());
         }
 
-        for (java.lang.reflect.Field field : cl.getDeclaredFields()) {
+        for (java.lang.reflect.Field field : allClassFields) {
           // @TimeToLive
           if (field.isAnnotationPresent(TimeToLive.class)) {
             setting.setTimeToLivePropertyName(field.getName());
@@ -278,7 +280,7 @@ public class RediSearchIndexer {
       // Recursively explore the fields for Index annotated fields
       //
       else {
-        for (java.lang.reflect.Field subfield : field.getType().getDeclaredFields()) {
+        for (java.lang.reflect.Field subfield : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(field.getType())) {
           String subfieldPrefix = (prefix == null || prefix.isBlank()) ? field.getName()
               : String.join(".", prefix, field.getName());
           fields.addAll(findIndexFields(subfield, subfieldPrefix, isDocument));
@@ -440,7 +442,7 @@ public class RediSearchIndexer {
     if (genericType instanceof ParameterizedType) {
       ParameterizedType pt = (ParameterizedType) genericType;
       Class<?> actualTypeArgument = (Class<?>) pt.getActualTypeArguments()[0];
-      java.lang.reflect.Field[] subDeclaredFields = actualTypeArgument.getDeclaredFields();
+      List<java.lang.reflect.Field> subDeclaredFields = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(actualTypeArgument);
       String tempPrefix = "";
       if (prefix == null) {
         prefix = field.getName();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -171,7 +171,7 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
     for (BeanDefinition beanDef : beanDefs) {
       try {
         Class<?> cl = Class.forName(beanDef.getBeanClassName());
-        for (java.lang.reflect.Field field : cl.getDeclaredFields()) {
+        for (java.lang.reflect.Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(cl)) {
           // Text
           if (field.isAnnotationPresent(Bloom.class)) {
             Bloom bloom = field.getAnnotation(Bloom.class);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/bloom/BloomAspect.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/bloom/BloomAspect.java
@@ -40,7 +40,7 @@ public class BloomAspect implements Ordered {
 
   @AfterReturning("inSaveOperation() && args(entity,..)")
   public void addToBloom(JoinPoint jp, Object entity) {
-    for (Field field : entity.getClass().getDeclaredFields()) {
+    for (Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(entity.getClass())) {
       if (field.isAnnotationPresent(Bloom.class)) {
         Bloom bloom = field.getAnnotation(Bloom.class);
         String filterName = !ObjectUtils.isEmpty(bloom.name()) ? bloom.name() : String.format("bf:%s:%s", entity.getClass().getSimpleName(), field.getName());
@@ -66,7 +66,7 @@ public class BloomAspect implements Ordered {
   @AfterReturning("inSaveAllOperation() && args(entities,..)")
   public void addAllToBloom(JoinPoint jp, List<Object> entities) {
     for (Object entity : entities) {
-      for (Field field : entity.getClass().getDeclaredFields()) {
+      for (Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(entity.getClass())) {
         if (field.isAnnotationPresent(Bloom.class)) {
           Bloom bloom = field.getAnnotation(Bloom.class);
           String filterName = !ObjectUtils.isEmpty(bloom.name()) ? bloom.name() : String.format("bf:%s:%s", entity.getClass().getSimpleName(), field.getName());

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/MappingRedisOMConverter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/MappingRedisOMConverter.java
@@ -60,6 +60,7 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.util.comparator.NullSafeComparator;
 
@@ -693,15 +694,17 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
     Indexed indexed = null;
     TagIndexed tagIndexed = null;
     try {
-      field = entityClass.getDeclaredField(path);
-      Optional<Class<?>> maybeCollectionElementType = com.redis.om.spring.util.ObjectUtils.getCollectionElementType(field);
-      collectionElementType = maybeCollectionElementType.isPresent() ? maybeCollectionElementType.get() : null;
-      if (field.isAnnotationPresent(Indexed.class)) {
-        indexed = entityClass.getDeclaredField(path).getAnnotation(Indexed.class);
-      } else if (field.isAnnotationPresent(TagIndexed.class)) {
-        tagIndexed = entityClass.getDeclaredField(path).getAnnotation(TagIndexed.class);
+      field = ReflectionUtils.findField(entityClass, path);
+      if (field != null) {
+        Optional<Class<?>> maybeCollectionElementType = com.redis.om.spring.util.ObjectUtils.getCollectionElementType(field);
+        collectionElementType = maybeCollectionElementType.isPresent() ? maybeCollectionElementType.get() : null;
+        if (field.isAnnotationPresent(Indexed.class)) {
+          indexed = field.getAnnotation(Indexed.class);
+        } else if (field.isAnnotationPresent(TagIndexed.class)) {
+          tagIndexed = field.getAnnotation(TagIndexed.class);
+        }
       }
-    } catch (NoSuchFieldException | SecurityException | NoSuchElementException e1) {
+    } catch (SecurityException | NoSuchElementException e1) {
       // it's ok, move on!
     }
 
@@ -781,15 +784,17 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
     Indexed indexed = null;
     TagIndexed tagIndexed = null;
     try {
-      field = entityClass.getDeclaredField(path);
-      Optional<Class<?>> maybeCollectionElementType = com.redis.om.spring.util.ObjectUtils.getCollectionElementType(field);
-      collectionElementType = maybeCollectionElementType.isPresent() ? maybeCollectionElementType.get() : null;
-      if (field.isAnnotationPresent(Indexed.class)) {
-        indexed = entityClass.getDeclaredField(path).getAnnotation(Indexed.class);
-      } else if (field.isAnnotationPresent(TagIndexed.class)) {
-        tagIndexed = entityClass.getDeclaredField(path).getAnnotation(TagIndexed.class);
+      field = ReflectionUtils.findField(entityClass, path);
+      if (field != null) {
+        Optional<Class<?>> maybeCollectionElementType = com.redis.om.spring.util.ObjectUtils.getCollectionElementType(field);
+        collectionElementType = maybeCollectionElementType.isPresent() ? maybeCollectionElementType.get() : null;
+        if (field.isAnnotationPresent(Indexed.class)) {
+          indexed = field.getAnnotation(Indexed.class);
+        } else if (field.isAnnotationPresent(TagIndexed.class)) {
+          tagIndexed = field.getAnnotation(TagIndexed.class);
+        }
       }
-    } catch (NoSuchFieldException | SecurityException | NoSuchElementException e) {
+    } catch (SecurityException | NoSuchElementException e) {
       // it's ok, move on!
     }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
@@ -22,6 +22,7 @@ import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import java.io.IOException;
@@ -49,6 +50,8 @@ public final class MetamodelGenerator extends AbstractProcessor {
   private ProcessingEnvironment processingEnvironment;
   private Messager messager;
 
+  private TypeElement objectTypeElement;
+
   @Override
   public synchronized void init(ProcessingEnvironment env) {
     super.init(env);
@@ -59,6 +62,8 @@ public final class MetamodelGenerator extends AbstractProcessor {
 
     messager = processingEnvironment.getMessager();
     messager.printMessage(Diagnostic.Kind.NOTE, "Redis OM Spring Field Generator Processor");
+
+    this.objectTypeElement = processingEnvironment.getElementUtils().getTypeElement("java.lang.Object");
   }
 
   @Override
@@ -91,7 +96,7 @@ public final class MetamodelGenerator extends AbstractProcessor {
     final String genEntityName = entityName + "$";
     TypeName entity = TypeName.get(annotatedElement.asType());
 
-    Map<? extends Element, String> enclosedFields = getDeclaredInstanceFields(annotatedElement);
+    Map<? extends Element, String> enclosedFields = getInstanceFields(annotatedElement);
 
     final PackageElement packageElement = processingEnvironment.getElementUtils().getPackageOf(annotatedElement);
     String packageName;
@@ -124,11 +129,16 @@ public final class MetamodelGenerator extends AbstractProcessor {
 
     blockBuilder.beginControlFlow("try");
     for (ObjectGraphFieldSpec ogfs : fields) {
-      String sb = "$L = $T.class";
-      sb = sb + ogfs.getChain().stream().map(e -> String.format(".getDeclaredField(\"%s\")", e.getSimpleName().toString())).collect(
-          Collectors.joining(".getType()"));
+      String sb = "$T.class";
+      for (int i = 0; i < ogfs.getChain().size(); i++) {
+        Element element = ogfs.getChain().get(i);
+        if (i != 0) {
+          sb = sb + ".getType()";
+        }
+        sb = String.format("com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(%s, \"%s\")", sb, element.getSimpleName());
+      }
       FieldSpec fieldSpec = ogfs.getFieldSpec();
-      blockBuilder.addStatement(sb, fieldSpec.name, entity);
+      blockBuilder.addStatement("$L = " + sb, fieldSpec.name, entity);
     }
 
     for (CodeBlock initCodeBlock : initCodeBlocks) {
@@ -296,7 +306,7 @@ public final class MetamodelGenerator extends AbstractProcessor {
     final String entityFieldName = fieldElement.toString();
     messager.printMessage(Diagnostic.Kind.NOTE, "entityFieldName => " + entityFieldName);
 
-    Map<? extends Element, String> enclosedFields = getDeclaredInstanceFields(entityField);
+    Map<? extends Element, String> enclosedFields = getInstanceFields(entityField);
 
     messager.printMessage(Diagnostic.Kind.NOTE, "Enclosed subfield size() ==> " + enclosedFields.size());
 
@@ -313,7 +323,11 @@ public final class MetamodelGenerator extends AbstractProcessor {
     return fieldMetamodels;
   }
 
-  private Map<? extends Element, String> getDeclaredInstanceFields(Element element) {
+  private Map<? extends Element, String> getInstanceFields(Element element) {
+    if (objectTypeElement.equals(element)) {
+      return Collections.emptyMap();
+    }
+
     final Map<String, Element> getters = element.getEnclosedElements().stream()
         .filter(ee -> ee.getKind() == ElementKind.METHOD)
         // Only consider methods with no parameters
@@ -329,11 +343,21 @@ public final class MetamodelGenerator extends AbstractProcessor {
         .map(ObjectUtils::lcfirst).collect(Collectors.toSet());
 
     // Retrieve all declared non-final instance fields of the annotated class
-    return element.getEnclosedElements().stream()
+    Map<Element, String> results = element.getEnclosedElements().stream()
         .filter(ee -> ee.getKind().isField() && !ee.getModifiers().contains(Modifier.STATIC) // Ignore static fields
             && !ee.getModifiers().contains(Modifier.FINAL)) // Ignore final fields
         .collect(Collectors.toMap(Function.identity(),
             ee -> findGetter(ee, getters, isGetters, element.toString(), lombokGetterAvailable(element, ee))));
+
+    Types types = processingEnvironment.getTypeUtils();
+    List<? extends TypeMirror> superTypes = types.directSupertypes(element.asType());
+    superTypes.stream()
+            .map(types::asElement)
+            .filter(superElement -> superElement.getKind().isClass())
+            .findFirst()
+            .ifPresent(superElement -> results.putAll(getInstanceFields(superElement)));
+
+    return results;
   }
 
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -35,6 +35,7 @@ import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.data.util.Pair;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
 import java.time.LocalDate;
@@ -244,91 +245,90 @@ public class RediSearchQuery implements RepositoryQuery {
     String property = path.get(level).getSegment();
     String key = part.getProperty().toDotPath().replace(".", "_");
 
-    Field field;
-    try {
-      field = type.getDeclaredField(property);
-      if (field.isAnnotationPresent(TextIndexed.class)) {
-        TextIndexed indexAnnotation = field.getAnnotation(TextIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
-      } else if (field.isAnnotationPresent(Searchable.class)) {
-        Searchable indexAnnotation = field.getAnnotation(Searchable.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
-      } else if (field.isAnnotationPresent(TagIndexed.class)) {
-        TagIndexed indexAnnotation = field.getAnnotation(TagIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+    Field field = ReflectionUtils.findField(type, property);
+    if (field == null) {
+      logger.info(String.format("Did not find a field named %s", key));
+      return qf;
+    }
+    if (field.isAnnotationPresent(TextIndexed.class)) {
+      TextIndexed indexAnnotation = field.getAnnotation(TextIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
+    } else if (field.isAnnotationPresent(Searchable.class)) {
+      Searchable indexAnnotation = field.getAnnotation(Searchable.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
+    } else if (field.isAnnotationPresent(TagIndexed.class)) {
+      TagIndexed indexAnnotation = field.getAnnotation(TagIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
+    } else if (field.isAnnotationPresent(GeoIndexed.class)) {
+      GeoIndexed indexAnnotation = field.getAnnotation(GeoIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
+    } else if (field.isAnnotationPresent(NumericIndexed.class)) {
+      NumericIndexed indexAnnotation = field.getAnnotation(NumericIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
+    } else if (field.isAnnotationPresent(Indexed.class)) {
+      Indexed indexAnnotation = field.getAnnotation(Indexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      Class<?> fieldType = ClassUtils.resolvePrimitiveIfNecessary(field.getType());
+      //
+      // Any Character class or Boolean -> Tag Search Field
+      //
+      if (CharSequence.class.isAssignableFrom(fieldType) || (fieldType == Boolean.class)) {
         qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
-      } else if (field.isAnnotationPresent(GeoIndexed.class)) {
-        GeoIndexed indexAnnotation = field.getAnnotation(GeoIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
-      } else if (field.isAnnotationPresent(NumericIndexed.class)) {
-        NumericIndexed indexAnnotation = field.getAnnotation(NumericIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      }
+      //
+      // Any Numeric class -> Numeric Search Field
+      //
+      else if (Number.class.isAssignableFrom(fieldType) || (fieldType == LocalDateTime.class)
+          || (field.getType() == LocalDate.class) || (field.getType() == Date.class)) {
         qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
-      } else if (field.isAnnotationPresent(Indexed.class)) {
-        Indexed indexAnnotation = field.getAnnotation(Indexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        Class<?> fieldType = ClassUtils.resolvePrimitiveIfNecessary(field.getType());
-        //
-        // Any Character class or Boolean -> Tag Search Field
-        //
-        if (CharSequence.class.isAssignableFrom(fieldType) || (fieldType == Boolean.class)) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
-        }
-        //
-        // Any Numeric class -> Numeric Search Field
-        //
-        else if (Number.class.isAssignableFrom(fieldType) || (fieldType == LocalDateTime.class)
-            || (field.getType() == LocalDate.class) || (field.getType() == Date.class)) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
-        }
-        //
-        // Set / List
-        //
-        else if (Set.class.isAssignableFrom(fieldType) || List.class.isAssignableFrom(fieldType)) {
-          Optional<Class<?>> maybeCollectionType = ObjectUtils.getCollectionElementType(field);
-          if (maybeCollectionType.isPresent()) {
-            Class<?> collectionType = maybeCollectionType.get();
-            if (Number.class.isAssignableFrom(collectionType)) {
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.Numeric_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
-              }
-            } else if (collectionType == Point.class) {
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.Geo_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
-              }
-            } else if (CharSequence.class.isAssignableFrom(collectionType) || (collectionType == Boolean.class)) {
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.Tag_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
-              }
+      }
+      //
+      // Set / List
+      //
+      else if (Set.class.isAssignableFrom(fieldType) || List.class.isAssignableFrom(fieldType)) {
+        Optional<Class<?>> maybeCollectionType = ObjectUtils.getCollectionElementType(field);
+        if (maybeCollectionType.isPresent()) {
+          Class<?> collectionType = maybeCollectionType.get();
+          if (Number.class.isAssignableFrom(collectionType)) {
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.Numeric_CONTAINING_ALL));
             } else {
-              qf.addAll(extractQueryFields(collectionType, part, path, level + 1));
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
             }
+          } else if (collectionType == Point.class) {
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.Geo_CONTAINING_ALL));
+            } else {
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
+            }
+          } else if (CharSequence.class.isAssignableFrom(collectionType) || (collectionType == Boolean.class)) {
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.Tag_CONTAINING_ALL));
+            } else {
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
+            }
+          } else {
+            qf.addAll(extractQueryFields(collectionType, part, path, level + 1));
           }
         }
-        //
-        // Point
-        //
-        else if (fieldType == Point.class) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
-        }
-        //
-        // Recursively explore the fields for @Indexed annotated fields
-        //
-        else {
-          qf.addAll(extractQueryFields(fieldType, part, path, level + 1));
-        }
       }
-    } catch (NoSuchFieldException e) {
-      logger.info(String.format("Did not find a field named %s", key));
+      //
+      // Point
+      //
+      else if (fieldType == Point.class) {
+        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
+      }
+      //
+      // Recursively explore the fields for @Indexed annotated fields
+      //
+      else {
+        qf.addAll(extractQueryFields(fieldType, part, path, level + 1));
+      }
     }
 
     return qf;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RedisEnhancedQuery.java
@@ -36,6 +36,7 @@ import org.springframework.data.repository.query.parser.Part;
 import org.springframework.data.repository.query.parser.PartTree;
 import org.springframework.data.util.Pair;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Field;
 import java.time.LocalDate;
@@ -243,90 +244,89 @@ public class RedisEnhancedQuery implements RepositoryQuery {
     String property = path.get(level).getSegment();
     String key = part.getProperty().toDotPath().replace(".", "_");
 
-    Field field;
-    try {
-      field = type.getDeclaredField(property);
+    Field field = ReflectionUtils.findField(type, property);
+    if (field == null) {
+      logger.info(String.format("Did not find a field named %s", key));
+      return qf;
+    }
 
-      if (field.isAnnotationPresent(TextIndexed.class)) {
-        TextIndexed indexAnnotation = field.getAnnotation(TextIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
-      } else if (field.isAnnotationPresent(Searchable.class)) {
-        Searchable indexAnnotation = field.getAnnotation(Searchable.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
-      } else if (field.isAnnotationPresent(TagIndexed.class)) {
-        TagIndexed indexAnnotation = field.getAnnotation(TagIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+    if (field.isAnnotationPresent(TextIndexed.class)) {
+      TextIndexed indexAnnotation = field.getAnnotation(TextIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
+    } else if (field.isAnnotationPresent(Searchable.class)) {
+      Searchable indexAnnotation = field.getAnnotation(Searchable.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.FullText, part.getType())));
+    } else if (field.isAnnotationPresent(TagIndexed.class)) {
+      TagIndexed indexAnnotation = field.getAnnotation(TagIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
+    } else if (field.isAnnotationPresent(GeoIndexed.class)) {
+      GeoIndexed indexAnnotation = field.getAnnotation(GeoIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
+    } else if (field.isAnnotationPresent(NumericIndexed.class)) {
+      NumericIndexed indexAnnotation = field.getAnnotation(NumericIndexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
+    } else if (field.isAnnotationPresent(Indexed.class)) {
+      Indexed indexAnnotation = field.getAnnotation(Indexed.class);
+      String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      Class<?> fieldType = ClassUtils.resolvePrimitiveIfNecessary(field.getType());
+      //
+      // Any Character class or Boolean -> Tag Search Field
+      //
+      if (CharSequence.class.isAssignableFrom(fieldType) || (fieldType == Boolean.class)) {
         qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
-      } else if (field.isAnnotationPresent(GeoIndexed.class)) {
-        GeoIndexed indexAnnotation = field.getAnnotation(GeoIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
-      } else if (field.isAnnotationPresent(NumericIndexed.class)) {
-        NumericIndexed indexAnnotation = field.getAnnotation(NumericIndexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
+      }
+      //
+      // Any Numeric class -> Numeric Search Field
+      //
+      else if (Number.class.isAssignableFrom(fieldType) || (fieldType == LocalDateTime.class)
+          || (field.getType() == LocalDate.class) || (field.getType() == Date.class)) {
         qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
-      } else if (field.isAnnotationPresent(Indexed.class)) {
-        Indexed indexAnnotation = field.getAnnotation(Indexed.class);
-        String actualKey = indexAnnotation.alias().isBlank() ? key : indexAnnotation.alias();
-        Class<?> fieldType = ClassUtils.resolvePrimitiveIfNecessary(field.getType());
-        //
-        // Any Character class or Boolean -> Tag Search Field
-        //
-        if (CharSequence.class.isAssignableFrom(fieldType) || (fieldType == Boolean.class)) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
-        }
-        //
-        // Any Numeric class -> Numeric Search Field
-        //
-        else if (Number.class.isAssignableFrom(fieldType) || (fieldType == LocalDateTime.class)
-            || (field.getType() == LocalDate.class) || (field.getType() == Date.class)) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
-        }
-        //
-        // Set / List
-        //
-        else if (Set.class.isAssignableFrom(fieldType) || List.class.isAssignableFrom(fieldType)) {
-          Optional<Class<?>> maybeCollectionType = ObjectUtils.getCollectionElementType(field);
-          if (maybeCollectionType.isPresent()) {
-            Class<?> collectionType = maybeCollectionType.get();
-            if (Number.class.isAssignableFrom(collectionType)) {
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.Numeric_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
-              }
-            } else if (collectionType == Point.class) {
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.Geo_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
-              }
-            } else { // String or Boolean
-              if (isANDQuery) {
-                qf.add(Pair.of(actualKey, QueryClause.Tag_CONTAINING_ALL));
-              } else {
-                qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
-              }
+      }
+      //
+      // Set / List
+      //
+      else if (Set.class.isAssignableFrom(fieldType) || List.class.isAssignableFrom(fieldType)) {
+        Optional<Class<?>> maybeCollectionType = ObjectUtils.getCollectionElementType(field);
+        if (maybeCollectionType.isPresent()) {
+          Class<?> collectionType = maybeCollectionType.get();
+          if (Number.class.isAssignableFrom(collectionType)) {
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.Numeric_CONTAINING_ALL));
+            } else {
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Numeric, part.getType())));
+            }
+          } else if (collectionType == Point.class) {
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.Geo_CONTAINING_ALL));
+            } else {
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
+            }
+          } else { // String or Boolean
+            if (isANDQuery) {
+              qf.add(Pair.of(actualKey, QueryClause.Tag_CONTAINING_ALL));
+            } else {
+              qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Tag, part.getType())));
             }
           }
         }
-        //
-        // Point
-        //
-        else if (fieldType == Point.class) {
-          qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
-        }
-        //
-        // Recursively explore the fields for @Indexed annotated fields
-        //
-        else {
-          qf.addAll(extractQueryFields(fieldType, part, path, level + 1));
-        }
       }
-    } catch (NoSuchFieldException e) {
-      logger.info(String.format("Did not find a field named %s", key));
+      //
+      // Point
+      //
+      else if (fieldType == Point.class) {
+        qf.add(Pair.of(actualKey, QueryClause.get(FieldType.Geo, part.getType())));
+      }
+      //
+      // Recursively explore the fields for @Indexed annotated fields
+      //
+      else {
+        qf.addAll(extractQueryFields(fieldType, part, path, level + 1));
+      }
     }
 
     return qf;

--- a/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseDocumentTest.java
@@ -17,7 +17,7 @@ import com.redis.om.spring.annotations.EnableRedisDocumentRepositories;
 public abstract class AbstractBaseDocumentTest extends AbstractBaseOMTest {
   @SpringBootApplication
   @Configuration
-  @EnableRedisDocumentRepositories(basePackages = "com.redis.om.spring.annotations.document.fixtures")
+  @EnableRedisDocumentRepositories(basePackages = {"com.redis.om.spring.annotations.document.fixtures", "com.redis.om.spring.repository"})
   static class Config extends TestConfig {
   }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
@@ -59,21 +59,21 @@ class MetamodelGeneratorTest {
 
         // test fields initialization
         () -> assertThat(fileContents)
-            .contains("createdDate = ValidDocumentIndexed.class.getDeclaredField(\"createdDate\");"), //
+            .contains("createdDate = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"createdDate\");"), //
         () -> assertThat(fileContents)
-            .contains("lastModifiedDate = ValidDocumentIndexed.class.getDeclaredField(\"lastModifiedDate\");"), //
-        () -> assertThat(fileContents).contains("email = ValidDocumentIndexed.class.getDeclaredField(\"email\");"), //
+            .contains("lastModifiedDate = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"lastModifiedDate\");"), //
+        () -> assertThat(fileContents).contains("email = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"email\");"), //
         () -> assertThat(fileContents)
-            .contains("publiclyListed = ValidDocumentIndexed.class.getDeclaredField(\"publiclyListed\");"), //
+            .contains("publiclyListed = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"publiclyListed\");"), //
         () -> assertThat(fileContents)
-            .contains("lastValuation = ValidDocumentIndexed.class.getDeclaredField(\"lastValuation\");"), //
-        () -> assertThat(fileContents).contains("id = ValidDocumentIndexed.class.getDeclaredField(\"id\");"), //
+            .contains("lastValuation = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"lastValuation\");"), //
+        () -> assertThat(fileContents).contains("id = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"id\");"), //
         () -> assertThat(fileContents)
-            .contains("yearFounded = ValidDocumentIndexed.class.getDeclaredField(\"yearFounded\");"), //
-        () -> assertThat(fileContents).contains("name = ValidDocumentIndexed.class.getDeclaredField(\"name\");"), //
+            .contains("yearFounded = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"yearFounded\");"), //
+        () -> assertThat(fileContents).contains("name = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"name\");"), //
         () -> assertThat(fileContents)
-            .contains("location = ValidDocumentIndexed.class.getDeclaredField(\"location\");"), //
-        () -> assertThat(fileContents).contains("tags = ValidDocumentIndexed.class.getDeclaredField(\"tags\");"), //
+            .contains("location = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"location\");"), //
+        () -> assertThat(fileContents).contains("tags = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexed.class, \"tags\");"), //
 
         // test Metamodel Field generation
         () -> assertThat(fileContents)
@@ -147,24 +147,24 @@ class MetamodelGeneratorTest {
         () -> assertThat(fileContents).contains("public static Field bool;"), //
 
         // test fields initialization
-        () -> assertThat(fileContents).contains("id = ValidDocumentUnindexed.class.getDeclaredField(\"id\");"), //
+        () -> assertThat(fileContents).contains("id = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"id\");"), //
         () -> assertThat(fileContents)
-            .contains("setThings = ValidDocumentUnindexed.class.getDeclaredField(\"setThings\");"), //
+            .contains("setThings = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"setThings\");"), //
         () -> assertThat(fileContents)
-            .contains("localDateTime = ValidDocumentUnindexed.class.getDeclaredField(\"localDateTime\");"), //
-        () -> assertThat(fileContents).contains("point = ValidDocumentUnindexed.class.getDeclaredField(\"point\");"), //
+            .contains("localDateTime = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"localDateTime\");"), //
+        () -> assertThat(fileContents).contains("point = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"point\");"), //
         () -> assertThat(fileContents)
-            .contains("listThings = ValidDocumentUnindexed.class.getDeclaredField(\"listThings\");"), //
-        () -> assertThat(fileContents).contains("date = ValidDocumentUnindexed.class.getDeclaredField(\"date\");"), //
+            .contains("listThings = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"listThings\");"), //
+        () -> assertThat(fileContents).contains("date = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"date\");"), //
         () -> assertThat(fileContents)
-            .contains("localDate = ValidDocumentUnindexed.class.getDeclaredField(\"localDate\");"), //
-        () -> assertThat(fileContents).contains("ulid = ValidDocumentUnindexed.class.getDeclaredField(\"ulid\");"), //
+            .contains("localDate = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"localDate\");"), //
+        () -> assertThat(fileContents).contains("ulid = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"ulid\");"), //
         () -> assertThat(fileContents)
-            .contains("integerWrapper = ValidDocumentUnindexed.class.getDeclaredField(\"integerWrapper\");"), //
+            .contains("integerWrapper = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"integerWrapper\");"), //
         () -> assertThat(fileContents)
-            .contains("integerPrimitive = ValidDocumentUnindexed.class.getDeclaredField(\"integerPrimitive\");"), //
-        () -> assertThat(fileContents).contains("string = ValidDocumentUnindexed.class.getDeclaredField(\"string\");"), //
-        () -> assertThat(fileContents).contains("bool = ValidDocumentUnindexed.class.getDeclaredField(\"bool\");"), //
+            .contains("integerPrimitive = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"integerPrimitive\");"), //
+        () -> assertThat(fileContents).contains("string = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"string\");"), //
+        () -> assertThat(fileContents).contains("bool = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentUnindexed.class, \"bool\");"), //
 
         // test Metamodel Field generation
         () -> assertThat(fileContents)
@@ -248,11 +248,11 @@ class MetamodelGeneratorTest {
         () -> assertThat(fileContents).contains("public static Field address_city;"), //
 
         // test fields initialization
-        () -> assertThat(fileContents).contains("id = ValidDocumentIndexedNested.class.getDeclaredField(\"id\");"), //
+        () -> assertThat(fileContents).contains("id = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexedNested.class, \"id\");"), //
         () -> assertThat(fileContents)
-            .contains("address_street = ValidDocumentIndexedNested.class.getDeclaredField(\"address\").getType().getDeclaredField(\"street\");"), //
+            .contains("address_street = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexedNested.class, \"address\").getType(), \"street\");"), //
         () -> assertThat(fileContents)
-            .contains("address_city = ValidDocumentIndexedNested.class.getDeclaredField(\"address\").getType().getDeclaredField(\"city\");"), //
+            .contains("address_city = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentIndexedNested.class, \"address\").getType(), \"city\");"), //
 
         // test Metamodel Field generation
         () -> assertThat(fileContents)

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/AbstractDocument.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/AbstractDocument.java
@@ -1,0 +1,35 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.annotations.Indexed;
+import org.springframework.data.annotation.Id;
+
+import java.util.UUID;
+
+public abstract class AbstractDocument {
+    @Id
+    private String id;
+
+    @Indexed
+    private String inherited;
+
+    protected AbstractDocument() {
+        this.id = UUID.randomUUID().toString();
+        this.inherited = "inherited";
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getInherited() {
+        return inherited;
+    }
+
+    public void setInherited(String inherited) {
+        this.inherited = inherited;
+    }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocument.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocument.java
@@ -1,0 +1,23 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+
+@Document
+public class InheritingDocument extends AbstractDocument {
+    @Indexed
+    private String notInherited;
+
+    public InheritingDocument() {
+        super();
+        this.notInherited = "notInherited";
+    }
+
+    public String getNotInherited() {
+        return notInherited;
+    }
+
+    public void setNotInherited(String notInherited) {
+        this.notInherited = notInherited;
+    }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocumentRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocumentRepository.java
@@ -1,0 +1,4 @@
+package com.redis.om.spring.repository;
+
+public interface InheritingDocumentRepository extends RedisDocumentRepository<InheritingDocument, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/InheritingDocumentTest.java
@@ -1,0 +1,74 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.ops.search.SearchOperations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+class InheritingDocumentTest extends AbstractBaseDocumentTest {
+    private static final int SIZE = 10;
+
+    private final InheritingDocumentRepository inheritingDocumentRepository;
+    private final SearchOperations<?> searchOperations;
+
+    @Autowired
+    InheritingDocumentTest(InheritingDocumentRepository inheritingDocumentRepository, RedisModulesOperations<String> redisModulesOperations) {
+        this.inheritingDocumentRepository = inheritingDocumentRepository;
+        this.searchOperations = redisModulesOperations.opsForSearch(InheritingDocument.class.getName() + "Idx");
+    }
+
+    @BeforeEach
+    void setUp() {
+        for (int i = 0; i < SIZE; ++i) {
+            inheritingDocumentRepository.save(new InheritingDocument());
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testIndexCreatedCorrectly() {
+        Map<String, Object> info = searchOperations.getInfo();
+        Object rawAttributes = info.get("attributes");
+        assertThat(rawAttributes).isNotNull().isInstanceOf(List.class);
+        List<?> attributes = (List<?>) rawAttributes;
+        assertThat(attributes).hasSize(3)
+                .allSatisfy(element -> {
+                    assertThat(element).isInstanceOf(List.class);
+                    assertThat((List<?>) element).allSatisfy(item -> assertThat(item).isInstanceOf(String.class));
+                })
+                .map(element -> (List<String>) element) // cast is checked through assertion
+                .extracting((List<String> attribute) -> {
+                    for (int i = 0; i < attribute.size(); i++) {
+                        String value = attribute.get(i);
+                        if ("attribute".equals(value)) {
+                            return attribute.get(i + 1);
+                        }
+                    }
+                    return null;
+                })
+                .doesNotContain((String) null)
+                .containsExactlyInAnyOrderElementsOf(List.of("id", "inherited", "notInherited"));
+    }
+
+    @Test
+    void testAllInheritedDocumentsReturned() {
+        assumeThat(inheritingDocumentRepository.count()).isEqualTo(SIZE);
+
+        Iterable<InheritingDocument> documents = inheritingDocumentRepository.findAll();
+        assertThat(documents).isNotNull().hasSize(SIZE);
+    }
+
+    @AfterEach
+    void tearDown() {
+        inheritingDocumentRepository.deleteAll();
+    }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/util/ObjectUtilsTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/util/ObjectUtilsTest.java
@@ -34,6 +34,7 @@ import com.redis.om.spring.annotations.document.fixtures.DocWithCustomNameIdRepo
 
 import io.redisearch.querybuilder.GeoValue;
 import io.redisearch.querybuilder.GeoValue.Unit;
+import org.springframework.util.ReflectionUtils;
 
 class ObjectUtilsTest extends AbstractBaseDocumentTest {
 
@@ -104,10 +105,12 @@ class ObjectUtilsTest extends AbstractBaseDocumentTest {
   }
 
   @Test
-  void testGetTargetClassName() throws NoSuchFieldException, SecurityException, NoSuchMethodException {
+  void testGetTargetClassName() throws SecurityException, NoSuchMethodException {
     List<String> lofs = new ArrayList<String>();
     int[] inta = new int[] {};
-    String typeName = Company.class.getDeclaredField("publiclyListed").getType().getName();
+    Field field = ReflectionUtils.findField(Company.class, "publiclyListed");
+    assertThat(field).isNotNull();
+    String typeName = field.getType().getName();
 
     assertThat(ObjectUtils.getTargetClassName(String.class.getTypeName())).isEqualTo(String.class.getTypeName());
     assertThat(ObjectUtils.getTargetClassName(lofs.getClass().getTypeName())).isEqualTo(ArrayList.class.getTypeName());
@@ -133,10 +136,14 @@ class ObjectUtilsTest extends AbstractBaseDocumentTest {
   }
 
   @Test
-  void testGetCollectionElementType() throws NoSuchFieldException, SecurityException {
-    Field lofsField = BunchOfCollections.class.getDeclaredField("lofs");
-    Field soisField = BunchOfCollections.class.getDeclaredField("sois");
-    Field iocField = BunchOfCollections.class.getDeclaredField("ioc");
+  void testGetCollectionElementType() throws SecurityException {
+    Field lofsField = ReflectionUtils.findField(BunchOfCollections.class, "lofs");
+    Field soisField = ReflectionUtils.findField(BunchOfCollections.class, "sois");
+    Field iocField = ReflectionUtils.findField(BunchOfCollections.class, "ioc");
+
+    assertThat(lofsField).isNotNull();
+    assertThat(soisField).isNotNull();
+    assertThat(iocField).isNotNull();
 
     Optional<Class<?>> maybeContentsOfLofs = ObjectUtils.getCollectionElementType(lofsField);
     Optional<Class<?>> maybeContentsOfSois = ObjectUtils.getCollectionElementType(soisField);


### PR DESCRIPTION
Backport for #204 

As described in #203, currently only fields in the `@Document` annotated class can have `@Id` or `@Indexed` annotations and annotations on fields from superclasses are not processed.

This PR attempts to resolve this issue. Therefore all fields are retrieved through the class hierarchy up to the `Object` class. To properly retrieve `private` fields, the JDK's reflection method `getFields()` can't be used. For now, recursion is used to traverse the class hierarchy and all `private` fields are retrieved via `getDeclaredFields()`.