### PR TITLE
Remove `CachingConfigurerSupport` superclass in `RedisModulesConfiguration`

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -58,7 +58,7 @@ import com.redis.om.spring.serialization.gson.UlidTypeAdapter;
 @ComponentScan("com.redis.om.spring.bloom")
 @ComponentScan("com.redis.om.spring.autocomplete")
 @ComponentScan("com.redis.om.spring.metamodel")
-public class RedisModulesConfiguration extends CachingConfigurerSupport {
+public class RedisModulesConfiguration {
 
   private static final Log logger = LogFactory.getLog(RedisModulesConfiguration.class);
 


### PR DESCRIPTION
Backport for #181

The `RedisModulesConfiguration` class implements the `CachingConfigurer` interface, but neither overrides nor uses a method from it. However, the implementation of the interface in a configuration class registeres a bean that may clash with an other caching configuration in an application. This PR therefore simply removes the interface declaration.