### PR TITLE
feature: add a configuration parameter to specify the default query limit

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -53,7 +53,7 @@ import com.redis.om.spring.serialization.gson.PointTypeAdapter;
 import com.redis.om.spring.serialization.gson.UlidTypeAdapter;
 
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(RedisProperties.class)
+@EnableConfigurationProperties({RedisProperties.class, RedisOMSpringProperties.class})
 @EnableAspectJAutoProxy
 @ComponentScan("com.redis.om.spring.bloom")
 @ComponentScan("com.redis.om.spring.autocomplete")
@@ -121,17 +121,17 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
   RedisJSONKeyValueAdapter getRedisJSONKeyValueAdapter(RedisOperations<?, ?> redisOps,
       RedisModulesOperations<?> redisModulesOperations, RedisMappingContext mappingContext,
       RediSearchIndexer keyspaceToIndexMap,
-      GsonBuilder gsonBuilder) {
-    return new RedisJSONKeyValueAdapter(redisOps, redisModulesOperations, mappingContext, keyspaceToIndexMap, gsonBuilder);
+      GsonBuilder gsonBuilder, RedisOMSpringProperties properties) {
+    return new RedisJSONKeyValueAdapter(redisOps, redisModulesOperations, mappingContext, keyspaceToIndexMap, gsonBuilder, properties);
   }
 
   @Bean(name = "redisJSONKeyValueTemplate")
   public CustomRedisKeyValueTemplate getRedisJSONKeyValueTemplate(RedisOperations<?, ?> redisOps,
       RedisModulesOperations<?> redisModulesOperations, RedisMappingContext mappingContext,
       RediSearchIndexer keyspaceToIndexMap,
-      GsonBuilder gsonBuilder) {
+      GsonBuilder gsonBuilder, RedisOMSpringProperties properties) {
     return new CustomRedisKeyValueTemplate(
-        getRedisJSONKeyValueAdapter(redisOps, redisModulesOperations, mappingContext, keyspaceToIndexMap, gsonBuilder),
+        getRedisJSONKeyValueAdapter(redisOps, redisModulesOperations, mappingContext, keyspaceToIndexMap, gsonBuilder, properties),
         mappingContext);
   }
 
@@ -154,7 +154,7 @@ public class RedisModulesConfiguration extends CachingConfigurerSupport {
     logger.info("Creating Indexes......");
 
     ApplicationContext ac = cre.getApplicationContext();
-    
+
     RediSearchIndexer indexer = (RediSearchIndexer) ac.getBean("rediSearchIndexer");
     indexer.createIndicesFor(Document.class);
     indexer.createIndicesFor(RedisHash.class);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisOMSpringProperties.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisOMSpringProperties.java
@@ -1,0 +1,35 @@
+package com.redis.om.spring;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(
+        prefix = "redis.om.spring",
+        ignoreInvalidFields = true
+)
+public class RedisOMSpringProperties {
+    private final Repository repository = new Repository();
+
+    public Repository getRepository() {
+        return repository;
+    }
+
+    public static class Repository {
+        private final Query query = new Query();
+
+        public Query getQuery() {
+            return query;
+        }
+
+        public static class Query {
+            private int limit = 10000;
+
+            public int getLimit() {
+                return limit;
+            }
+
+            public void setLimit(int limit) {
+                this.limit = limit;
+            }
+        }
+    }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseDocumentTest.java
@@ -17,7 +17,7 @@ import com.redis.om.spring.annotations.EnableRedisDocumentRepositories;
 public abstract class AbstractBaseDocumentTest extends AbstractBaseOMTest {
   @SpringBootApplication
   @Configuration
-  @EnableRedisDocumentRepositories(basePackages = "com.redis.om.spring.annotations.document.fixtures")
+  @EnableRedisDocumentRepositories(basePackages = {"com.redis.om.spring.annotations.document.fixtures", "com.redis.om.spring.repository"})
   static class Config extends TestConfig {
   }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/SimpleDocument.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/SimpleDocument.java
@@ -1,0 +1,24 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.annotations.Document;
+import org.springframework.data.annotation.Id;
+
+import java.util.UUID;
+
+@Document
+public class SimpleDocument {
+    @Id
+    private String id;
+
+    public SimpleDocument() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/SimpleDocumentRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/SimpleDocumentRepository.java
@@ -1,0 +1,4 @@
+package com.redis.om.spring.repository;
+
+public interface SimpleDocumentRepository extends RedisDocumentRepository<SimpleDocument, String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/repository/SimpleDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/repository/SimpleDocumentTest.java
@@ -1,0 +1,44 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+class SimpleDocumentTest extends AbstractBaseDocumentTest {
+
+    private static final int SIZE = 20;
+
+    private final SimpleDocumentRepository simpleDocumentRepository;
+
+    @Autowired
+    SimpleDocumentTest(SimpleDocumentRepository simpleDocumentRepository) {
+        this.simpleDocumentRepository = simpleDocumentRepository;
+    }
+
+    @BeforeEach
+    void setUp() {
+        for (int i = 0; i < SIZE; ++i) {
+            simpleDocumentRepository.save(new SimpleDocument());
+        }
+    }
+
+    @Test
+    void testAllSimpleDocumentsReturned() {
+        assumeThat(simpleDocumentRepository.count()).isEqualTo(SIZE);
+
+        Iterable<SimpleDocument> documents = simpleDocumentRepository.findAll();
+        assertThat(documents).isNotNull().hasSize(SIZE);
+    }
+
+    @AfterEach
+    void tearDown() {
+        simpleDocumentRepository.deleteAll();
+    }
+}

--- a/redis-om-spring/src/test/resources/application.yaml
+++ b/redis-om-spring/src/test/resources/application.yaml
@@ -1,0 +1,6 @@
+redis:
+  om:
+    spring:
+      repository:
+        query:
+          limit: 20


### PR DESCRIPTION
Backport for #178 

I've recognized that only the first 10 elements are returned when querying all elements from a repository. This was also reported in [this StackOverflow thread](https://stackoverflow.com/questions/72948903/returning-only-the-first-10-record-redis-om).

This PR attempts to fix this behaviour by providing a configuration option for this value. The default value is 10 to prevent a breaking change. Users may set it to `Integer.MAX_VALUE` to retrieve all elements from a repository.