### PR TITLE
Bsb/issue 180 search object collections

### DIFF
--- a/demos/roms-documents/pom.xml
+++ b/demos/roms-documents/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/demos/roms-hashes/pom.xml
+++ b/demos/roms-hashes/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/demos/roms-permits/pom.xml
+++ b/demos/roms-permits/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <relativePath />
     <!-- lookup parent from repository -->
   </parent>

--- a/demos/roms-vss/pom.xml
+++ b/demos/roms-vss/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.5</version>
+    <version>3.0.6</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -59,7 +59,7 @@
     <maven.test.source>17</maven.test.source>
     <maven.test.target>17</maven.test.target>
     <java.version>17</java.version>
-    <spring.version>3.0.5</spring.version>
+    <spring.version>3.0.6</spring.version>
     <sdr.version>3.0.4</sdr.version>
     <jedis.version>4.3.1</jedis.version>
     <cdi>1.0</cdi>

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -60,7 +60,7 @@
     <maven.test.target>17</maven.test.target>
     <java.version>17</java.version>
     <spring.version>3.0.6</spring.version>
-    <sdr.version>3.0.4</sdr.version>
+    <sdr.version>3.0.5</sdr.version>
     <jedis.version>4.3.1</jedis.version>
     <cdi>1.0</cdi>
     <auto-service.version>1.0.1</auto-service.version>

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -61,7 +61,7 @@
     <java.version>17</java.version>
     <spring.version>3.0.6</spring.version>
     <sdr.version>3.0.5</sdr.version>
-    <jedis.version>4.3.1</jedis.version>
+    <jedis.version>4.3.2</jedis.version>
     <cdi>1.0</cdi>
     <auto-service.version>1.0.1</auto-service.version>
     <spring.test.version>6.0.4</spring.test.version>

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -64,9 +64,9 @@
     <jedis.version>4.3.2</jedis.version>
     <cdi>1.0</cdi>
     <auto-service.version>1.0.1</auto-service.version>
-    <spring.test.version>6.0.4</spring.test.version>
-    <testcontainers.redis.version>1.6.2</testcontainers.redis.version>
-    <testcontainers.redis.junit.version>1.6.2</testcontainers.redis.junit.version>
+    <spring.test.version>6.0.8</spring.test.version>
+    <testcontainers.redis.version>1.6.4</testcontainers.redis.version>
+    <testcontainers.redis.junit.version>1.6.4</testcontainers.redis.junit.version>
     <guava.version>31.1-jre</guava.version>
     <ulid.version>5.0.1</ulid.version>
     <lombok.version>1.18.24</lombok.version>

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/CollectionField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/CollectionField.java
@@ -1,0 +1,9 @@
+package com.redis.om.spring.metamodel.indexed;
+
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+
+public class CollectionField<E, T> extends TagField<E, T> {
+  public CollectionField(SearchFieldAccessor searchFieldAccessor, boolean indexed) {
+    super(searchFieldAccessor, indexed);
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
@@ -63,6 +63,15 @@ public class ObjectUtils {
     return cls;
   }
 
+  public static String getCollectionTargetClassName(String fullTypeClassName) {
+    String[] splitted = fullTypeClassName.split(" ");
+    String cls = splitted[splitted.length - 1];
+    if (cls.contains("<")) {
+      cls = cls.substring(cls.indexOf("<") + 1, cls.indexOf(">"));
+    }
+    return cls;
+  }
+
   public static String firstToLowercase(String string) {
     char[] c = string.toCharArray();
     c[0] = Character.toLowerCase(c[0]);

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DeepList.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DeepList.java
@@ -5,11 +5,13 @@ import com.redis.om.spring.annotations.Indexed;
 import lombok.*;
 import org.springframework.data.annotation.Id;
 
+import java.util.List;
+
 @Data
 @RequiredArgsConstructor(staticName = "of")
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Document
-public class DeepNest {
+public class DeepList {
   @Id
   private String id;
 
@@ -19,5 +21,5 @@ public class DeepNest {
 
   @Indexed
   @NonNull
-  private NestLevel1 nestLevel1;
+  private List<NestLevel2> nestLevels;
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DeepListRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DeepListRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface DeepListRepository extends RedisDocumentRepository<DeepList, String> {
+}


### PR DESCRIPTION
Add the ability to search over object collections (List and Set), for example:

### Model DeepList.java:

```java
@Document
public class DeepList {
  @Id
  private String id;

  @Indexed
  @NonNull
  private String name;

  @Indexed
  @NonNull
  private List<NestLevel2> nestLevels;
}
```

### Collection elements:

```java
public class NestLevel2 {
  @NonNull
  @Indexed
  private String name;

  @NonNull
  @Searchable
  private String block;
}
```

### EntityStream searches:

Search over `@Indexed` field:

```java
var results = entityStream.of(DeepList.class) //
    .filter(DeepList$.NEST_LEVELS.NAME.startsWith("nl-2")) //
    .map(DeepList$.NAME) //
    .collect(Collectors.toList());
```

Search over `@Searchable` field:

```java
var results = entityStream.of(DeepList.class) //
    .filter(DeepList$.NEST_LEVELS.BLOCK.eq("have")) //
    .map(DeepList$.NAME) //
    .collect(Collectors.toList());
```
