### PR TITLE
Issue 236 - Fixes "Fail setting TTL from property during save operation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ ext {
 }
 
 dependencies {
-  implementation: "com.redis.om:redis-om-spring:$redisOmVersion"
+  implementation "com.redis.om:redis-om-spring:$redisOmVersion"
   annotationProcessor "com.redis.om:redis-om-spring:$redisOmVersion"
 }
 ```


### PR DESCRIPTION
To lookup an entity class in the (Spring Data Redis) KeyspaceConfiguration, the class object to lookup has to be loaded with the System Class Loader, but then the same class object cannot be used when finding the getter to reflectively invoke the assigned TTL getter method on a given entity. This PR separates the lookup from the reflection parts of this procedure.