### PR TITLE
Bsb/v0.8.3 kotlin and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ public class PeopleService {
   EntityStream entityStream;
 
   // Find all people
-  public Iterable<Person> findAllPeople(int minAge, int maxAge) {
+  public Iterable<Person> findAllPeople() {
     return entityStream //
         .of(Person.class) //
         .collect(Collectors.toList());
@@ -319,14 +319,14 @@ underlying search engine field. For example, in the example we have an `age` pro
 numeric operations we can use with the stream's `filter` method such as `between`.
 
 ```java
-  // Find people by age range
-  public Iterable<Person> findByAgeBetween(int minAge, int maxAge) {
-    return entityStream //
-        .of(Person.class) //
-        .filter(Person$.AGE.between(minAge, maxAge)) //
-        .sorted(Person$.AGE, SortOrder.ASC) //
-        .collect(Collectors.toList());
-  }
+// Find people by age range
+public Iterable<Person> findByAgeBetween(int minAge, int maxAge) {
+  return entityStream //
+      .of(Person.class) //
+      .filter(Person$.AGE.between(minAge, maxAge)) //
+      .sorted(Person$.AGE, SortOrder.ASC) //
+      .collect(Collectors.toList());
+}
 ```
 
 In this example we also make use of the Streams `sorted` method to declare that our stream will be sorted by the `Person$.AGE` in `ASC`ending order.
@@ -360,7 +360,7 @@ inherited from the parent poms):
       <path>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-configuration-processor</artifactId>
-        <version>3.0.4</version>
+        <version>3.0.6</version>
       </path>
       <path>
         <groupId>org.projectlombok</groupId>
@@ -370,7 +370,7 @@ inherited from the parent poms):
       <path>
         <groupId>com.redis.om</groupId>
         <artifactId>redis-om-spring</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.2</version>
       </path>
     </annotationProcessorPaths>
   </configuration>
@@ -416,7 +416,7 @@ repositories {
 ### Dependency
 ```groovy
 ext {
-  redisOmVersion = '0.8.1-SNAPSHOT'
+  redisOmVersion = '0.8.3-SNAPSHOT'
 }
 
 dependencies {

--- a/demos/roms-vss/src/main/resources/application.properties
+++ b/demos/roms-vss/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.mvc.hiddenmethod.filter.enabled=true
 com.redis.om.vss.useLocalImages=false
 com.redis.om.vss.maxLines=300
+redis.om.spring.djl.enabled=true

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisEnhancedKeyValueAdapter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisEnhancedKeyValueAdapter.java
@@ -203,7 +203,7 @@ public class RedisEnhancedKeyValueAdapter extends RedisKeyValueAdapter {
       byte[] keyToDelete = createKey(asStringValue(keyspace), asStringValue(id));
 
       redisOperations.execute((RedisCallback<Void>) connection -> {
-        connection.keyCommands().del(keyToDelete);
+        connection.keyCommands().unlink(keyToDelete);
         return null;
       });
     }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisEnhancedKeyValueAdapter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisEnhancedKeyValueAdapter.java
@@ -30,8 +30,7 @@ import java.lang.reflect.Field;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
-import static com.redis.om.spring.util.ObjectUtils.documentToObject;
-import static com.redis.om.spring.util.ObjectUtils.getIdFieldForEntity;
+import static com.redis.om.spring.util.ObjectUtils.*;
 
 public class RedisEnhancedKeyValueAdapter extends RedisKeyValueAdapter {
 
@@ -234,7 +233,7 @@ public class RedisEnhancedKeyValueAdapter extends RedisKeyValueAdapter {
     List<String> keys = List.of();
     if (maybeSearchIndex.isPresent()) {
       SearchOperations<String> searchOps = modulesOperations.opsForSearch(maybeSearchIndex.get());
-      Optional<Field> maybeIdField = com.redis.om.spring.util.ObjectUtils.getIdFieldForEntityClass(type);
+      Optional<Field> maybeIdField = getIdFieldForEntityClass(type);
       String idField = maybeIdField.map(Field::getName).orElse("id");
 
       Query query = new Query("*");

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisOMSpringProperties.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisOMSpringProperties.java
@@ -40,6 +40,8 @@ public class RedisOMSpringProperties {
     @Data
     public static class Djl {
         private static final String DEFAULT_ENGINE = "PyTorch";
+        @NotNull
+        private boolean enabled = false;
         // image embedding settings
         @NotNull
         private String imageEmbeddingModelEngine = DEFAULT_ENGINE;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/Alias.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/Alias.java
@@ -5,7 +5,7 @@ public class Alias<E, T> extends MetamodelField<E, T> {
     super(alias, String.class, true);
   }
 
-  public static Alias of(String alias) {
+  public static <E, T> Alias<E, T> of(String alias) {
     return new Alias<>(alias);
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
@@ -140,7 +140,8 @@ public final class MetamodelGenerator extends AbstractProcessor {
 
     CodeBlock.Builder blockBuilder = CodeBlock.builder();
 
-    blockBuilder.beginControlFlow("try");
+    boolean hasFields = !fields.isEmpty();
+    if (hasFields) blockBuilder.beginControlFlow("try");
     for (ObjectGraphFieldSpec ogfs : fields) {
       StringBuilder sb = new StringBuilder("$T.class");
       for (int i = 0; i < ogfs.chain().size(); i++) {
@@ -153,16 +154,18 @@ public final class MetamodelGenerator extends AbstractProcessor {
         sb.append(formattedString);
       }
       FieldSpec fieldSpec = ogfs.fieldSpec();
-      blockBuilder.addStatement("$L = " + sb.toString(), fieldSpec.name, entity);
+      blockBuilder.addStatement("$L = " + sb, fieldSpec.name, entity);
     }
 
     for (CodeBlock initCodeBlock : initCodeBlocks) {
       blockBuilder.add(initCodeBlock);
     }
 
-    blockBuilder.nextControlFlow("catch($T | $T e)", NoSuchFieldException.class, SecurityException.class);
-    blockBuilder.addStatement("System.err.println(e.getMessage())");
-    blockBuilder.endControlFlow();
+    if (hasFields) {
+      blockBuilder.nextControlFlow("catch($T | $T e)", NoSuchFieldException.class, SecurityException.class);
+      blockBuilder.addStatement("System.err.println(e.getMessage())");
+      blockBuilder.endControlFlow();
+    }
 
     CodeBlock staticBlock = blockBuilder.build();
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/EndsWithPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/EndsWithPredicate.java
@@ -3,6 +3,7 @@ package com.redis.om.spring.search.stream.predicates.fulltext;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.repository.query.QueryUtils;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 
@@ -21,7 +22,9 @@ public class EndsWithPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return QueryBuilders.intersect(root).add(getSearchAlias(), "*" + QueryUtils.escape(getValue().toString(), true) );
+    return ObjectUtils.isNotEmpty(getValue()) ?
+        QueryBuilders.intersect(root).add(getSearchAlias(), "*" + QueryUtils.escape(getValue().toString(), true)) :
+        root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/EqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/EqualPredicate.java
@@ -3,6 +3,7 @@ package com.redis.om.spring.search.stream.predicates.fulltext;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.repository.query.QueryUtils;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 
@@ -20,7 +21,7 @@ public class EqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return QueryBuilders.intersect(root).add(getSearchAlias(), QueryUtils.escape(getValue().toString(), true));
+    return ObjectUtils.isNotEmpty(getValue()) ? QueryBuilders.intersect(root).add(getSearchAlias(), QueryUtils.escape(getValue().toString(), true)) : root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/InPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/InPredicate.java
@@ -3,6 +3,7 @@ package com.redis.om.spring.search.stream.predicates.fulltext;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.repository.query.QueryUtils;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 
@@ -24,12 +25,14 @@ public class InPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    StringJoiner sj = new StringJoiner(" | ");
-    for (Object value : getValues()) {
-      sj.add(QueryUtils.escape(value.toString(), true));
-    }
+    if (ObjectUtils.isNotEmpty(getValues())) {
+      StringJoiner sj = new StringJoiner(" | ");
+      for (Object value : getValues()) {
+        sj.add(QueryUtils.escape(value.toString(), true));
+      }
 
-    return QueryBuilders.intersect(root).add(getSearchAlias(), sj.toString());
+      return QueryBuilders.intersect(root).add(getSearchAlias(), sj.toString());
+    } else return root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/LikePredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/LikePredicate.java
@@ -3,6 +3,7 @@ package com.redis.om.spring.search.stream.predicates.fulltext;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.repository.query.QueryUtils;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 
@@ -21,7 +22,7 @@ public class LikePredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return QueryBuilders.intersect(root).add(getSearchAlias(), "%%%" + QueryUtils.escape(getValue().toString(), true) + "%%%");
+    return ObjectUtils.isNotEmpty(getValue()) ? QueryBuilders.intersect(root).add(getSearchAlias(), "%%%" + QueryUtils.escape(getValue().toString(), true) + "%%%") : root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/NotEqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/NotEqualPredicate.java
@@ -3,6 +3,7 @@ package com.redis.om.spring.search.stream.predicates.fulltext;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.repository.query.QueryUtils;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 import redis.clients.jedis.search.querybuilder.Values;
@@ -21,8 +22,8 @@ public class NotEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return QueryBuilders.intersect(root).add(QueryBuilders.disjunct(getSearchAlias(), Values.value(
-        QueryUtils.escape(getValue().toString(), true))));
+    return ObjectUtils.isNotEmpty(getValue()) ? QueryBuilders.intersect(root).add(QueryBuilders.disjunct(getSearchAlias(), Values.value(
+        QueryUtils.escape(getValue().toString(), true)))) : root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/NotLikePredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/NotLikePredicate.java
@@ -3,6 +3,7 @@ package com.redis.om.spring.search.stream.predicates.fulltext;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.repository.query.QueryUtils;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 import redis.clients.jedis.search.querybuilder.Values;
@@ -22,8 +23,8 @@ public class NotLikePredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return QueryBuilders.intersect(root)
-        .add(QueryBuilders.disjunct(getSearchAlias(), Values.value("%%%" + QueryUtils.escape(getValue().toString(), true) + "%%%")));
+    return ObjectUtils.isNotEmpty(getValue()) ? QueryBuilders.intersect(root)
+        .add(QueryBuilders.disjunct(getSearchAlias(), Values.value("%%%" + QueryUtils.escape(getValue().toString(), true) + "%%%"))) : root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/StartsWithPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/StartsWithPredicate.java
@@ -3,6 +3,7 @@ package com.redis.om.spring.search.stream.predicates.fulltext;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.repository.query.QueryUtils;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 
@@ -21,7 +22,7 @@ public class StartsWithPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return QueryBuilders.intersect(root).add(getSearchAlias(), QueryUtils.escape(getValue().toString(), true) + "*");
+    return ObjectUtils.isNotEmpty(getValue()) ? QueryBuilders.intersect(root).add(getSearchAlias(), QueryUtils.escape(getValue().toString(), true) + "*") : root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/geo/EqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/geo/EqualPredicate.java
@@ -2,6 +2,7 @@ package com.redis.om.spring.search.stream.predicates.geo;
 
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.data.geo.Point;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
@@ -40,7 +41,8 @@ public class EqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return QueryBuilders.intersect(root).add(getSearchAlias(), String.format("[%s %s 0.0001 mi]", x, y));
+    boolean paramsPresent = ObjectUtils.isNotEmpty(x) && ObjectUtils.isNotEmpty(y);
+    return paramsPresent ? QueryBuilders.intersect(root).add(getSearchAlias(), String.format("[%s %s 0.0001 mi]", x, y)) : root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/geo/NearPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/geo/NearPredicate.java
@@ -8,6 +8,7 @@ import org.springframework.data.geo.Point;
 import redis.clients.jedis.search.querybuilder.GeoValue;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
 
 public class NearPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
@@ -30,10 +31,11 @@ public class NearPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    GeoValue geoValue = new GeoValue(getPoint().getX(), getPoint().getY(), getDistance().getValue(),
-        ObjectUtils.getDistanceUnit(getDistance()));
-
-    return QueryBuilders.intersect(root).add(getSearchAlias(), geoValue);
+    boolean paramsPresent = isNotEmpty(point) && isNotEmpty(distance);
+    if (paramsPresent) {
+      GeoValue geoValue = new GeoValue(getPoint().getX(), getPoint().getY(), getDistance().getValue(), ObjectUtils.getDistanceUnit(getDistance()));
+      return QueryBuilders.intersect(root).add(getSearchAlias(), geoValue);
+    } else return root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/geo/NotEqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/geo/NotEqualPredicate.java
@@ -2,6 +2,7 @@ package com.redis.om.spring.search.stream.predicates.geo;
 
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+import org.apache.commons.lang3.ObjectUtils;
 import org.springframework.data.geo.Point;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
@@ -41,8 +42,9 @@ public class NotEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return QueryBuilders.intersect(root)
-        .add(QueryBuilders.disjunct(getSearchAlias(), Values.value(String.format("[%s %s 0.0001 mi]", x, y))));
+    boolean paramsPresent = ObjectUtils.isNotEmpty(x) && ObjectUtils.isNotEmpty(y);
+    return paramsPresent ? QueryBuilders.intersect(root)
+        .add(QueryBuilders.disjunct(getSearchAlias(), Values.value(String.format("[%s %s 0.0001 mi]", x, y)))) : root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/geo/OutsideOfPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/geo/OutsideOfPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.GeoValue;
 import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
 public class OutsideOfPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final Point point;
@@ -30,11 +32,12 @@ public class OutsideOfPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    GeoValue geoValue = new GeoValue(getPoint().getX(), getPoint().getY(), getDistance().getValue(),
-        ObjectUtils.getDistanceUnit(getDistance()));
+    boolean paramsPresent = isNotEmpty(point) && isNotEmpty(distance);
+    if (paramsPresent) {
+      GeoValue geoValue = new GeoValue(getPoint().getX(), getPoint().getY(), getDistance().getValue(), ObjectUtils.getDistanceUnit(getDistance()));
 
-    return QueryBuilders.intersect(root)
-        .add(QueryBuilders.disjunct(getSearchAlias(), geoValue));
+      return QueryBuilders.intersect(root).add(QueryBuilders.disjunct(getSearchAlias(), geoValue));
+    } else return root;
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/BetweenPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/BetweenPredicate.java
@@ -12,6 +12,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 
+import static org.apache.commons.lang3.ObjectUtils.isNotEmpty;
+
 public class BetweenPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final T min;
@@ -33,6 +35,8 @@ public class BetweenPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    boolean paramsPresent = isNotEmpty(getMin()) && isNotEmpty(getMax());
+    if (!paramsPresent) return root;
     Class<?> cls = min.getClass();
     if (cls == LocalDate.class) {
       LocalDate minLocalDate = (LocalDate) min;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/EqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/EqualPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.Values;
 import java.time.*;
 import java.util.Date;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class EqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
   private final T value;
 
@@ -23,6 +25,7 @@ public class EqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     Class<?> cls = getValue().getClass();
     if (cls == LocalDate.class) {
       LocalDate localDate = (LocalDate) getValue();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/GreaterThanOrEqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/GreaterThanOrEqualPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.Values;
 import java.time.*;
 import java.util.Date;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class GreaterThanOrEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final T value;
@@ -24,6 +26,7 @@ public class GreaterThanOrEqualPredicate<E, T> extends BaseAbstractPredicate<E, 
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     Class<?> cls = value.getClass();
     if (cls == LocalDate.class) {
       LocalDate localDate = (LocalDate) getValue();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/GreaterThanPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/GreaterThanPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.Values;
 import java.time.*;
 import java.util.Date;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class GreaterThanPredicate<E, T> extends BaseAbstractPredicate<E, T> {
   private final T value;
 
@@ -23,6 +25,7 @@ public class GreaterThanPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     Class<?> cls = value.getClass();
     if (cls == LocalDate.class) {
       LocalDate localDate = (LocalDate) getValue();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/InPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/InPredicate.java
@@ -11,6 +11,8 @@ import java.time.*;
 import java.util.Date;
 import java.util.List;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class InPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final List<T> values;
@@ -26,6 +28,7 @@ public class InPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValues())) return root;
     QueryNode or = QueryBuilders.union();
 
     Class<?> cls = values.get(0).getClass();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/LessThanOrEqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/LessThanOrEqualPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.Values;
 import java.time.*;
 import java.util.Date;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class LessThanOrEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final T value;
@@ -24,6 +26,7 @@ public class LessThanOrEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> 
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     Class<?> cls = value.getClass();
     if (cls == LocalDate.class) {
       LocalDate localDate = (LocalDate) getValue();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/LessThanPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/LessThanPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.Values;
 import java.time.*;
 import java.util.Date;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class LessThanPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final T value;
@@ -24,6 +26,7 @@ public class LessThanPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     Class<?> cls = value.getClass();
     if (cls == LocalDate.class) {
       LocalDate localDate = (LocalDate) getValue();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/NotEqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/NotEqualPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.Values;
 import java.time.*;
 import java.util.Date;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class NotEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
   private final T value;
 
@@ -23,6 +25,7 @@ public class NotEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     Class<?> cls = value.getClass();
     if (cls == LocalDate.class) {
       LocalDate localDate = (LocalDate) getValue();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/ContainsAllPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/ContainsAllPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.QueryNode;
 
 import java.util.List;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class ContainsAllPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final List<String> values;
@@ -24,6 +26,7 @@ public class ContainsAllPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValues())) return root;
     QueryNode and = QueryBuilders.intersect();
     for (String value : getValues()) {
       and.add(getSearchAlias(), "{" + value + "}");

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/EndsWithPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/EndsWithPredicate.java
@@ -7,6 +7,8 @@ import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 import redis.clients.jedis.search.querybuilder.QueryNode;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class EndsWithPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final T value;
@@ -22,6 +24,7 @@ public class EndsWithPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     if (Iterable.class.isAssignableFrom(getValue().getClass())) {
       Iterable<?> values = (Iterable<?>) getValue();
       QueryNode and = QueryBuilders.intersect();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/EqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/EqualPredicate.java
@@ -7,6 +7,8 @@ import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 import redis.clients.jedis.search.querybuilder.QueryNode;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class EqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
   private final T value;
 
@@ -21,6 +23,7 @@ public class EqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     if (Iterable.class.isAssignableFrom(getValue().getClass())) {
       Iterable<?> values = (Iterable<?>) getValue();
       QueryNode and = QueryBuilders.intersect();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/InPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/InPredicate.java
@@ -9,6 +9,8 @@ import redis.clients.jedis.search.querybuilder.QueryBuilders;
 import java.util.List;
 import java.util.StringJoiner;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class InPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final List<String> values;
@@ -24,6 +26,7 @@ public class InPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValues())) return root;
     StringJoiner sj = new StringJoiner(" | ");
     for (Object value : getValues()) {
       sj.add(value.toString());

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/NotEqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/NotEqualPredicate.java
@@ -11,6 +11,8 @@ import redis.clients.jedis.search.querybuilder.Values;
 import java.util.List;
 import java.util.stream.StreamSupport;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class NotEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
   private T value;
   private Iterable<?> values;
@@ -31,6 +33,7 @@ public class NotEqualPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValues())) return root;
     QueryNode and = QueryBuilders.intersect();
 
     StreamSupport.stream(getValues().spliterator(), false) //

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/StartsWithPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/tag/StartsWithPredicate.java
@@ -7,6 +7,8 @@ import redis.clients.jedis.search.querybuilder.Node;
 import redis.clients.jedis.search.querybuilder.QueryBuilders;
 import redis.clients.jedis.search.querybuilder.QueryNode;
 
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
 public class StartsWithPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   private final T value;
@@ -22,6 +24,7 @@ public class StartsWithPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
+    if (isEmpty(getValue())) return root;
     if (Iterable.class.isAssignableFrom(getValue().getClass())) {
       Iterable<?> values = (Iterable<?>) getValue();
       QueryNode and = QueryBuilders.intersect();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
@@ -92,19 +92,15 @@ public class ObjectUtils {
     return getDeclaredFieldsTransitively(cl).stream().filter(f -> f.isAnnotationPresent(Id.class)).findFirst();
   }
 
-  public static Optional<?> getIdFieldForEntity(Object entity) {
+  public static Object getIdFieldForEntity(Object entity) {
     Optional<Field> maybeIdField = getIdFieldForEntityClass(entity.getClass());
-    if (maybeIdField.isPresent()) {
-      Field idField = maybeIdField.get();
+    if (maybeIdField.isEmpty()) return null;
 
-      String getterName = "get" + ObjectUtils.ucfirst(idField.getName());
-      Method getter = ReflectionUtils.findMethod(entity.getClass(), getterName);
-      Object id = ReflectionUtils.invokeMethod(getter, entity);
+    Field idField = maybeIdField.get();
 
-      return Optional.of(id);
-    } else {
-      return Optional.empty();
-    }
+    String getterName = "get" + ObjectUtils.ucfirst(idField.getName());
+    Method getter = ReflectionUtils.findMethod(entity.getClass(), getterName);
+    return getter != null ? ReflectionUtils.invokeMethod(getter, entity) : null;
   }
 
   public static Object getIdFieldForEntity(Field idField, Object entity) {

--- a/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseDocumentTest.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
@@ -13,6 +14,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
     classes = AbstractBaseDocumentTest.Config.class, //
     properties = { "spring.main.allow-bean-definition-overriding=true" } //
 )
+@TestPropertySource(properties = {"spring.config.location=classpath:vss_on.yaml"})
 public abstract class AbstractBaseDocumentTest extends AbstractBaseOMTest {
   @SpringBootApplication
   @Configuration

--- a/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseEnhancedRedisTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/AbstractBaseEnhancedRedisTest.java
@@ -4,11 +4,13 @@ import com.redis.om.spring.annotations.EnableRedisEnhancedRepositories;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
 
 @SpringBootTest( //
     classes = AbstractBaseEnhancedRedisTest.Config.class, //
     properties = { "spring.main.allow-bean-definition-overriding=true" } //
 )
+@TestPropertySource(properties = {"spring.config.location=classpath:vss_on.yaml"})
 public abstract class AbstractBaseEnhancedRedisTest extends AbstractBaseOMTest {
   @SpringBootApplication
   @Configuration

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/HashRepositoriesAutoDiscoveryTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/HashRepositoriesAutoDiscoveryTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.Optional;
 
@@ -17,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
     classes = HashRepositoriesAutoDiscoveryTest.Config.class, //
     properties = { "spring.main.allow-bean-definition-overriding=true" } //
 )
+@TestPropertySource(properties = {"spring.config.location=classpath:vss_on.yaml"})
 class HashRepositoriesAutoDiscoveryTest extends AbstractBaseOMTest {
   @SpringBootApplication
   @Configuration

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/HashRepositoryBasePackageClassesTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/HashRepositoryBasePackageClassesTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.geo.Point;
+import org.springframework.test.context.TestPropertySource;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
     classes = HashRepositoryBasePackageClassesTest.Config.class, //
     properties = { "spring.main.allow-bean-definition-overriding=true" } //
 )
+@TestPropertySource(properties = {"spring.config.location=classpath:vss_on.yaml"})
 class HashRepositoryBasePackageClassesTest extends AbstractBaseOMTest {
   @SpringBootApplication
   @Configuration

--- a/redis-om-spring/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
@@ -300,6 +300,38 @@ class MetamodelGeneratorTest {
     );
   }
 
+  @Test
+  @Classpath("data.metamodel.IdOnly")
+  void testValidIdOnlyDocument(Results results) throws IOException {List<String> warnings = getWarningStrings(results);
+    assertThat(warnings).isEmpty();
+
+    List<String> errors = getErrorStrings(results);
+    assertThat(errors).isEmpty();
+
+    assertThat(results.generated).hasSize(1);
+    JavaFileObject metamodel = results.generated.get(0);
+    assertThat(metamodel.getName()).isEqualTo("/SOURCE_OUTPUT/valid/IdOnly$.java");
+
+    var fileContents = metamodel.getCharContent(true);
+
+    var expected = """
+    package valid;
+    
+    import com.redis.om.spring.metamodel.MetamodelField;
+    import java.lang.String;
+
+    public final class IdOnly$ {
+      public static MetamodelField<IdOnly, String> _KEY;
+
+      static {
+        _KEY = new MetamodelField<IdOnly, String>("__key", String.class, true);
+      }
+    }
+    """;
+
+    assertThat(fileContents).containsIgnoringWhitespaces(expected);
+  }
+
   private List<String> getWarningStrings(Results results) {
     return results.find().warnings().list().stream().map(w -> w.getMessage(Locale.US)).collect(Collectors.toList());
   }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
@@ -2378,4 +2378,16 @@ import static org.junit.jupiter.api.Assertions.*;
     List<String> names = companies.stream().map(Company::getName).toList();
     assertTrue(names.contains("Tesla"));
   }
+
+  @Test void testIgnorePredicatesWithNullParamsAnded() {
+    SearchStream<Company> stream = entityStream.of(Company.class);
+
+    List<Company> companies = stream //
+        .filter(Company$.NAME.eq("RedisInc")) //
+        .filter(Company$.YEAR_FOUNDED.eq(null)) //
+        .collect(Collectors.toList());
+
+    List<String> names = companies.stream().map(Company::getName).collect(Collectors.toList());
+    assertThat(names).contains("RedisInc");
+  }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamHashTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamHashTest.java
@@ -1508,4 +1508,16 @@ import static org.junit.jupiter.api.Assertions.*;
     List<String> names = companies.stream().map(Company::getName).toList();
     assertTrue(names.contains("Tesla"));
   }
+
+  @Test void testIgnorePredicatesWithNullParamsAnded() {
+    SearchStream<Company> stream = entityStream.of(Company.class);
+
+    List<Company> companies = stream //
+        .filter(Company$.NAME.eq("RedisInc")) //
+        .filter(Company$.YEAR_FOUNDED.eq(null)) //
+        .collect(Collectors.toList());
+
+    List<String> names = companies.stream().map(Company::getName).collect(Collectors.toList());
+    assertThat(names).contains("RedisInc");
+  }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/util/ObjectUtilsTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/util/ObjectUtilsTest.java
@@ -168,21 +168,21 @@ import static org.junit.jupiter.api.Assertions.assertAll;
         Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690), "stack@redis.com"));
     String actualCompanyId = redis.getId();
 
-    Optional<?> maybeId = ObjectUtils.getIdFieldForEntity(redis);
+    Object id = ObjectUtils.getIdFieldForEntity(redis);
 
-    assertThat(maybeId).isPresent();
-    assertThat(maybeId.get()).hasToString(actualCompanyId);
+    assertThat(id).isNotNull();
+    assertThat(id).hasToString(actualCompanyId);
 
     DocWithCustomNameId doc = docWithCustomNameIdRepository.save(new DocWithCustomNameId());
     String actualDocId = doc.getIdentidad();
 
-    Optional<?> maybeDocId = ObjectUtils.getIdFieldForEntity(doc);
+    Object docId = ObjectUtils.getIdFieldForEntity(doc);
 
-    assertThat(maybeDocId).isPresent();
-    assertThat(maybeDocId.get()).hasToString(actualDocId);
+    assertThat(docId).isNotNull();
+    assertThat(docId).hasToString(actualDocId);
 
-    Optional<?> noEntityId = ObjectUtils.getIdFieldForEntity("");
-    assertThat(noEntityId).isEmpty();
+    Object noEntityId = ObjectUtils.getIdFieldForEntity("");
+    assertThat(noEntityId).isNull();
   }
 
   @Test

--- a/redis-om-spring/src/test/resources/data/metamodel/IdOnly.java
+++ b/redis-om-spring/src/test/resources/data/metamodel/IdOnly.java
@@ -1,0 +1,14 @@
+package valid;
+
+import com.redis.om.spring.annotations.Document;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Document
+public class IdOnly {
+}
+

--- a/redis-om-spring/src/test/resources/vss_on.yaml
+++ b/redis-om-spring/src/test/resources/vss_on.yaml
@@ -1,0 +1,5 @@
+redis:
+  om:
+    spring:
+      djl:
+        enabled: true


### PR DESCRIPTION
**Fixes:**
- fix: correct metamodel generation when only id present 

**Features:**
- feature: use UNLINK instead of DEL for single Hash Entity deletion
- feature: make DJL/VSS optional by setting redis.om.spring.djl.enabled…

**Refactor/Cleanup:**
- refactor: add generics to Alias#of
- refactor: add generics and null checks to ObjectUtils#getIdFieldForEn…
- refactor: reduce complexity of RediSearchIndexer#createIndexFor method
- refactor: add null checking for predicate params
- refactor: add djl enabled flag to vss demo