### PR TITLE
Make FeatureExtractor injectable

### DIFF
--- a/demos/roms-vss/src/main/resources/application.properties
+++ b/demos/roms-vss/src/main/resources/application.properties
@@ -2,5 +2,3 @@ spring.mvc.hiddenmethod.filter.enabled=true
 com.redis.om.vss.useLocalImages=false
 com.redis.om.vss.maxLines=300
 redis.om.spring.djl.enabled=true
-server.port=8082
-spring.data.redis.url=redis://172.18.36.1/

--- a/demos/roms-vss/src/main/resources/application.properties
+++ b/demos/roms-vss/src/main/resources/application.properties
@@ -2,3 +2,5 @@ spring.mvc.hiddenmethod.filter.enabled=true
 com.redis.om.vss.useLocalImages=false
 com.redis.om.vss.maxLines=300
 redis.om.spring.djl.enabled=true
+server.port=8082
+spring.data.redis.url=redis://172.18.36.1/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring-parent</artifactId>
-  <version>0.8.3</version>
+  <version>0.8.4-SNAPSHOT</version>
   <name>redis-om-spring-parent</name>
   <packaging>pom</packaging>
 

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring</artifactId>
-  <version>0.8.3</version>
+  <version>0.8.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>redis-om-spring</name>
@@ -304,7 +304,7 @@
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.80</minimum>
+                      <minimum>0.40</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -304,7 +304,7 @@
                     <limit>
                       <counter>LINE</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.40</minimum>
+                      <minimum>0.80</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -26,6 +26,7 @@ import com.redis.om.spring.ops.pds.BloomOperations;
 import com.redis.om.spring.search.stream.EntityStream;
 import com.redis.om.spring.search.stream.EntityStreamImpl;
 import com.redis.om.spring.serialization.gson.*;
+import com.redis.om.spring.vectorize.DefaultFeatureExtractor;
 import com.redis.om.spring.vectorize.FeatureExtractor;
 import com.redis.om.spring.vectorize.face.FaceDetectionTranslator;
 import com.redis.om.spring.vectorize.face.FaceFeatureTranslator;
@@ -264,7 +265,7 @@ public class RedisModulesConfiguration {
       @Nullable @Qualifier("redisTemplate") RedisTemplate<?, ?> redisTemplate,
       RedisOMSpringProperties properties,
       ApplicationContext ac) {
-    return properties.getDjl().isEnabled() ? new FeatureExtractor(redisTemplate, ac, imageEmbeddingModel, faceEmbeddingModel, imageFactory, defaultImagePipeline, sentenceTokenizer) : null;
+    return properties.getDjl().isEnabled() ? new DefaultFeatureExtractor(redisTemplate, ac, imageEmbeddingModel, faceEmbeddingModel, imageFactory, defaultImagePipeline, sentenceTokenizer) : null;
   }
 
   @Bean(name = "redisJSONKeyValueAdapter")

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -262,10 +262,9 @@ public class RedisModulesConfiguration {
       @Nullable @Qualifier("djlImageFactory") ImageFactory imageFactory,
       @Nullable @Qualifier("djlDefaultImagePipeline") Pipeline defaultImagePipeline,
       @Nullable @Qualifier("djlSentenceTokenizer") HuggingFaceTokenizer sentenceTokenizer,
-      @Nullable @Qualifier("redisTemplate") RedisTemplate<?, ?> redisTemplate,
       RedisOMSpringProperties properties,
       ApplicationContext ac) {
-    return properties.getDjl().isEnabled() ? new DefaultFeatureExtractor(redisTemplate, ac, imageEmbeddingModel, faceEmbeddingModel, imageFactory, defaultImagePipeline, sentenceTokenizer) : null;
+    return properties.getDjl().isEnabled() ? new DefaultFeatureExtractor( ac, imageEmbeddingModel, faceEmbeddingModel, imageFactory, defaultImagePipeline, sentenceTokenizer) : null;
   }
 
   @Bean(name = "redisJSONKeyValueAdapter")

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultFeatureExtractor.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultFeatureExtractor.java
@@ -25,114 +25,111 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.List;
 
-@Component
 public class DefaultFeatureExtractor implements FeatureExtractor {
-  private final RedisOperations<?, ?> redisOperations;
-  private final ZooModel<Image, byte[]> imageEmbeddingModel;
-  private final ZooModel<Image, float[]> faceEmbeddingModel;
-  private final ImageFactory imageFactory;
-  private final ApplicationContext applicationContext;
-  private ImageFeatureExtractor imageFeatureExtractor;
-  public final Pipeline imagePipeline;
-  public final HuggingFaceTokenizer sentenceTokenizer;
+    private final ZooModel<Image, byte[]> imageEmbeddingModel;
+    private final ZooModel<Image, float[]> faceEmbeddingModel;
+    private final ImageFactory imageFactory;
+    private final ApplicationContext applicationContext;
+    private ImageFeatureExtractor imageFeatureExtractor;
+    public final Pipeline imagePipeline;
+    public final HuggingFaceTokenizer sentenceTokenizer;
 
-  private static final Log logger = LogFactory.getLog(DefaultFeatureExtractor.class);
+    private static final Log logger = LogFactory.getLog(DefaultFeatureExtractor.class);
 
-  public DefaultFeatureExtractor( //
-                                  RedisOperations<?, ?> redisOperations, //
-                                  ApplicationContext applicationContext, //
-                                  ZooModel<Image, byte[]> imageEmbeddingModel, //
-                                  ZooModel<Image, float[]> faceEmbeddingModel, //
-                                  ImageFactory imageFactory, //
-                                  Pipeline imagePipeline,
-                                  HuggingFaceTokenizer sentenceTokenizer
-      ) {
-    this.redisOperations = redisOperations;
-    this.applicationContext = applicationContext;
-    this.imageEmbeddingModel = imageEmbeddingModel;
-    this.faceEmbeddingModel = faceEmbeddingModel;
-    this.imageFactory = imageFactory;
-    this.imagePipeline = imagePipeline;
-    this.sentenceTokenizer = sentenceTokenizer;
+    public DefaultFeatureExtractor( //
+                                    ApplicationContext applicationContext, //
+                                    ZooModel<Image, byte[]> imageEmbeddingModel, //
+                                    ZooModel<Image, float[]> faceEmbeddingModel, //
+                                    ImageFactory imageFactory, //
+                                    Pipeline imagePipeline,
+                                    HuggingFaceTokenizer sentenceTokenizer
+    ) {
+        this.applicationContext = applicationContext;
+        this.imageEmbeddingModel = imageEmbeddingModel;
+        this.faceEmbeddingModel = faceEmbeddingModel;
+        this.imageFactory = imageFactory;
+        this.imagePipeline = imagePipeline;
+        this.sentenceTokenizer = sentenceTokenizer;
 
-    // feature extractor
-    this.imageFeatureExtractor = ImageFeatureExtractor.builder().setPipeline(imagePipeline).build();
-  }
-
-  @Override
-  public void processEntity(byte[] redisKey, Object item) {
-    processEntity(item);
-  }
-
-  @Override
-  public byte[] getImageEmbeddingsFor(InputStream is) {
-    try {
-      var img = imageFactory.fromInputStream(is);
-      Predictor<Image, byte[]> predictor = imageEmbeddingModel.newPredictor(imageFeatureExtractor);
-      return predictor.predict(img);
-    } catch (IOException | TranslateException e) {
-      logger.warn("Error generating image embedding", e);
-      return new byte[]{};
+        // feature extractor
+        this.imageFeatureExtractor = ImageFeatureExtractor.builder().setPipeline(imagePipeline).build();
     }
-  }
 
-  @Override
-  public byte[] getFacialImageEmbeddingsFor(InputStream is) throws IOException, TranslateException {
-    try (Predictor<Image, float[]> predictor = faceEmbeddingModel.newPredictor()) {
-      var img = imageFactory.fromInputStream(is);
-      return ObjectUtils.floatArrayToByteArray(predictor.predict(img));
+    @Override
+    public void processEntity(byte[] redisKey, Object item) {
+        processEntity(item);
     }
-  }
 
-  @Override
-  public byte[] getSentenceEmbeddingsFor(String text) {
-    Encoding encoding = sentenceTokenizer.encode(text);
-    return ObjectUtils.longArrayToByteArray(encoding.getIds());
-  }
-
-  @Override
-  public void processEntity(Object item) {
-    if (!isReady()) {
-      return;
-    }
-    List<Field> fields = ObjectUtils.getFieldsWithAnnotation(item.getClass(), Vectorize.class);
-    if (!fields.isEmpty()) {
-      PropertyAccessor accessor = PropertyAccessorFactory.forBeanPropertyAccess(item);
-      fields.forEach(f -> {
-        Vectorize vectorize = f.getAnnotation(Vectorize.class);
-        Object fieldValue = accessor.getPropertyValue(f.getName());
-        if (fieldValue != null) {
-          switch (vectorize.embeddingType()) {
-            case IMAGE -> {
-              Resource resource = applicationContext.getResource(fieldValue.toString());
-              try {
-                byte[] feature = getImageEmbeddingsFor(resource.getInputStream());
-                accessor.setPropertyValue(vectorize.destination(), feature);
-              } catch (IOException e) {
-                logger.warn("Error generating image embedding", e);
-              }
-            }
-            case WORD -> {
-              //TODO: implement me!
-            }
-            case FACE -> {
-              Resource resource = applicationContext.getResource(fieldValue.toString());
-              try {
-                byte[] feature = getFacialImageEmbeddingsFor(resource.getInputStream());
-                accessor.setPropertyValue(vectorize.destination(), feature);
-              } catch (IOException | TranslateException e) {
-                logger.warn("Error generating facial image embedding", e);
-              }
-            }
-            case SENTENCE -> accessor.setPropertyValue(vectorize.destination(), getSentenceEmbeddingsFor(fieldValue.toString()));
-          }
+    @Override
+    public byte[] getImageEmbeddingsFor(InputStream is) {
+        try {
+            var img = imageFactory.fromInputStream(is);
+            Predictor<Image, byte[]> predictor = imageEmbeddingModel.newPredictor(imageFeatureExtractor);
+            return predictor.predict(img);
+        } catch (IOException | TranslateException e) {
+            logger.warn("Error generating image embedding", e);
+            return new byte[]{};
         }
-      });
     }
-  }
 
-  @Override
-  public boolean isReady() {
-    return this.faceEmbeddingModel != null && this.sentenceTokenizer != null;
-  }
+    @Override
+    public byte[] getFacialImageEmbeddingsFor(InputStream is) throws IOException, TranslateException {
+        try (Predictor<Image, float[]> predictor = faceEmbeddingModel.newPredictor()) {
+            var img = imageFactory.fromInputStream(is);
+            return ObjectUtils.floatArrayToByteArray(predictor.predict(img));
+        }
+    }
+
+    @Override
+    public byte[] getSentenceEmbeddingsFor(String text) {
+        Encoding encoding = sentenceTokenizer.encode(text);
+        return ObjectUtils.longArrayToByteArray(encoding.getIds());
+    }
+
+    @Override
+    public void processEntity(Object item) {
+        if (!isReady()) {
+            return;
+        }
+        List<Field> fields = ObjectUtils.getFieldsWithAnnotation(item.getClass(), Vectorize.class);
+        if (!fields.isEmpty()) {
+            PropertyAccessor accessor = PropertyAccessorFactory.forBeanPropertyAccess(item);
+            fields.forEach(f -> {
+                Vectorize vectorize = f.getAnnotation(Vectorize.class);
+                Object fieldValue = accessor.getPropertyValue(f.getName());
+                if (fieldValue != null) {
+                    switch (vectorize.embeddingType()) {
+                        case IMAGE -> {
+                            Resource resource = applicationContext.getResource(fieldValue.toString());
+                            try {
+                                byte[] feature = getImageEmbeddingsFor(resource.getInputStream());
+                                accessor.setPropertyValue(vectorize.destination(), feature);
+                            } catch (IOException e) {
+                                logger.warn("Error generating image embedding", e);
+                            }
+                        }
+                        case WORD -> {
+                            //TODO: implement me!
+                        }
+                        case FACE -> {
+                            Resource resource = applicationContext.getResource(fieldValue.toString());
+                            try {
+                                byte[] feature = getFacialImageEmbeddingsFor(resource.getInputStream());
+                                accessor.setPropertyValue(vectorize.destination(), feature);
+                            } catch (IOException | TranslateException e) {
+                                logger.warn("Error generating facial image embedding", e);
+                            }
+                        }
+                        case SENTENCE ->
+                                accessor.setPropertyValue(vectorize.destination(), getSentenceEmbeddingsFor(fieldValue.toString()));
+                    }
+                }
+            });
+        }
+    }
+
+    @Override
+    public boolean isReady() {
+        return this.faceEmbeddingModel != null && this.sentenceTokenizer != null;
+    }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultFeatureExtractor.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultFeatureExtractor.java
@@ -1,0 +1,138 @@
+package com.redis.om.spring.vectorize;
+
+import ai.djl.huggingface.tokenizers.Encoding;
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import ai.djl.inference.Predictor;
+import ai.djl.modality.cv.Image;
+import ai.djl.modality.cv.ImageFactory;
+import ai.djl.modality.cv.translator.ImageFeatureExtractor;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.translate.Pipeline;
+import ai.djl.translate.TranslateException;
+import com.redis.om.spring.annotations.Vectorize;
+import com.redis.om.spring.util.ObjectUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.PropertyAccessor;
+import org.springframework.beans.PropertyAccessorFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.Resource;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.List;
+
+@Component
+public class DefaultFeatureExtractor implements FeatureExtractor {
+  private final RedisOperations<?, ?> redisOperations;
+  private final ZooModel<Image, byte[]> imageEmbeddingModel;
+  private final ZooModel<Image, float[]> faceEmbeddingModel;
+  private final ImageFactory imageFactory;
+  private final ApplicationContext applicationContext;
+  private ImageFeatureExtractor imageFeatureExtractor;
+  public final Pipeline imagePipeline;
+  public final HuggingFaceTokenizer sentenceTokenizer;
+
+  private static final Log logger = LogFactory.getLog(DefaultFeatureExtractor.class);
+
+  public DefaultFeatureExtractor( //
+                                  RedisOperations<?, ?> redisOperations, //
+                                  ApplicationContext applicationContext, //
+                                  ZooModel<Image, byte[]> imageEmbeddingModel, //
+                                  ZooModel<Image, float[]> faceEmbeddingModel, //
+                                  ImageFactory imageFactory, //
+                                  Pipeline imagePipeline,
+                                  HuggingFaceTokenizer sentenceTokenizer
+      ) {
+    this.redisOperations = redisOperations;
+    this.applicationContext = applicationContext;
+    this.imageEmbeddingModel = imageEmbeddingModel;
+    this.faceEmbeddingModel = faceEmbeddingModel;
+    this.imageFactory = imageFactory;
+    this.imagePipeline = imagePipeline;
+    this.sentenceTokenizer = sentenceTokenizer;
+
+    // feature extractor
+    this.imageFeatureExtractor = ImageFeatureExtractor.builder().setPipeline(imagePipeline).build();
+  }
+
+  @Override
+  public void processEntity(byte[] redisKey, Object item) {
+    processEntity(item);
+  }
+
+  @Override
+  public byte[] getImageEmbeddingsFor(InputStream is) {
+    try {
+      var img = imageFactory.fromInputStream(is);
+      Predictor<Image, byte[]> predictor = imageEmbeddingModel.newPredictor(imageFeatureExtractor);
+      return predictor.predict(img);
+    } catch (IOException | TranslateException e) {
+      logger.warn("Error generating image embedding", e);
+      return new byte[]{};
+    }
+  }
+
+  @Override
+  public byte[] getFacialImageEmbeddingsFor(InputStream is) throws IOException, TranslateException {
+    try (Predictor<Image, float[]> predictor = faceEmbeddingModel.newPredictor()) {
+      var img = imageFactory.fromInputStream(is);
+      return ObjectUtils.floatArrayToByteArray(predictor.predict(img));
+    }
+  }
+
+  @Override
+  public byte[] getSentenceEmbeddingsFor(String text) {
+    Encoding encoding = sentenceTokenizer.encode(text);
+    return ObjectUtils.longArrayToByteArray(encoding.getIds());
+  }
+
+  @Override
+  public void processEntity(Object item) {
+    if (!isReady()) {
+      return;
+    }
+    List<Field> fields = ObjectUtils.getFieldsWithAnnotation(item.getClass(), Vectorize.class);
+    if (!fields.isEmpty()) {
+      PropertyAccessor accessor = PropertyAccessorFactory.forBeanPropertyAccess(item);
+      fields.forEach(f -> {
+        Vectorize vectorize = f.getAnnotation(Vectorize.class);
+        Object fieldValue = accessor.getPropertyValue(f.getName());
+        if (fieldValue != null) {
+          switch (vectorize.embeddingType()) {
+            case IMAGE -> {
+              Resource resource = applicationContext.getResource(fieldValue.toString());
+              try {
+                byte[] feature = getImageEmbeddingsFor(resource.getInputStream());
+                accessor.setPropertyValue(vectorize.destination(), feature);
+              } catch (IOException e) {
+                logger.warn("Error generating image embedding", e);
+              }
+            }
+            case WORD -> {
+              //TODO: implement me!
+            }
+            case FACE -> {
+              Resource resource = applicationContext.getResource(fieldValue.toString());
+              try {
+                byte[] feature = getFacialImageEmbeddingsFor(resource.getInputStream());
+                accessor.setPropertyValue(vectorize.destination(), feature);
+              } catch (IOException | TranslateException e) {
+                logger.warn("Error generating facial image embedding", e);
+              }
+            }
+            case SENTENCE -> accessor.setPropertyValue(vectorize.destination(), getSentenceEmbeddingsFor(fieldValue.toString()));
+          }
+        }
+      });
+    }
+  }
+
+  @Override
+  public boolean isReady() {
+    return this.faceEmbeddingModel != null && this.sentenceTokenizer != null;
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/FeatureExtractor.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/FeatureExtractor.java
@@ -1,132 +1,20 @@
 package com.redis.om.spring.vectorize;
 
-import ai.djl.huggingface.tokenizers.Encoding;
-import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
-import ai.djl.inference.Predictor;
-import ai.djl.modality.cv.Image;
-import ai.djl.modality.cv.ImageFactory;
-import ai.djl.modality.cv.translator.ImageFeatureExtractor;
-import ai.djl.repository.zoo.ZooModel;
-import ai.djl.translate.Pipeline;
 import ai.djl.translate.TranslateException;
-import com.redis.om.spring.annotations.Vectorize;
-import com.redis.om.spring.util.ObjectUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-import org.springframework.beans.PropertyAccessor;
-import org.springframework.beans.PropertyAccessorFactory;
-import org.springframework.context.ApplicationContext;
-import org.springframework.core.io.Resource;
-import org.springframework.data.redis.core.RedisCallback;
-import org.springframework.data.redis.core.RedisOperations;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.util.List;
 
-@Component public class FeatureExtractor {
-  private final RedisOperations<?, ?> redisOperations;
-  private final ZooModel<Image, byte[]> imageEmbeddingModel;
-  private final ZooModel<Image, float[]> faceEmbeddingModel;
-  private final ImageFactory imageFactory;
-  private final ApplicationContext applicationContext;
-  private ImageFeatureExtractor imageFeatureExtractor;
-  public final Pipeline imagePipeline;
-  public final HuggingFaceTokenizer sentenceTokenizer;
+public interface FeatureExtractor {
+    void processEntity(byte[] redisKey, Object item);
 
-  private static final Log logger = LogFactory.getLog(FeatureExtractor.class);
+    byte[] getImageEmbeddingsFor(InputStream is);
 
-  public FeatureExtractor( //
-      RedisOperations<?, ?> redisOperations, //
-      ApplicationContext applicationContext, //
-      ZooModel<Image, byte[]> imageEmbeddingModel, //
-      ZooModel<Image, float[]> faceEmbeddingModel, //
-      ImageFactory imageFactory, //
-      Pipeline imagePipeline,
-      HuggingFaceTokenizer sentenceTokenizer
-      ) {
-    this.redisOperations = redisOperations;
-    this.applicationContext = applicationContext;
-    this.imageEmbeddingModel = imageEmbeddingModel;
-    this.faceEmbeddingModel = faceEmbeddingModel;
-    this.imageFactory = imageFactory;
-    this.imagePipeline = imagePipeline;
-    this.sentenceTokenizer = sentenceTokenizer;
+    byte[] getFacialImageEmbeddingsFor(InputStream is) throws IOException, TranslateException;
 
-    // feature extractor
-    this.imageFeatureExtractor = ImageFeatureExtractor.builder().setPipeline(imagePipeline).build();
-  }
+    byte[] getSentenceEmbeddingsFor(String text);
 
-  public void processEntity(byte[] redisKey, Object item) {
-    processEntity(item);
-  }
+    void processEntity(Object item);
 
-  public byte[] getImageEmbeddingsFor(InputStream is) {
-    try {
-      var img = imageFactory.fromInputStream(is);
-      Predictor<Image, byte[]> predictor = imageEmbeddingModel.newPredictor(imageFeatureExtractor);
-      return predictor.predict(img);
-    } catch (IOException | TranslateException e) {
-      logger.warn("Error generating image embedding", e);
-      return new byte[]{};
-    }
-  }
-
-  public byte[] getFacialImageEmbeddingsFor(InputStream is) throws IOException, TranslateException {
-    try (Predictor<Image, float[]> predictor = faceEmbeddingModel.newPredictor()) {
-      var img = imageFactory.fromInputStream(is);
-      return ObjectUtils.floatArrayToByteArray(predictor.predict(img));
-    }
-  }
-
-  public byte[] getSentenceEmbeddingsFor(String text) {
-    Encoding encoding = sentenceTokenizer.encode(text);
-    return ObjectUtils.longArrayToByteArray(encoding.getIds());
-  }
-
-  public void processEntity(Object item) {
-    if (!isReady()) {
-      return;
-    }
-    List<Field> fields = ObjectUtils.getFieldsWithAnnotation(item.getClass(), Vectorize.class);
-    if (!fields.isEmpty()) {
-      PropertyAccessor accessor = PropertyAccessorFactory.forBeanPropertyAccess(item);
-      fields.forEach(f -> {
-        Vectorize vectorize = f.getAnnotation(Vectorize.class);
-        Object fieldValue = accessor.getPropertyValue(f.getName());
-        if (fieldValue != null) {
-          switch (vectorize.embeddingType()) {
-            case IMAGE -> {
-              Resource resource = applicationContext.getResource(fieldValue.toString());
-              try {
-                byte[] feature = getImageEmbeddingsFor(resource.getInputStream());
-                accessor.setPropertyValue(vectorize.destination(), feature);
-              } catch (IOException e) {
-                logger.warn("Error generating image embedding", e);
-              }
-            }
-            case WORD -> {
-              //TODO: implement me!
-            }
-            case FACE -> {
-              Resource resource = applicationContext.getResource(fieldValue.toString());
-              try {
-                byte[] feature = getFacialImageEmbeddingsFor(resource.getInputStream());
-                accessor.setPropertyValue(vectorize.destination(), feature);
-              } catch (IOException | TranslateException e) {
-                logger.warn("Error generating facial image embedding", e);
-              }
-            }
-            case SENTENCE -> accessor.setPropertyValue(vectorize.destination(), getSentenceEmbeddingsFor(fieldValue.toString()));
-          }
-        }
-      });
-    }
-  }
-
-  public boolean isReady() {
-    return this.faceEmbeddingModel != null && this.sentenceTokenizer != null;
-  }
+    boolean isReady();
 }


### PR DESCRIPTION
I want to make injectable FeatureExtractor because I don't need DJL. So everyone now can implement FeatureExtractor or use the provided DefaultFeatureExtractor.

Also removed `@Component` to avoid auto discovery (the bean is declared in configuration).
