### PR TITLE
Update GreaterThanOrEqualPredicate.java

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/GreaterThanOrEqualPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/numeric/GreaterThanOrEqualPredicate.java
@@ -40,7 +40,8 @@ public class GreaterThanOrEqualPredicate<E, T> extends BaseAbstractPredicate<E, 
       return QueryBuilders.intersect(root).add(getSearchAlias(), Values.ge(unixTime));
     } else if (cls == LocalDateTime.class) {
       LocalDateTime localDateTime = (LocalDateTime) getValue();
-      Instant instant = localDateTime.toInstant(ZoneOffset.of(ZoneId.systemDefault().getId()));
+     // Instant instant = localDateTime.toInstant(ZoneOffset.of(ZoneId.systemDefault().getId()));
+      Instant instant = ZonedDateTime.of(localDateTime, ZoneId.systemDefault()).toInstant();
       long unixTime = instant.getEpochSecond();
       return QueryBuilders.intersect(root).add(getSearchAlias(), Values.ge(unixTime));
     } else if (cls == Instant.class) {


### PR DESCRIPTION
use ZoneId insteadof ZoneOffset ,for java.time.DateTimeException: Invalid ID for ZoneOffset, non numeric characters found: UTC
	at java.base/java.time.ZoneOffset.parseNumber(ZoneOffset.java:271)
	at java.base/java.time.ZoneOffset.of(ZoneOffset.java:218)
	at com.redis.om.spring.search.stream.predicates.numeric.GreaterThanOrEqualPredicate.apply(GreaterThanOrEqualPredicate.java:43)