### PR TITLE
release: version 0.8.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ inherited from the parent poms):
       <path>
         <groupId>com.redis.om</groupId>
         <artifactId>redis-om-spring</artifactId>
-        <version>0.8.8-SNAPSHOT</version>
+        <version>0.8.8</version>
       </path>
     </annotationProcessorPaths>
   </configuration>
@@ -453,7 +453,7 @@ repositories {
 ### Dependency
 ```groovy
 ext {
-  redisOmVersion = '0.8.8-SNAPSHOT'
+  redisOmVersion = '0.8.8'
 }
 
 dependencies {

--- a/demos/roms-documents/pom.xml
+++ b/demos/roms-documents/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.8.8-SNAPSHOT</version>
+      <version>0.8.8</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -147,7 +147,7 @@
             <path>
               <groupId>com.redis.om</groupId>
               <artifactId>redis-om-spring</artifactId>
-              <version>0.8.8-SNAPSHOT</version>
+              <version>0.8.8</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/demos/roms-hashes/pom.xml
+++ b/demos/roms-hashes/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.8.8-SNAPSHOT</version>
+      <version>0.8.8</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/demos/roms-permits/pom.xml
+++ b/demos/roms-permits/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.8.8-SNAPSHOT</version>
+      <version>0.8.8</version>
     </dependency>
 
     <dependency>

--- a/demos/roms-vss/pom.xml
+++ b/demos/roms-vss/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.8.8-SNAPSHOT</version>
+      <version>0.8.8</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring-parent</artifactId>
-  <version>0.8.8-SNAPSHOT</version>
+  <version>0.8.8</version>
   <name>redis-om-spring-parent</name>
   <packaging>pom</packaging>
 

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring</artifactId>
-  <version>0.8.8-SNAPSHOT</version>
+  <version>0.8.8</version>
   <packaging>jar</packaging>
 
   <name>redis-om-spring</name>


### PR DESCRIPTION
Spring Boot 3.2 release:

- feature: Add support for UUIDs and ULIDs as TAG indexable field (resolves gh-364) 
- feature: adds Redis sentinel support (resolves gh-227)
- refactor: removed commented out code 
- refactor: Use FTCreateParams for ftCreate method, update Jedis constants for VSS 
- refactor: clean up, warnings, deprecations
- refactor: upgrade all Jedis calls to RedisJsonV2Commands
- refactor: removed unused class EnhancedRedisQueryEngine
 - release: 0.8.8-SNAPSHOT - Spring Boot 3.2
- dependencies: update spring/sdr to 3.1.7 and all sub-deps
- Bumped spellcheck action to latest version, since 0.23.0 is EOL
- fixed infinite nested loop during metamodel creation
- Minor tweaks to README 
- refactor: clean up VSS demo
- fix: prevent index out of bounds on nocontent empty query results (#353) 
- docs: Fixed a couple of typos. (#347)
- fix: #341 fixed parameter extraction in @Query (resolved gh-346) 
- fix - added implementation of findAll method for RedisDocumentRepository (resolves gh-344) (#345) 