### PR TITLE
Release 0.8.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ inherited from the parent poms):
       <path>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-configuration-processor</artifactId>
-        <version>3.1.2</version>
+        <version>3.2.3</version>
       </path>
       <path>
         <groupId>org.projectlombok</groupId>
@@ -407,7 +407,7 @@ inherited from the parent poms):
       <path>
         <groupId>com.redis.om</groupId>
         <artifactId>redis-om-spring</artifactId>
-        <version>0.8.8</version>
+        <version>0.8.9</version>
       </path>
     </annotationProcessorPaths>
   </configuration>
@@ -453,7 +453,7 @@ repositories {
 ### Dependency
 ```groovy
 ext {
-  redisOmVersion = '0.8.8'
+  redisOmVersion = '0.8.9'
 }
 
 dependencies {

--- a/demos/roms-documents/pom.xml
+++ b/demos/roms-documents/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -24,14 +24,14 @@
     <maven.test.source>17</maven.test.source>
     <maven.test.target>17</maven.test.target>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <testcontainers.redis.version>2.0.1</testcontainers.redis.version>
+    <testcontainers.redis.version>2.2.0</testcontainers.redis.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.8.8</version>
+      <version>0.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -147,7 +147,7 @@
             <path>
               <groupId>com.redis.om</groupId>
               <artifactId>redis-om-spring</artifactId>
-              <version>0.8.8</version>
+              <version>0.8.9</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/demos/roms-hashes/pom.xml
+++ b/demos/roms-hashes/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.8.8</version>
+      <version>0.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/demos/roms-permits/pom.xml
+++ b/demos/roms-permits/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.3</version>
     <relativePath />
     <!-- lookup parent from repository -->
   </parent>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.8.8</version>
+      <version>0.8.9</version>
     </dependency>
 
     <dependency>

--- a/demos/roms-vss/pom.xml
+++ b/demos/roms-vss/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
 
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.8.8</version>
+      <version>0.8.9</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring-parent</artifactId>
-  <version>0.8.8</version>
+  <version>0.8.9</version>
   <name>redis-om-spring-parent</name>
   <packaging>pom</packaging>
 

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring</artifactId>
-  <version>0.8.8</version>
+  <version>0.8.9</version>
   <packaging>jar</packaging>
 
   <name>redis-om-spring</name>
@@ -59,25 +59,24 @@
     <maven.test.source>17</maven.test.source>
     <maven.test.target>17</maven.test.target>
     <java.version>17</java.version>
-    <spring.version>3.2.0</spring.version>
-    <sdr.version>3.2.0</sdr.version>
+    <spring.version>3.2.3</spring.version>
+    <sdr.version>3.2.3</sdr.version>
     <jedis.version>5.0.2</jedis.version>
     <cdi>1.0</cdi>
-    <auto-service.version>1.0.1</auto-service.version>
-    <spring.test.version>6.0.15</spring.test.version>
-    <testcontainers.redis.version>2.0.1</testcontainers.redis.version>
-    <testcontainers.redis.junit.version>2.0.1</testcontainers.redis.junit.version>
+    <auto-service.version>1.1.1</auto-service.version>
+    <testcontainers.redis.version>2.2.0</testcontainers.redis.version>
+    <testcontainers.redis.junit.version>2.2.0</testcontainers.redis.junit.version>
     <guava.version>33.0.0-jre</guava.version>
-    <ulid.version>5.2.2</ulid.version>
+    <ulid.version>5.2.3</ulid.version>
     <lombok.version>1.18.30</lombok.version>
     <commons-lang.version>3.13.0</commons-lang.version>
     <javapoet.version>1.13.0</javapoet.version>
-    <assertj.version>3.24.2</assertj.version>
-    <elementary.version>2.0.0</elementary.version>
+    <assertj.version>3.25.3</assertj.version>
+    <elementary.version>2.0.1</elementary.version>
     <gson.version>2.10.1</gson.version>
-    <djl.starter.version>0.23</djl.starter.version>
-    <djl.version>0.23.0</djl.version>
-    <junit-bom.version>5.10.1</junit-bom.version>
+    <djl.starter.version>0.26</djl.starter.version>
+    <djl.version>0.26.0</djl.version>
+    <junit-bom.version>5.10.2</junit-bom.version>
   </properties>
 
   <dependencyManagement>
@@ -263,7 +262,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.8</version>
+        <version>0.8.9</version>
         <executions>
           <execution>
             <goals>

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RediSearchIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RediSearchIndexer.java
@@ -117,6 +117,7 @@ public class RediSearchIndexer {
       }
 
       String entityPrefix = maybeEntityPrefix.orElse(getEntityPrefix(cl));
+      entityPrefix = entityPrefix.endsWith(":") ? entityPrefix : entityPrefix + ":";
       params.prefix(entityPrefix);
       addKeySpaceMapping(entityPrefix, cl);
       updateTTLSettings(cl, entityPrefix, isDocument, document, allClassFields);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/Sort.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/Sort.java
@@ -25,6 +25,11 @@ public class Sort extends org.springframework.data.domain.Sort {
     return org.springframework.data.domain.Sort.by(direction, properties);
   }
 
+  public static org.springframework.data.domain.Sort by(MetamodelField<?, ?>... fields) {
+    String[] properties = Arrays.stream(fields).map(MetamodelField::getSearchAlias).toArray(String[]::new);
+    return org.springframework.data.domain.Sort.by(properties);
+  }
+
   @Serial private static final long serialVersionUID = 7789210988714363618L;
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -246,7 +246,7 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
   }
 
   public byte[] createKey(String keyspace, String id) {
-    return this.mappingConverter.toBytes(keyspace + ":" + id);
+    return this.mappingConverter.toBytes(keyspace.endsWith(":") ? keyspace + id : keyspace + ":" + id);
   }
 
   private void processReferenceAnnotations(byte[] objectKey, Object entity, Pipeline pipeline) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
@@ -271,7 +271,7 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
   }
 
   public byte[] createKey(String keyspace, String id) {
-    return this.mappingConverter.toBytes(keyspace + ":" + id);
+    return this.mappingConverter.toBytes(keyspace.endsWith(":") ? keyspace + id : keyspace + ":" + id);
   }
 
   private boolean expires(RedisData data) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/ReturnFieldsSearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/ReturnFieldsSearchStreamImpl.java
@@ -57,7 +57,8 @@ public class ReturnFieldsSearchStreamImpl<E, T> implements SearchStream<T> {
     this.returning = returning;
     this.gson = gson;
     this.mappingConverter = mappingConverter;
-    this.useNoContent = returning.size() == 1 && returning.get(0).getSearchFieldAccessor().getField().isAnnotationPresent(Id.class);
+    this.useNoContent = returning.size() == 1 && returning.get(0).getSearchFieldAccessor() != null && returning.get(0)
+      .getSearchFieldAccessor().getField().isAnnotationPresent(Id.class);
     this.isDocument = isDocument;
   }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -184,6 +184,8 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
       return new WrapperSearchStream<>(resolveStream().map(mapper));
     }
 
+    resolvedStream = Stream.empty();
+
     return new ReturnFieldsSearchStreamImpl<>(this, returning, mappingConverter, getGson(), isDocument);
   }
 
@@ -334,6 +336,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
     Query query = (rootNode.toString().isBlank()) ? new Query() : new Query(rootNode.toString());
     query.limit(0, 0);
     SearchResult searchResult = search.search(query);
+    resolvedStream = Stream.empty();
 
     return searchResult.getTotalResults();
   }
@@ -566,6 +569,8 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
       result = wrappedIds.mapToLong(mapper).boxed();
     }
+    resolvedStream = Stream.empty();
+
     return result;
   }
 
@@ -576,12 +581,14 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @SafeVarargs @Override
   public final <R> AggregationStream<R> groupBy(MetamodelField<E, ?>... fields) {
+    resolvedStream = Stream.empty();
     String query = (rootNode.toString().isBlank()) ? "*" : rootNode.toString();
     return new AggregationStreamImpl<>(searchIndex, modulesOperations, getGson(), entityClass, query, fields);
   }
 
   @Override
   public <R> AggregationStream<R> apply(String expression, String alias) {
+    resolvedStream = Stream.empty();
     String query = (rootNode.toString().isBlank()) ? "*" : rootNode.toString();
     AggregationStream<R> aggregationStream = new AggregationStreamImpl<>(searchIndex, modulesOperations, getGson(), entityClass, query);
     aggregationStream.apply(expression, alias);
@@ -590,6 +597,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @SafeVarargs @Override
   public final <R> AggregationStream<R> load(MetamodelField<E, ?>... fields) {
+    resolvedStream = Stream.empty();
     String query = (rootNode.toString().isBlank()) ? "*" : rootNode.toString();
     AggregationStream<R> aggregationStream = new AggregationStreamImpl<>(searchIndex, modulesOperations, getGson(), entityClass, query);
     aggregationStream.load(fields);
@@ -598,6 +606,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @Override
   public <R> AggregationStream<R> loadAll() {
+    resolvedStream = Stream.empty();
     String query = (rootNode.toString().isBlank()) ? "*" : rootNode.toString();
     AggregationStream<R> aggregationStream = new AggregationStreamImpl<>(searchIndex, modulesOperations, getGson(), entityClass, query);
     aggregationStream.loadAll();
@@ -606,6 +615,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @Override
   public <R> AggregationStream<R> cursor(int count, Duration timeout) {
+    resolvedStream = Stream.empty();
     String query = (rootNode.toString().isBlank()) ? "*" : rootNode.toString();
     AggregationStream<R> aggregationStream = new AggregationStreamImpl<>(searchIndex, modulesOperations, getGson(), entityClass, query);
     aggregationStream.cursor(count, timeout);
@@ -614,6 +624,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @Override
   public Optional<E> min(NumericField<E, ?> field) {
+    resolvedStream = Stream.empty();
     List<Pair<String, ?>> minByField = this //
         .load(new MetamodelField<E, String>("__key", String.class)) //
         .sorted(Order.asc("@" + field.getSearchAlias()))
@@ -625,6 +636,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @Override
   public Optional<E> max(NumericField<E, ?> field) {
+    resolvedStream = Stream.empty();
     List<Pair<String, ?>> maxByField = this //
         .load(new MetamodelField<E, String>("__key", String.class)) //
         .sorted(1, Order.desc("@" + field.getSearchAlias()))
@@ -645,6 +657,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @Override
   public Slice<E> getSlice(Pageable pageable) {
+    resolvedStream = Stream.empty();
     if (pageable.getClass().isAssignableFrom(AggregationPageable.class)) {
       AggregationPageable ap = (AggregationPageable) pageable;
       AggregationResult ar = search.cursorRead(ap.getCursorId(), pageable.getPageSize());

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/ContainingPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/fulltext/ContainingPredicate.java
@@ -1,7 +1,6 @@
 package com.redis.om.spring.search.stream.predicates.fulltext;
 
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
-import com.redis.om.spring.repository.query.QueryUtils;
 import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
 import org.apache.commons.lang3.ObjectUtils;
 import redis.clients.jedis.search.querybuilder.Node;
@@ -22,7 +21,7 @@ public class ContainingPredicate<E, T> extends BaseAbstractPredicate<E, T> {
 
   @Override
   public Node apply(Node root) {
-    return ObjectUtils.isNotEmpty(getValue()) ? QueryBuilders.intersect(root).add(getSearchAlias(), "*" + QueryUtils.escape(getValue().toString(), true) + "*") : root;
+    return ObjectUtils.isNotEmpty(getValue()) ? QueryBuilders.intersect(root).add(getSearchAlias(), "*" + getValue().toString() + "*") : root;
   }
 
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/BasicRedisDocumentMappingTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/BasicRedisDocumentMappingTest.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.connection.RedisGeoCommands;
@@ -714,5 +715,41 @@ class BasicRedisDocumentMappingTest extends AbstractBaseDocumentTest {
       .map(Company::getName)
       .collect(Collectors.toList());
     assertThat(Ordering.<String>natural().isOrdered(companyNames)).isTrue();
+  }
+
+  @Test
+  void testFindAllWithSortingById() {
+    final List<Company> bunchOfCompanies = new ArrayList<>();
+    IntStream.range(1, 25).forEach(i -> {
+      Company c = Company.of("Company" + i, 2022, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690),
+        "company" + i + "@inc.com");
+      bunchOfCompanies.add(c);
+    });
+    repository.saveAll(bunchOfCompanies);
+
+    Iterable<Company> result = repository.findAll(Sort.by("id").ascending());
+
+    List<String> ids = StreamSupport.stream(result.spliterator(), false)
+      .map(Company::getId)
+      .toList();
+    assertThat(Ordering.<String>natural().isOrdered(ids)).isTrue();
+  }
+
+  @Test
+  void testFindAllWithSortingByIdUsingMetamodel() {
+    final List<Company> bunchOfCompanies = new ArrayList<>();
+    IntStream.range(1, 25).forEach(i -> {
+      Company c = Company.of("Company" + i, 2022, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690),
+        "company" + i + "@inc.com");
+      bunchOfCompanies.add(c);
+    });
+    repository.saveAll(bunchOfCompanies);
+
+    Iterable<Company> result = repository.findAll(com.redis.om.spring.repository.query.Sort.by(Company$.ID).ascending());
+
+    List<String> ids = StreamSupport.stream(result.spliterator(), false)
+      .map(Company::getId)
+      .toList();
+    assertThat(Ordering.<String>natural().isOrdered(ids)).isTrue();
   }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/ExplicitPrefixesDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/ExplicitPrefixesDocumentTest.java
@@ -1,0 +1,76 @@
+package com.redis.om.spring.annotations.document;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.annotations.document.fixtures.*;
+import com.redis.om.spring.search.stream.EntityStream;
+import com.redis.om.spring.search.stream.SearchStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class ExplicitPrefixesDocumentTest extends AbstractBaseDocumentTest {
+  @Autowired
+  CountryRepository countryRepository;
+
+  @Autowired
+  DocWithColonInPrefixRepository docWithColonInPrefixRepository;
+
+  @Autowired
+  EntityStream entityStream;
+
+  @BeforeEach
+  void prepare() {
+    countryRepository.deleteAll();
+
+    var countriesInBulk = Set.of( //
+      Country.of("Mexico"), Country.of("Canada"), //
+      Country.of("Panama"), Country.of("Venezuela") //
+    );
+    countryRepository.saveAll(countriesInBulk);
+    countryRepository.save(Country.of("USA"));
+
+    docWithColonInPrefixRepository.deleteAll();
+    var countriesInBulk2 = Set.of( //
+      DocWithColonInPrefix.of("Mexico"), DocWithColonInPrefix.of("Canada"), //
+      DocWithColonInPrefix.of("Panama"), DocWithColonInPrefix.of("Venezuela") //
+    );
+    docWithColonInPrefixRepository.saveAll(countriesInBulk2);
+    docWithColonInPrefixRepository.save(DocWithColonInPrefix.of("USA"));
+  }
+
+  @Test
+  void testKeyGenerationWithCustomPrefix() {
+    try (SearchStream<Country> stream = entityStream.of(Country.class)) {
+      var countries = stream.map(Country$._KEY).collect(Collectors.toSet());
+      assertThat(countries).containsExactlyInAnyOrder( //
+        "country:Mexico", "country:Canada", //
+        "country:Panama", "country:Venezuela", //
+        "country:USA" //
+      );
+    }
+  }
+
+  @Test
+  void testKeyGenerationWithCustomPrefixWithColon() {
+    try (SearchStream<DocWithColonInPrefix> stream = entityStream.of(DocWithColonInPrefix.class)) {
+      var countries = stream.map(DocWithColonInPrefix$._KEY).collect(Collectors.toSet());
+      assertThat(countries).containsExactlyInAnyOrder( //
+        "dwcip:Mexico", "dwcip:Canada", //
+        "dwcip:Panama", "dwcip:Venezuela", //
+        "dwcip:USA" //
+      );
+    }
+  }
+
+  @Test void testFindByIdForCustomPrefixWithColon() {
+    Optional<DocWithColonInPrefix> maybePanama = docWithColonInPrefixRepository.findById("Panama");
+    assertThat(maybePanama).isPresent();
+  }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RedisDocumentQueryByExampleTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RedisDocumentQueryByExampleTest.java
@@ -155,6 +155,30 @@ public class RedisDocumentQueryByExampleTest extends AbstractBaseDocumentTest {
   }
 
   @Test
+  void testFindAllByExampleById() {
+    MyDoc template = new MyDoc();
+    template.setId(id1);
+
+    Example<MyDoc> example = Example.of(template);
+
+    Iterable<MyDoc> docs = repository.findAll(example);
+    assertThat(docs).hasSize(1);
+    assertThat(docs.iterator().next()).extracting(MyDoc::getTitle).isEqualTo("hello world");
+  }
+
+  @Test
+  void testFindAllByExampleByIdWithExampleMatcher() {
+    MyDoc template = new MyDoc();
+    template.setId(id1);
+
+    Example<MyDoc> example = Example.of(template, ExampleMatcher.matching().withIgnoreCase(false));
+
+    Iterable<MyDoc> docs = repository.findAll(example);
+    assertThat(docs).hasSize(1);
+    assertThat(docs.iterator().next()).extracting(MyDoc::getTitle).isEqualTo("hello world");
+  }
+
+  @Test
   void testFindAllByWithPageableAndSortAsc() {
     Pageable pageRequest = PageRequest.of(0, 2,
         Sort.by("title").ascending());

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DocWithColonInPrefix.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DocWithColonInPrefix.java
@@ -1,0 +1,16 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.annotations.Document;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@Document("dwcip:")
+public class DocWithColonInPrefix {
+  @Id
+  @NonNull
+  private String id;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DocWithColonInPrefixRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/DocWithColonInPrefixRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface DocWithColonInPrefixRepository extends RedisDocumentRepository<DocWithColonInPrefix,String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/BasicRedisHashMappingTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/BasicRedisHashMappingTest.java
@@ -364,6 +364,40 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.with;
   }
 
   @Test
+  void testFindAllWithSortingById() {
+    final List<Company> bunchOfCompanies = new ArrayList<>();
+    IntStream.range(1, 25).forEach(i -> {
+      Company c = Company.of("Company" + i, 2022, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690),
+        "company" + i + "@inc.com");
+      bunchOfCompanies.add(c);
+    });
+    companyRepo.saveAll(bunchOfCompanies);
+
+    Iterable<Company> result = companyRepo.findAll(Sort.by("id").ascending());
+
+    List<String> ids = StreamSupport.stream(result.spliterator(), false).map(Company::getId)
+      .collect(Collectors.toList());
+    assertThat(Ordering.<String>natural().isOrdered(ids)).isTrue();
+  }
+
+  @Test
+  void testFindAllWithSortingByIdUsingMetamodel() {
+    final List<Company> bunchOfCompanies = new ArrayList<>();
+    IntStream.range(1, 25).forEach(i -> {
+      Company c = Company.of("Company" + i, 2022, LocalDate.of(2021, 5, 1), new Point(-122.066540, 37.377690),
+        "company" + i + "@inc.com");
+      bunchOfCompanies.add(c);
+    });
+    companyRepo.saveAll(bunchOfCompanies);
+
+    Iterable<Company> result = companyRepo.findAll(com.redis.om.spring.repository.query.Sort.by(Company$.ID).ascending());
+
+    List<String> ids = StreamSupport.stream(result.spliterator(), false).map(Company::getId)
+      .collect(Collectors.toList());
+    assertThat(Ordering.<String>natural().isOrdered(ids)).isTrue();
+  }
+
+  @Test
   void testBasicPaginationForNonIndexedEntity() {
     final List<NonIndexedHash> bunchOfNihs = new ArrayList<>();
     IntStream.range(1, 25).forEach(i -> {

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/ExplicitPrefixesHashTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/ExplicitPrefixesHashTest.java
@@ -1,0 +1,75 @@
+package com.redis.om.spring.annotations.hash;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.annotations.hash.fixtures.*;
+import com.redis.om.spring.search.stream.EntityStream;
+import com.redis.om.spring.search.stream.SearchStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExplicitPrefixesHashTest extends AbstractBaseEnhancedRedisTest {
+  @Autowired
+  CountryRepository countryRepository;
+
+  @Autowired
+  HashWithColonInPrefixRepository hashWithColonInPrefixRepository;
+
+  @Autowired
+  EntityStream entityStream;
+
+  @BeforeEach
+  void prepare() {
+    countryRepository.deleteAll();
+
+    var countriesInBulk = Set.of( //
+      Country.of("Mexico"), Country.of("Canada"), //
+      Country.of("Panama"), Country.of("Venezuela") //
+    );
+    countryRepository.saveAll(countriesInBulk);
+    countryRepository.save(Country.of("USA"));
+
+    hashWithColonInPrefixRepository.deleteAll();
+    var countriesInBulk2 = Set.of( //
+      HashWithColonInPrefix.of("Mexico"), HashWithColonInPrefix.of("Canada"), //
+      HashWithColonInPrefix.of("Panama"), HashWithColonInPrefix.of("Venezuela") //
+    );
+    hashWithColonInPrefixRepository.saveAll(countriesInBulk2);
+    hashWithColonInPrefixRepository.save(HashWithColonInPrefix.of("USA"));
+  }
+
+  @Test
+  void testKeyGenerationWithCustomPrefix() {
+    try (SearchStream<Country> stream = entityStream.of(Country.class)) {
+      var countries = stream.map(Country$._KEY).collect(Collectors.toSet());
+      assertThat(countries).containsExactlyInAnyOrder( //
+        "country:Mexico", "country:Canada", //
+        "country:Panama", "country:Venezuela", //
+        "country:USA" //
+      );
+    }
+  }
+
+  @Test
+  void testKeyGenerationWithCustomPrefixWithColon() {
+    try (SearchStream<HashWithColonInPrefix> stream = entityStream.of(HashWithColonInPrefix.class)) {
+      var countries = stream.map(HashWithColonInPrefix$._KEY).collect(Collectors.toSet());
+      assertThat(countries).containsExactlyInAnyOrder( //
+        "hwcip:Mexico", "hwcip:Canada", //
+        "hwcip:Panama", "hwcip:Venezuela", //
+        "hwcip:USA" //
+      );
+    }
+  }
+
+  @Test void testFindByIdForCustomPrefixWithColon() {
+    Optional<HashWithColonInPrefix> maybePanama = hashWithColonInPrefixRepository.findById("Panama");
+    assertThat(maybePanama).isPresent();
+  }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashQueryByExampleTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashQueryByExampleTest.java
@@ -100,6 +100,30 @@ public class RedisHashQueryByExampleTest extends AbstractBaseEnhancedRedisTest {
   }
 
   @Test
+  void testFindAllByExampleById() {
+    MyHash template = new MyHash();
+    template.setId(id1);
+
+    Example<MyHash> example = Example.of(template);
+
+    Iterable<MyHash> hashes = repository.findAll(example);
+    assertThat(hashes).hasSize(1);
+    assertThat(hashes.iterator().next()).extracting(MyHash::getTitle).isEqualTo("hello world");
+  }
+
+  @Test
+  void testFindAllByExampleByIdWithExampleMatcher() {
+    MyHash template = new MyHash();
+    template.setId(id1);
+
+    Example<MyHash> example = Example.of(template, ExampleMatcher.matching().withIgnoreCase(false));
+
+    Iterable<MyHash> hashes = repository.findAll(example);
+    assertThat(hashes).hasSize(1);
+    assertThat(hashes.iterator().next()).extracting(MyHash::getTitle).isEqualTo("hello world");
+  }
+
+  @Test
   void testFindByTextIndexedProperty() {
     MyHash template = new MyHash();
     template.setTitle("hello world");

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ASimpleHash.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ASimpleHash.java
@@ -1,0 +1,26 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.annotations.Searchable;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(force = true)
+@RedisHash
+public class ASimpleHash {
+  @Id
+  private String id;
+
+  @Searchable(sortable = true)
+  @NonNull
+  private String first;
+
+  @Searchable(sortable = true)
+  private String second;
+
+  @Searchable(sortable = true)
+  private String third;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ASimpleHashRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/ASimpleHashRepository.java
@@ -2,5 +2,5 @@ package com.redis.om.spring.annotations.hash.fixtures;
 
 import com.redis.om.spring.repository.RedisEnhancedRepository;
 
-public interface TextRepository extends RedisEnhancedRepository<Text, String> {
+public interface ASimpleHashRepository extends RedisEnhancedRepository<ASimpleHash, String> {
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/Country.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/Country.java
@@ -1,0 +1,16 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@RedisHash("country")
+public class Country {
+  @Id
+  @NonNull
+  private String id;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/CountryRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/CountryRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface CountryRepository extends RedisEnhancedRepository<Country,String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithColonInPrefix.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithColonInPrefix.java
@@ -1,0 +1,16 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@RedisHash("hwcip:")
+public class HashWithColonInPrefix {
+  @Id
+  @NonNull
+  private String id;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithColonInPrefixRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithColonInPrefixRepository.java
@@ -1,0 +1,6 @@
+package com.redis.om.spring.annotations.hash.fixtures;
+
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface HashWithColonInPrefixRepository extends RedisEnhancedRepository<HashWithColonInPrefix,String> {
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithEnumRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/fixtures/HashWithEnumRepository.java
@@ -1,10 +1,11 @@
 package com.redis.om.spring.annotations.hash.fixtures;
 
 import com.redis.om.spring.annotations.document.fixtures.MyJavaEnum;
-import com.redis.om.spring.repository.RedisDocumentRepository;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
 
 import java.util.List;
 
-@SuppressWarnings("unused") public interface HashWithEnumRepository extends RedisDocumentRepository<HashWithEnum, String> {
+@SuppressWarnings("unused")
+public interface HashWithEnumRepository extends RedisEnhancedRepository<HashWithEnum, String> {
   List<HashWithEnum> findByEnumProp(MyJavaEnum value);
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
@@ -2440,4 +2440,75 @@ import static org.junit.jupiter.api.Assertions.*;
 
     assertThat(names).isEmpty();
   }
+
+  @Test void testContainingPredicateOnFreeFormTextStartMatches() {
+    doc3Repository.deleteAll();
+    var doc = Doc3.of("someDoc");
+    doc.setSecond("some text about nothing");
+    doc.setThird("some other text");
+
+    doc3Repository.save(doc);
+
+    var docs = entityStream.of(Doc3.class)
+      .filter(Doc3$.SECOND.containing("some text"))
+      .collect(Collectors.toList());
+
+    assertEquals(1, docs.size());
+    assertThat(docs.get(0).getSecond()).isEqualTo("some text about nothing");
+
+    doc3Repository.delete(doc);
+  }
+
+  @Test void testContainingPredicateOnFreeFormTextMiddleMatches() {
+    doc3Repository.deleteAll();
+    var doc = Doc3.of("someDoc");
+    doc.setSecond("some text about nothing");
+    doc.setThird("some other text");
+
+    doc3Repository.save(doc);
+
+    var docs = entityStream.of(Doc3.class)
+      .filter(Doc3$.SECOND.containing("text about"))
+      .collect(Collectors.toList());
+
+    assertEquals(1, docs.size());
+    assertThat(docs.get(0).getSecond()).isEqualTo("some text about nothing");
+
+    doc3Repository.delete(doc);
+  }
+
+  @Test void testContainingPredicateOnFreeFormTextEndMatches() {
+    doc3Repository.deleteAll();
+    var doc = Doc3.of("someDoc");
+    doc.setSecond("some text about nothing");
+    doc.setThird("some other text");
+
+    doc3Repository.save(doc);
+
+    var docs = entityStream.of(Doc3.class)
+      .filter(Doc3$.SECOND.containing("about nothing"))
+      .collect(Collectors.toList());
+
+    assertEquals(1, docs.size());
+    assertThat(docs.get(0).getSecond()).isEqualTo("some text about nothing");
+
+    doc3Repository.delete(doc);
+  }
+
+  @Test void testContainingPredicateOnFreeFormTextMiddleIncompleteWords() {
+    doc3Repository.deleteAll();
+    var doc = Doc3.of("someDoc");
+    doc.setSecond("some text about nothing");
+    doc.setThird("some other text");
+    doc3Repository.save(doc);
+
+    var docs = entityStream.of(Doc3.class)
+      .filter(Doc3$.SECOND.containing("ext abou"))
+      .collect(Collectors.toList());
+
+    assertEquals(1, docs.size());
+    assertThat(docs.get(0).getSecond()).isEqualTo("some text about nothing");
+
+    doc3Repository.delete(doc);
+  }
 }


### PR DESCRIPTION
Address some bugs, added more tests, upgrade dependencies:
```
* 3a0e096 - (HEAD -> bsb/release-0.8.9, origin/bsb/release-0.8.9) release: version 0.8.9 - Spring 3.2.3 - other deps updates Brian Sam-Bodden (85 seconds ago)
* fa04c72 - fix: prevent multiple queries on close when mapping/aggregating (resolved gh-372) Brian Sam-Bodden (29 minutes ago)
* 08603d8 - fix: prevent double escaping on searchable text fields when using .containing (resolves gh-373) Brian Sam-Bodden (2 hours ago)
* 3c2401c - test: tests for QBE with findAll by Id with and without Metamodel usage Brian Sam-Bodden (2 hours ago)
* 5eb8a63 - refactor: ignore explicit ':' terminator in entity prefixes (resolves gh-386) Brian Sam-Bodden (2 hours ago)
```