### PR TITLE
Bsb/v0.9.1

### DIFF
--- a/demos/roms-documents/src/test/java/com/redis/om/documents/TestConfig.java
+++ b/demos/roms-documents/src/test/java/com/redis/om/documents/TestConfig.java
@@ -25,7 +25,7 @@ public class TestConfig {
 
         final JedisPoolConfig poolConfig = new JedisPoolConfig();
         poolConfig.setTestWhileIdle(false);
-        poolConfig.setMinEvictableIdleTime(Duration.ofMillis(60000));
+        poolConfig.setMinEvictableIdleDuration(Duration.ofMillis(60000));
         poolConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(30000));
         poolConfig.setNumTestsPerEvictionRun(-1);
 

--- a/demos/roms-vss/compose.yml
+++ b/demos/roms-vss/compose.yml
@@ -1,0 +1,14 @@
+name: roms-vss
+services:
+  redis:
+    image: "redis/redis-stack:edge"
+    ports:
+      - "6379:6379"
+    environment:
+      - "REDIS_ARGS=--appendonly yes"
+    volumes:
+      - ./../../data:/data
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,9 @@
-version: "3.9"
+name: redis-om-spring
 services:
   redis:
     image: "redis/redis-stack:edge"
     ports:
       - "6379:6379"
-    environment:
-      - "REDIS_ARGS=--appendonly yes"
-    volumes:
-      - ./data:/data
     deploy:
       replicas: 1
       restart_policy:

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -59,8 +59,8 @@
     <maven.test.source>17</maven.test.source>
     <maven.test.target>17</maven.test.target>
     <java.version>17</java.version>
-    <spring.version>3.2.3</spring.version>
-    <sdr.version>3.2.3</sdr.version>
+    <spring.version>3.2.5</spring.version>
+    <sdr.version>3.2.5</sdr.version>
     <jedis.version>5.0.2</jedis.version>
     <cdi>2.0-PFD</cdi>
     <auto-service.version>1.1.1</auto-service.version>

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -77,6 +77,7 @@ import static com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively
 @ComponentScan("com.redis.om.spring.cuckoo")
 @ComponentScan("com.redis.om.spring.autocomplete")
 @ComponentScan("com.redis.om.spring.metamodel")
+@ComponentScan("com.redis.om.spring.util")
 public class RedisModulesConfiguration {
 
   private static final Log logger = LogFactory.getLog(RedisModulesConfiguration.class);
@@ -149,6 +150,7 @@ public class RedisModulesConfiguration {
   @Bean(name = "rediSearchIndexer")
   public RediSearchIndexer redisearchIndexer(ApplicationContext ac,
                                              @Qualifier("omGsonBuilder") GsonBuilder gsonBuilder) {
+
     return new RediSearchIndexer(ac, gsonBuilder);
   }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/SentinelConfig.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/SentinelConfig.java
@@ -18,11 +18,8 @@ import java.util.stream.Collectors;
 import static org.springframework.util.StringUtils.commaDelimitedListToSet;
 
 public class SentinelConfig {
-  @Autowired
-  Environment env;
-
   @Bean
-  public JedisConnectionFactory jedisConnectionFactory() {
+  public JedisConnectionFactory jedisConnectionFactory(Environment env) {
     String master = env.getProperty("spring.redis.sentinel.master", "localhost");
     String nodes = env.getProperty("spring.redis.sentinel.nodes");
     Set<String> sentinelNodes = commaDelimitedListToSet(nodes);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/BytesToDateConverter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/BytesToDateConverter.java
@@ -1,0 +1,23 @@
+package com.redis.om.spring.convert;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@ReadingConverter
+public class BytesToDateConverter implements Converter<byte[], Date> {
+
+  @Override
+  public Date convert(byte[] source) {
+    long milliseconds = Long.parseLong(toString(source));
+    return new Date(milliseconds);
+  }
+
+  String toString(byte[] source) {
+    return new String(source, StandardCharsets.UTF_8);
+  }
+
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/DateToBytesConverter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/DateToBytesConverter.java
@@ -1,0 +1,22 @@
+package com.redis.om.spring.convert;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@WritingConverter
+public class DateToBytesConverter implements Converter<Date, byte[]> {
+  byte[] fromString(String source) {
+    return source.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public byte[] convert(Date source) {
+    return fromString(Long.toString(source.getTime()));
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/DateToStringConverter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/DateToStringConverter.java
@@ -1,0 +1,17 @@
+package com.redis.om.spring.convert;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.WritingConverter;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@WritingConverter
+public class DateToStringConverter implements Converter<Date, String> {
+  @Override
+  public String convert(Date source) {
+    return Long.toString(source.getTime());
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/MappingRedisOMConverter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/MappingRedisOMConverter.java
@@ -1056,6 +1056,11 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
     return null;
   }
 
+  @Override
+  public EntityInstantiators getEntityInstantiators() {
+    return entityInstantiators;
+  }
+
   /* (non-Javadoc)
    *
    * @see

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/RedisOMCustomConversions.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/RedisOMCustomConversions.java
@@ -16,6 +16,11 @@ public class RedisOMCustomConversions extends RedisCustomConversions {
     // Point
     omConverters.add(new PointToBytesConverter());
     omConverters.add(new BytesToPointConverter());
+    // Date
+    omConverters.add(new DateToBytesConverter());
+    omConverters.add(new BytesToDateConverter());
+    omConverters.add(new DateToStringConverter());
+
     // LocalDate
     omConverters.add(new LocalDateToBytesConverter());
     omConverters.add(new BytesToLocalDateConverter());

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelField.java
@@ -1,5 +1,8 @@
 package com.redis.om.spring.metamodel;
 
+import com.redis.om.spring.search.stream.aggregations.filters.AggregationFilter;
+import com.redis.om.spring.search.stream.aggregations.filters.ExistsFilter;
+import com.redis.om.spring.search.stream.aggregations.filters.NotExistsFilter;
 import org.springframework.data.domain.Sort.Order;
 
 import java.util.Comparator;
@@ -68,5 +71,13 @@ public class MetamodelField<E, T> implements Comparator<E>, Function<E,T> {
 
   public Order desc() {
     return Order.desc("@" + getSearchAlias());
+  }
+
+  public AggregationFilter exists() {
+    return new ExistsFilter(this.getSearchAlias());
+  }
+
+  public AggregationFilter notExists() {
+    return new NotExistsFilter(this.getSearchAlias());
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisDocumentRepository.java
@@ -35,4 +35,6 @@ public interface RedisDocumentRepository<T, ID> extends KeyValueRepository<T, ID
   Iterable<T> bulkLoad(String file) throws IOException;
 
   <S extends T> S update(S entity);
+
+  String getKeyspace();
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisEnhancedRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/RedisEnhancedRepository.java
@@ -26,4 +26,6 @@ public interface RedisEnhancedRepository<T, ID> extends KeyValueRepository<T, ID
   <F> Iterable<F> getFieldsByIds(Iterable<ID> ids, MetamodelField<T, F> field);
 
   Long getExpiration(ID id);
+
+  String getKeyspace();
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQueryType.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQueryType.java
@@ -4,5 +4,6 @@ public enum RediSearchQueryType {
   QUERY,
   AGGREGATION,
   TAGVALS,
-  AUTOCOMPLETE
+  AUTOCOMPLETE,
+  DELETE,
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -237,7 +237,8 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
         .toList();
   }
 
-  private String getKeyspace() {
+  @Override
+  public String getKeyspace() {
     return indexer.getKeyspaceForEntityClass(metadata.getJavaType());
   }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
@@ -223,7 +223,8 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
     }
   }
 
-  private String getKeyspace() {
+  @Override
+  public String getKeyspace() {
     return indexer.getKeyspaceForEntityClass(metadata.getJavaType());
   }
   

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/AggregationStream.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/AggregationStream.java
@@ -2,6 +2,7 @@ package com.redis.om.spring.search.stream;
 
 import com.redis.om.spring.annotations.ReducerFunction;
 import com.redis.om.spring.metamodel.MetamodelField;
+import com.redis.om.spring.search.stream.aggregations.filters.AggregationFilter;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort.Order;
@@ -36,6 +37,8 @@ public interface AggregationStream<T> {
   AggregationStream<T> limit(int limit, int offset);
 
   AggregationStream<T> filter(String... filters);
+
+  AggregationStream<T> filter(AggregationFilter... filters);
 
   AggregationResult aggregate();
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -84,11 +84,14 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   private final ExampleToNodeConverter<E> exampleToNodeConverter;
 
+  private final RediSearchIndexer indexer;
+
   public SearchStreamImpl(Class<E> entityClass, RedisModulesOperations<String> modulesOperations, GsonBuilder gsonBuilder,
       RediSearchIndexer indexer) {
+    this.indexer = indexer;
     this.modulesOperations = modulesOperations;
     this.entityClass = entityClass;
-    Optional<String> maybeIndex = indexer.getIndexName(entityClass);
+    Optional<String> maybeIndex = this.indexer.getIndexName(entityClass);
     this.searchIndex = maybeIndex.orElse(entityClass.getName() + "Idx");
     this.search = modulesOperations.opsForSearch(searchIndex);
     this.json = modulesOperations.opsForJSON();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/aggregations/filters/AggregationFilter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/aggregations/filters/AggregationFilter.java
@@ -1,0 +1,7 @@
+package com.redis.om.spring.search.stream.aggregations.filters;
+
+public interface AggregationFilter {
+  String getFilter();
+
+  String getField();
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/aggregations/filters/ExistsFilter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/aggregations/filters/ExistsFilter.java
@@ -1,0 +1,17 @@
+package com.redis.om.spring.search.stream.aggregations.filters;
+
+public class ExistsFilter implements AggregationFilter {
+  private final String field;
+
+  public ExistsFilter(String field) {
+    this.field = field;
+  }
+
+  public String getFilter() {
+    return "exists(@" + this.getField() + ")";
+  }
+
+  public String getField() {
+    return this.field;
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/aggregations/filters/NotExistsFilter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/aggregations/filters/NotExistsFilter.java
@@ -1,0 +1,17 @@
+package com.redis.om.spring.search.stream.aggregations.filters;
+
+public class NotExistsFilter implements AggregationFilter {
+  private final String field;
+
+  public NotExistsFilter(String field) {
+    this.field = field;
+  }
+
+  public String getFilter() {
+    return "!exists(@" + this.getField() + ")";
+  }
+
+  public String getField() {
+    return this.field;
+  }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RepositoryDeleteTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/RepositoryDeleteTest.java
@@ -1,0 +1,64 @@
+package com.redis.om.spring.annotations.document;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.annotations.document.fixtures.Fruit;
+import com.redis.om.spring.annotations.document.fixtures.FruitRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RepositoryDeleteTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  private FruitRepository fruitRepository;
+
+  @BeforeEach
+  void beforeEach() {
+    Fruit apple = Fruit.of(1, "apple", "red");
+    Fruit custardApple = Fruit.of(2, "custard apple", "green");
+    Fruit mango = Fruit.of(3, "mango", "yellow");
+    Fruit guava = Fruit.of(4, "guava", "green");
+    Fruit unknown = Fruit.of(5, "unknown", null);
+    fruitRepository.saveAll(List.of(apple, custardApple, mango, guava, unknown));
+  }
+
+  @Test
+  public void givenFruits_WhenDeletedByName_ThenDeletedFruitCountShouldReturn() {
+    long deletedFruitCount = fruitRepository.deleteByName("apple");
+
+    assertThat(deletedFruitCount).isEqualTo(1);
+  }
+
+  @Test
+  public void givenFruits_WhenRemovedByColor_ThenDeletedFruitsShouldReturn() {
+    List<Fruit> fruits = fruitRepository.removeByColor("green");
+
+    assertThat(fruits).hasSize(2);
+    assertThat(fruits).extracting(Fruit::getColor).containsOnly("green");
+  }
+
+  @Test
+  public void givenFruits_WhenRemovedByName_ThenDeletedFruitCountShouldReturn() {
+    long deletedFruitCount = fruitRepository.removeByName("apple");
+
+    assertThat(deletedFruitCount).isEqualTo(1);
+  }
+
+  @Test
+  public void givenFruits_WhenDeletedByColorOrName_ThenDeletedFruitsShouldReturn() {
+    long deletedCount = fruitRepository.deleteByNameOrColor("apple", "green");
+
+    assertThat(deletedCount).isEqualTo(3);
+  }
+
+  @Test
+  public void givenFruits_WhenDeletedByColorIsNull_ThenDeletedFruitsShouldReturn() {
+    long deletedCount = fruitRepository.deleteByColorIsNull();
+
+    assertThat(deletedCount).isEqualTo(1);
+  }
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Film.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Film.java
@@ -1,0 +1,46 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Reference;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Date;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@NoArgsConstructor(force = true)
+@Document("sakila.film")
+public class Film {
+
+  @Id
+  @NonNull
+  private Integer filmId;
+  @Searchable
+  @NonNull
+  private String title;
+  @Searchable
+  private String description;
+  @Indexed
+  private LocalDate releaseYear;
+  @Indexed
+  @Reference
+  private Language language;
+  @Reference
+  private Language originalLanguage;
+  private Integer rentalDuration;
+  private BigDecimal rentalRate;
+  @Indexed
+  private Integer length;
+  private BigDecimal replacementCost;
+  private String rating;
+  private String specialFeatures;
+  private Date lastUpdate;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/FilmRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/FilmRepository.java
@@ -1,0 +1,11 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+import java.util.List;
+
+public interface FilmRepository extends RedisDocumentRepository<Film, Integer> {
+  List<Film> search(String text);
+  List<Film> searchByTitle(String title);
+  List<Film> searchByTitleAndLengthLessThanEqual(String title, Integer length);
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Fruit.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Fruit.java
@@ -1,0 +1,22 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Data
+@Document("froots")
+@AllArgsConstructor(staticName = "of")
+public class Fruit {
+
+  @Id
+  private long id;
+  @Indexed
+  private String name;
+  @Indexed
+  private String color;
+
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/FruitRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/FruitRepository.java
@@ -1,0 +1,19 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+//import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface FruitRepository extends RedisDocumentRepository<Fruit, Long> {
+  Long deleteByName(String name);
+  List<Fruit> removeByColor(String color);
+  List<Fruit> deleteByColor(String color);
+  Long removeByName(String name);
+  long deleteByNameOrColor(String apple, String green);
+  long deleteByColorIsNull();
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Language.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/Language.java
@@ -1,0 +1,25 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Searchable;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+import java.time.LocalDate;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@NoArgsConstructor(force = true)
+@Document("sakila.language")
+public class Language {
+
+  @Id
+  @NonNull
+  private Integer languageId;
+  @Searchable
+  @NonNull
+  private String name;
+  private LocalDate lastUpdate;
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/LanguageRepository.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/fixtures/LanguageRepository.java
@@ -1,0 +1,9 @@
+package com.redis.om.spring.annotations.document.fixtures;
+
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+import java.util.Optional;
+
+public interface LanguageRepository extends RedisDocumentRepository<Language, Integer> {
+  Optional<Language> findOneByName(String name);
+}

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/sentinel/BasicSentinelTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/sentinel/BasicSentinelTest.java
@@ -22,7 +22,6 @@ class BasicSentinelTest extends AbstractBaseDocumentSentinelTest {
   @Autowired
   CompanyRepository repository;
 
-  @Disabled("Potential Regression on Sentinel Support - see GH-227")
   @Test
   @DisabledIfEnvironmentVariable(named = "GITHUB_ACTIONS", matches = "true")
   void testBasicCrudOperations() {

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashVSSIndexCreationTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/RedisHashVSSIndexCreationTest.java
@@ -24,7 +24,7 @@ class RedisHashVSSIndexCreationTest extends AbstractBaseEnhancedRedisTest {
 
   private UnifiedJedis jedis;
 
-  private static String INDEX = "com.redis.om.spring.annotations.hash.fixtures.HashWithVectorsIdx";
+  private static final String INDEX = "com.redis.om.spring.annotations.hash.fixtures.HashWithVectorsIdx";
   private HashWithVectors hwv1;
   private HashWithVectors hwv2;
   private HashWithVectors hwv3;

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/serialization/SerializationTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/serialization/SerializationTest.java
@@ -220,7 +220,7 @@ import static org.assertj.core.api.Assertions.assertThat;
   
   @Test
   void testLocalDateDeSerializationInQuery() {
-    List<KitchenSink> all = repository.findByLocalDateGreaterThan(localDate.minus(2, ChronoUnit.DAYS));
+    List<KitchenSink> all = repository.findByLocalDateGreaterThan(localDate.minusDays(2));
     assertThat(all).containsExactlyInAnyOrder(ks, ks1, ks2, ks3, ks4);
   }
   

--- a/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsIssuesTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/search/stream/EntityStreamsIssuesTest.java
@@ -238,7 +238,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
         .filter(Doc2$.TEXT.endsWith("o 11")) //
         .collect(Collectors.toList());
 
-    String regex = ".*o\s11$";
+    String regex = ".*o 11$";
     assertThat(startingWithMarca2).map(Doc2::getText).allMatch(t -> t.matches(regex));
   }
 
@@ -247,13 +247,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
         .filter(Doc2$.TAG.endsWith("LOR 12")) //
         .collect(Collectors.toList());
 
-    String regex = ".*LOR\s12$";
+    String regex = ".*LOR 12$";
     assertThat(startingWithMarca2).map(Doc2::getTag).allMatch(t -> t.matches(regex));
   }
 
   @Test void testSearchInsideListOfObjects() {
     var results = entityStream.of(DeepList.class) //
-        .filter(DeepList$.NEST_LEVELS.NAME.eq("nl-2-2")) //
+        .filter(DeepList_nestLevels$.NAME.eq("nl-2-2")) //
         .map(DeepList$.NAME) //
         .collect(Collectors.toList());
 
@@ -265,7 +265,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
   @Test void testSearchInsideListOfObjects2() {
     var results = entityStream.of(DeepList.class) //
-        .filter(DeepList$.NEST_LEVELS.NAME.startsWith("nl-2")) //
+        .filter(DeepList_nestLevels$.NAME.startsWith("nl-2")) //
         .map(DeepList$.NAME) //
         .collect(Collectors.toList());
 
@@ -277,7 +277,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
   @Test void testSearchInsideListOfObjects3() {
     var results = entityStream.of(DeepList.class) //
-        .filter(DeepList$.NEST_LEVELS.BLOCK.eq("have")) //
+        .filter(DeepList_nestLevels$.BLOCK.eq("have")) //
         .map(DeepList$.NAME) //
         .collect(Collectors.toList());
 

--- a/redis-om-spring/src/test/java/com/redis/om/spring/util/ObjectUtilsTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/util/ObjectUtilsTest.java
@@ -385,7 +385,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
   @Test
   public void testInvalidPartCharacter() {
     String result = ObjectUtils.replaceIfIllegalJavaIdentifierCharacter("invalid*identifier");
-    assertThat(result).isEqualTo("invalid" + ObjectUtils.REPLACEMENT_CHARACTER.toString() + "identifier");
+    assertThat(result).isEqualTo("invalid" + ObjectUtils.REPLACEMENT_CHARACTER + "identifier");
   }
 
   @Test


### PR DESCRIPTION
* refactor: code clean up 
* fix: address Sentinel support regression (resolves GH-227) 
* fix: change default serializer for java.util.Date to store as millis since epoch for search 
* feature: adds support for repository derived delete methods like Spring Data JPA (resolves gh-419) 
* dependencies: update Spring Boot/Sprign Data Redis to v3.2.5 
* refactor: add roms-vss demo app specific docker compose file 
* feature: add exist/notExist predicated for EntityStream's aggregations (resolves gh-421) 
* fix: add com.redis.om.spring.util package to component scan path init the SpringContext class 
* refactor: keep instance of RediSearchIndexer in SearchStreamImpl 
* refactor: make getKeyspace part of the public repository APIs 