### PR TITLE
fix: treat just-expired document as inexistent

### DIFF
--- a/demos/roms-documents/pom.xml
+++ b/demos/roms-documents/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/demos/roms-hashes/pom.xml
+++ b/demos/roms-hashes/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/demos/roms-permits/pom.xml
+++ b/demos/roms-permits/pom.xml
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/demos/roms-vss/pom.xml
+++ b/demos/roms-vss/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>com.redis.om</groupId>
       <artifactId>redis-om-spring</artifactId>
-      <version>0.9.3</version>
+      <version>0.9.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redis.om</groupId>
   <artifactId>redis-om-spring-parent</artifactId>
-  <version>0.9.3</version>
+  <version>0.9.4-SNAPSHOT</version>
   <name>redis-om-spring-parent</name>
   <packaging>pom</packaging>
 

--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.redis.om</groupId>
     <artifactId>redis-om-spring</artifactId>
-    <version>0.9.3</version>
+    <version>0.9.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>redis-om-spring</name>

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -501,18 +501,13 @@ public class RediSearchQuery implements RepositoryQuery {
   }
 
   private Object parseDocumentResult(redis.clients.jedis.search.Document doc) {
+    if (doc == null || doc.get("$") == null) {
+      return null;
+    }
+
     Gson gsonInstance = getGson();
 
-    if (doc == null) {
-      return gsonInstance.fromJson("", domainType);
-    }
-
-    if (doc.get("$") != null) {
-      return gsonInstance.fromJson(SafeEncoder.encode((byte[]) doc.get("$")), domainType);
-    }
-
-    return gsonInstance.fromJson(gsonInstance.toJsonTree(StreamSupport.stream(doc.getProperties().spliterator(), false)
-        .collect(Collectors.toMap(Entry::getKey, entry -> SafeEncoder.encode((byte[]) entry.getValue())))), domainType);
+    return gsonInstance.fromJson(SafeEncoder.encode((byte[]) doc.get("$")), domainType);
   }
 
   private Object executeDeleteQuery(Object[] parameters) {


### PR DESCRIPTION
This is a naive fix for #483 .
It is supposed to treat document results that just-expired as inexistent.