### PR TITLE
docs: fix version requiring spring-milestones in Maven snippets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ Iterable<MyDoc> allMatches = repository.findAll(example);
 </dependency>
 ```
 
-> ⚠️ Redis OM Spring versions greater than `v0.9.2` require the addition
+> ⚠️ Redis OM Spring versions greater than `v0.9.1` require the addition
 of the [**Spring Milestone Repository**](https://repo.spring.io/milestone) to account
 for the recent integration with the [**Spring AI**](https://docs.spring.io/spring-ai/reference/) project. When Spring AI `v1.0.0` is
 released we will drop this requirement.


### PR DESCRIPTION
The README indicates that a new repository is required due to the new spring-ai dependency, but it says greater than 0.9.2 when it should be starting at 0.9.2 or greater than 0.9.1.