### PR TITLE
Removing Spring AI BOM

### DIFF
--- a/redis-om-spring/pom.xml
+++ b/redis-om-spring/pom.xml
@@ -99,14 +99,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.springframework.ai</groupId>
-                <artifactId>spring-ai-bom</artifactId>
-                <version>${spring-ai.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-                <optional>true</optional>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -179,6 +171,7 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-openai</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -196,41 +189,49 @@
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-ollama</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-azure-openai</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-vertex-ai-palm2</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-bedrock</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-transformers</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-mistral-ai</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-minimax</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>
             <artifactId>spring-ai-zhipuai</artifactId>
+            <version>${spring-ai.version}</version>
             <optional>true</optional>
         </dependency>
         <!-- Spring AI end -->


### PR DESCRIPTION
I ran another test: 

1. Remove Spring AI BOM folder from .m2:
`rm -rf ~/.m2/repository/org/springframework/ai/spring-ai-bom`

2. Reload Maven project:
2.1. with Redis OM Spring v0.9.8:
Directory and contents are recreated

2.2. with a new snapshot of Redis OM Spring without Spring AI BOM:
Directory and contents are not recreated. 

Turns out that even though Maven won't download the actual dependencies (and that's why nothing shows in the dependency tree), it will still import the POM file of the BOM. To avoid this from happening, I simply removed the BOM and managed the versions of Spring AI optional dependencies manually. 