### PR TITLE
Using bulk APIs/calls on entities during saveAll

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisOMAiProperties.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisOMAiProperties.java
@@ -14,6 +14,7 @@ import java.util.Map;
 )
 public class RedisOMAiProperties {
   private boolean enabled = false;
+  private int embeddingBatchSize = 1000;
   private final Djl djl = new Djl();
   private final Transformers transformers = new Transformers();
   private final OpenAi openAi = new OpenAi();
@@ -63,7 +64,15 @@ public class RedisOMAiProperties {
     return ollama;
   }
 
-  // Transformer properties
+    public int getEmbeddingBatchSize() {
+        return embeddingBatchSize;
+    }
+
+    public void setEmbeddingBatchSize(int embeddingBatchSize) {
+        this.embeddingBatchSize = embeddingBatchSize;
+    }
+
+    // Transformer properties
   public static class Transformers {
     private String tokenizerResource;
     private String modelResource;
@@ -87,7 +96,6 @@ public class RedisOMAiProperties {
     }
   }
 
-  // DJL properties
   public static class Djl {
     private static final String DEFAULT_ENGINE = "PyTorch";
     // image embedding settings

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -185,6 +185,8 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
     List<S> saved = new ArrayList<>();
     List<Object> entityIds = new ArrayList<>();
 
+    embedder.processEntities(entities);
+
     try (Jedis jedis = modulesOperations.client().getJedis().get()) {
       Pipeline pipeline = jedis.pipelined();
       Gson gson = gsonBuilder.create();
@@ -209,7 +211,6 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
 
         // process entity pre-save mutation
         auditor.processEntity(entity, isNew);
-        embedder.processEntity(entity);
 
         Optional<Long> maybeTtl = getTTLForEntity(entity);
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
@@ -360,6 +360,8 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
     Assert.notNull(entities, "The given Iterable of entities must not be null!");
     List<S> saved = new ArrayList<>();
 
+    embedder.processEntities(entities);
+
     try (Jedis jedis = modulesOperations.client().getJedis().get()) {
       Pipeline pipeline = jedis.pipelined();
 
@@ -380,7 +382,6 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
 
         // process entity pre-save mutation
         auditor.processEntity(entity, isNew);
-        embedder.processEntity(entity);
 
         RedisData rdo = new RedisData();
         mappingConverter.write(entity, rdo);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
@@ -245,7 +245,7 @@ public class DefaultEmbedder implements Embedder {
       return;
     }
 
-    int batchSize = 100; // TODO Replace with a propoerty
+    int batchSize = properties.getEmbeddingBatchSize();
     List<FieldData> batch = new ArrayList<>(batchSize);
 
     for (Object item : items) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
@@ -25,9 +25,7 @@ import org.springframework.ai.bedrock.titan.BedrockTitanEmbeddingModel;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi;
 import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingModel;
 import org.springframework.ai.document.MetadataMode;
-import org.springframework.ai.embedding.Embedding;
 import org.springframework.ai.embedding.EmbeddingModel;
-import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.ollama.OllamaEmbeddingModel;
 import org.springframework.ai.ollama.api.OllamaApi;
@@ -209,28 +207,19 @@ public class DefaultEmbedder implements Embedder {
   }
 
   private List<byte[]> getEmbeddingsAsByteArrayFor(List<String> texts, EmbeddingModel model) {
-    EmbeddingResponse embeddingResponse = model.embedForResponse(texts);
-    List<Embedding> embeddings = embeddingResponse.getResults();
-
-    return embeddings.stream().map(e -> ObjectUtils.floatArrayToByteArray(e.getOutput())).toList();
+    return model.embed(texts).stream().map(ObjectUtils::floatArrayToByteArray).toList();
   }
 
   private List<float[]> getEmbeddingAsFloatArrayFor(List<String> texts, EmbeddingModel model) {
-    EmbeddingResponse embeddingResponse = model.embedForResponse(texts);
-    List<Embedding> embeddings = embeddingResponse.getResults();
-    return embeddings.stream().map(Embedding::getOutput).toList();
+    return model.embed(texts);
   }
 
   private byte[] getEmbeddingsAsByteArrayFor(String text, EmbeddingModel model) {
-    EmbeddingResponse embeddingResponse = model.embedForResponse(List.of(text));
-    Embedding embedding = embeddingResponse.getResult();
-    return ObjectUtils.floatArrayToByteArray(embedding.getOutput());
+    return ObjectUtils.floatArrayToByteArray(model.embed(text));
   }
 
   private float[] getEmbeddingAsFloatArrayFor(String text, EmbeddingModel model) {
-    EmbeddingResponse embeddingResponse = model.embedForResponse(List.of(text));
-    Embedding embedding = embeddingResponse.getResult();
-    return embedding.getOutput();
+    return model.embed(text);
   }
 
   @Override
@@ -238,6 +227,7 @@ public class DefaultEmbedder implements Embedder {
     if (!isReady()) {
       return;
     }
+
     List<Field> fields = ObjectUtils.getFieldsWithAnnotation(item.getClass(), Vectorize.class);
     if (!fields.isEmpty()) {
       PropertyAccessor accessor = PropertyAccessorFactory.forBeanPropertyAccess(item);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
@@ -377,7 +377,7 @@ public class DefaultEmbedder implements Embedder {
     fieldDataList.stream().collect(Collectors.groupingBy(it -> it.vectorize().provider()))
             .forEach((provider, groupedFieldDataList) -> {
               switch (provider) {
-                case TRANSFORMERS -> processDjlSentenceEmbedding(groupedFieldDataList);
+                case TRANSFORMERS -> processSentenceEmbedding(groupedFieldDataList, this::getTransformersEmbeddingModel);
                 case DJL -> {
                 }
                 case OPENAI -> processSentenceEmbedding(groupedFieldDataList, this::getOpenAiEmbeddingModel);
@@ -403,24 +403,6 @@ public class DefaultEmbedder implements Embedder {
       case AMAZON_BEDROCK_COHERE -> processSentenceEmbedding(accessor, vectorize, fieldValue, isDocument, this::getBedrockCohereEmbeddingModel);
       case AMAZON_BEDROCK_TITAN -> processSentenceEmbedding(accessor, vectorize, fieldValue, isDocument, this::getBedrockTitanEmbeddingModel);
     }
-  }
-
-  private void processDjlSentenceEmbedding(List<FieldData> fieldDataList) {
-    fieldDataList.stream()
-            .collect(Collectors.groupingBy(FieldData::isDocument))
-            .forEach((isDocument, groupedByIsDocument) ->
-                    groupedByIsDocument.stream()
-                            .collect(Collectors.groupingBy(FieldData::vectorize))
-                            .forEach((vectorize, groupedByVectorize) -> {
-                              List<?> embeddings = isDocument
-                                      ? getSentenceEmbeddingAsFloats(mapValues(groupedByVectorize), vectorize)
-                                      : getSentenceEmbeddingAsBytes(mapValues(groupedByVectorize), vectorize);
-
-                              if (embeddings != null) {
-                                applyEmbeddings(groupedByVectorize, embeddings, vectorize);
-                              }
-                            })
-            );
   }
 
   private List<String> mapValues(List<FieldData> fieldDataList) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/Embedder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/Embedder.java
@@ -9,6 +9,8 @@ public interface Embedder {
 
   void processEntity(Object item);
 
+  <S> void processEntities(Iterable<S> items);
+
   boolean isReady();
 
   List<byte[]> getTextEmbeddingsAsBytes(List<String> texts, Field field);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/NoopEmbedder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/NoopEmbedder.java
@@ -13,6 +13,11 @@ public class NoopEmbedder implements Embedder {
   }
 
   @Override
+  public <S> void processEntities(Iterable<S> items) {
+    // NOOP
+  }
+
+  @Override
   public boolean isReady() {
     return false;
   }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.junit.jupiter.EnabledIf;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -35,50 +36,50 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
   void loadTestData() throws IOException {
     if (repository.count() == 0) {
       repository.save(Product.of("cat", "classpath:/images/cat.jpg",
-          "The cat (Felis catus) is a domestic species of small carnivorous mammal."));
+              "The cat (Felis catus) is a domestic species of small carnivorous mammal."));
       repository.save(Product.of("cat2", "classpath:/images/cat2.jpg",
-          "It is the only domesticated species in the family Felidae and is commonly referred to as the domestic cat or house cat"));
+              "It is the only domesticated species in the family Felidae and is commonly referred to as the domestic cat or house cat"));
       repository.save(
-          Product.of("catdog", "classpath:/images/catdog.jpg", "This is a picture of a cat and a dog together"));
+              Product.of("catdog", "classpath:/images/catdog.jpg", "This is a picture of a cat and a dog together. And this sentence is just making the whole text longer."));
       repository.save(
-          Product.of("face", "classpath:/images/face.jpg", "Three years later, the coffin was still full of Jello."));
+              Product.of("face", "classpath:/images/face.jpg", "Three years later, the coffin was still full of Jello. And this sentence is just making the whole text longer."));
       repository.save(Product.of("face2", "classpath:/images/face2.jpg",
-          "The person box was packed with jelly many dozens of months later."));
+              "The person box was packed with jelly many dozens of months later. And this sentence is just making the whole text longer."));
     }
   }
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
-      loadContext = true //
-      )
+          expression = "#{@featureExtractor.isReady()}", //
+          loadContext = true //
+  )
   void testImageIsVectorized() {
     Optional<Product> cat = repository.findFirstByName("cat");
     assertAll( //
-        () -> assertThat(cat).isPresent(), //
-        () -> assertThat(cat.get()).extracting("imageEmbedding").isNotNull(), //
-        () -> assertThat(cat.get().getImageEmbedding()).hasSize(512));
+            () -> assertThat(cat).isPresent(), //
+            () -> assertThat(cat.get()).extracting("imageEmbedding").isNotNull(), //
+            () -> assertThat(cat.get().getImageEmbedding()).hasSize(512));
   }
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
-      loadContext = true //
-      )
+          expression = "#{@featureExtractor.isReady()}", //
+          loadContext = true //
+  )
   void testSentenceIsVectorized() {
     Optional<Product> cat = repository.findFirstByName("cat");
     assertAll( //
-        () -> assertThat(cat).isPresent(), //
-        () -> assertThat(cat.get()).extracting("sentenceEmbedding").isNotNull(), //
-        () -> assertThat(cat.get().getSentenceEmbedding()).hasSize(384)
+            () -> assertThat(cat).isPresent(), //
+            () -> assertThat(cat.get()).extracting("sentenceEmbedding").isNotNull(), //
+            () -> assertThat(cat.get().getSentenceEmbedding()).hasSize(384)
     );
   }
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
-      loadContext = true //
-      )
+          expression = "#{@featureExtractor.isReady()}", //
+          loadContext = true //
+  )
   void testKnnImageSimilaritySearch() {
     Product cat = repository.findFirstByName("cat").get();
     int K = 5;
@@ -86,21 +87,21 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
     SearchStream<Product> stream = entityStream.of(Product.class);
 
     List<Product> results = stream //
-        .filter(Product$.IMAGE_EMBEDDING.knn(K, cat.getImageEmbedding())) //
-        .sorted(Product$._IMAGE_EMBEDDING_SCORE) //
-        .limit(K) //
-        .collect(Collectors.toList());
+            .filter(Product$.IMAGE_EMBEDDING.knn(K, cat.getImageEmbedding())) //
+            .sorted(Product$._IMAGE_EMBEDDING_SCORE) //
+            .limit(K) //
+            .collect(Collectors.toList());
 
     assertThat(results).hasSize(5).map(Product::getName).containsExactly( //
-        "cat", "cat2", "catdog", "face", "face2" //
+            "cat", "cat2", "catdog", "face", "face2" //
     );
   }
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
-      loadContext = true //
-      )
+          expression = "#{@featureExtractor.isReady()}", //
+          loadContext = true //
+  )
   void testKnnSentenceSimilaritySearch() {
     Product cat = repository.findFirstByName("cat").get();
     int K = 5;
@@ -108,21 +109,21 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
     SearchStream<Product> stream = entityStream.of(Product.class);
 
     List<Product> results = stream //
-        .filter(Product$.SENTENCE_EMBEDDING.knn(K, cat.getSentenceEmbedding())) //
-        .sorted(Product$._SENTENCE_EMBEDDING_SCORE) //
-        .limit(K) //
-        .collect(Collectors.toList());
+            .filter(Product$.SENTENCE_EMBEDDING.knn(K, cat.getSentenceEmbedding())) //
+            .sorted(Product$._SENTENCE_EMBEDDING_SCORE) //
+            .limit(K) //
+            .collect(Collectors.toList());
 
     assertThat(results).hasSize(5).map(Product::getName).containsExactly( //
-        "cat", "cat2", "catdog", "face", "face2" //
+            "cat", "cat2", "catdog", "face", "face2" //
     );
   }
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
-      loadContext = true //
-      )
+          expression = "#{@featureExtractor.isReady()}", //
+          loadContext = true //
+  )
   void testKnnHybridSentenceSimilaritySearch() {
     Product cat = repository.findFirstByName("cat").get();
     int K = 5;
@@ -130,22 +131,22 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
     SearchStream<Product> stream = entityStream.of(Product.class);
 
     List<Product> results = stream //
-        .filter(Product$.NAME.startsWith("cat")) //
-        .filter(Product$.SENTENCE_EMBEDDING.knn(K, cat.getSentenceEmbedding())) //
-        .sorted(Product$._SENTENCE_EMBEDDING_SCORE) //
-        .limit(K) //
-        .collect(Collectors.toList());
+            .filter(Product$.NAME.startsWith("cat")) //
+            .filter(Product$.SENTENCE_EMBEDDING.knn(K, cat.getSentenceEmbedding())) //
+            .sorted(Product$._SENTENCE_EMBEDDING_SCORE) //
+            .limit(K) //
+            .collect(Collectors.toList());
 
     assertThat(results).hasSize(3).map(Product::getName).containsExactly( //
-        "cat", "cat2", "catdog" //
+            "cat", "cat2", "catdog" //
     );
   }
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
-      loadContext = true //
-      )
+          expression = "#{@featureExtractor.isReady()}", //
+          loadContext = true //
+  )
   void testKnnSentenceSimilaritySearchWithScores() {
     Product cat = repository.findFirstByName("cat").get();
     int K = 5;
@@ -153,23 +154,23 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
     SearchStream<Product> stream = entityStream.of(Product.class);
 
     List<Pair<Product, Double>> results = stream //
-        .filter(Product$.SENTENCE_EMBEDDING.knn(K, cat.getSentenceEmbedding())) //
-        .sorted(Product$._SENTENCE_EMBEDDING_SCORE) //
-        .limit(K) //
-        .map(Fields.of(Product$._THIS, Product$._SENTENCE_EMBEDDING_SCORE)) //
-        .collect(Collectors.toList());
+            .filter(Product$.SENTENCE_EMBEDDING.knn(K, cat.getSentenceEmbedding())) //
+            .sorted(Product$._SENTENCE_EMBEDDING_SCORE) //
+            .limit(K) //
+            .map(Fields.of(Product$._THIS, Product$._SENTENCE_EMBEDDING_SCORE)) //
+            .collect(Collectors.toList());
 
     assertAll( //
-        () -> assertThat(results).hasSize(5).map(Pair::getFirst).map(Product::getName)
-            .containsExactly("cat", "cat2", "catdog", "face", "face2") //
+            () -> assertThat(results).hasSize(5).map(Pair::getFirst).map(Product::getName)
+                    .containsExactly("cat", "cat2", "catdog", "face", "face2") //
     );
   }
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
-      loadContext = true //
-      )
+          expression = "#{@featureExtractor.isReady()}", //
+          loadContext = true //
+  )
   void testEmbedderCanVectorizeSentence() {
     Optional<Product> maybeCat = repository.findFirstByName("cat");
     assertThat(maybeCat).isPresent();
@@ -177,7 +178,42 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
     var catEmbedding = cat.getSentenceEmbedding();
     List<float[]> embeddings = embedder.getTextEmbeddingsAsFloats(List.of(cat.getDescription()), Product$.DESCRIPTION);
     assertAll( //
-        () -> assertThat(embeddings).isNotEmpty(), //
-        () -> assertThat(embeddings.get(0)).isEqualTo(catEmbedding));
+            () -> assertThat(embeddings).isNotEmpty(), //
+            () -> assertThat(embeddings.get(0)).isEqualTo(catEmbedding));
+  }
+
+  @Test
+  @EnabledIf(
+          expression = "#{@featureExtractor.isReady()}", //
+          loadContext = true //
+  )
+  void testBulkEmbedMapEmbeddingsCorrectly() {
+    List<Product> saveAllEntities = repository.saveAll(List.of(
+                    Product.of("cat-saveAll", "classpath:/images/cat.jpg",
+                            "The cat (Felis catus) is a domestic species of small carnivorous mammal."),
+                    Product.of("cat2-saveAll", "classpath:/images/cat2.jpg",
+                            "It is the only domesticated species in the family Felidae and is commonly referred to as the domestic cat or house cat"),
+                    Product.of("catdog-saveAll", "classpath:/images/catdog.jpg", "This is a picture of a cat and a dog together. And this sentence is just making the whole text longer."),
+                    Product.of("face-saveAll", "classpath:/images/face.jpg", "Three years later, the coffin was still full of Jello. And this sentence is just making the whole text longer."),
+                    Product.of("face2-saveAll", "classpath:/images/face2.jpg", "The person box was packed with jelly many dozens of months later. And this sentence is just making the whole text longer.")
+            )
+    );
+
+    saveAllEntities.forEach(saveAllEntity -> {
+      Optional<Product> cat = repository.findFirstByName(saveAllEntity.getName().replace("-saveAll", ""));
+      Optional<Product> catSaveAll = repository.findFirstByName(saveAllEntity.getName());
+
+      assertAll( //
+              () -> assertThat(cat).isPresent(), //
+              () -> assertThat(cat.get().getSentenceEmbedding())
+                      .withFailMessage("Sentence embeddings aren't the same for: " + saveAllEntity.getName() + " and " + cat.get().getName() + "\n" +
+                              "Embedding 1: " + Arrays.toString(catSaveAll.get().getSentenceEmbedding()) + "\n" +
+                              "Embedding 2: " + Arrays.toString(cat.get().getSentenceEmbedding()))
+                      .isEqualTo(saveAllEntity.getSentenceEmbedding()),
+              () -> assertThat(cat.get().getImageEmbedding())
+                      .withFailMessage("Image embeddings aren't the same for: " + saveAllEntity.getName() + " and " + cat.get().getName())
+                      .isEqualTo(saveAllEntity.getImageEmbedding())
+      );
+    });
   }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
@@ -33,7 +33,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
   Embedder embedder;
 
   @BeforeEach
-  void loadTestData() throws IOException {
+  void loadTestData() {
     if (repository.count() == 0) {
       repository.save(Product.of("cat", "classpath:/images/cat.jpg",
               "The cat (Felis catus) is a domestic species of small carnivorous mammal."));
@@ -215,5 +215,6 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
                       .isEqualTo(saveAllEntity.getImageEmbedding())
       );
     });
+    repository.deleteAll();
   }
 }

--- a/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/vectorize/VectorizeHashTest.java
+++ b/redis-om-spring/src/test/java/com/redis/om/spring/annotations/hash/vectorize/VectorizeHashTest.java
@@ -215,5 +215,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
                       .isEqualTo(saveAllEntity.getImageEmbedding())
       );
     });
+
+    repository.deleteAll();
   }
 }


### PR DESCRIPTION
Work In Progress

Within saveAll methods (SimpleRedisEnhancedRepository & SimpleRedisDocumentRepository): 
- Calling new processEntities() before iterating through all entities. 

processEntities():
- Based on processEntity()
- Uses embedding functions to create embeddings in bulks 
- Remap created embeddings into the original entity list (destination field)

Methods for creating bulk embeddings already existed for sentence embeddings, but had to be created for image and face embeddings. 

DefaultEmbedder: 
- Cleaned up

Tests: 
- To test embeddings are created and mapped correctly, I use the existing Vectorize Test classes and compare the embeddings of the saveAll method with the embeddings of the save method. 

Will create benchmarks to compare bulk embedding with original implementation.