### PR TITLE
test: add test cases for boolean and datetime query methods

### DIFF
--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/Doc5.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/Doc5.java
@@ -1,0 +1,59 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import org.springframework.data.annotation.Id;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Document
+public class Doc5 {
+    @Id
+    private String id;
+
+    @Indexed
+    private int age;
+
+    @Indexed
+    private LocalDateTime registrationDate;
+
+    @Indexed
+    private Boolean isActive;
+
+    public Doc5() {
+        this.id = UUID.randomUUID().toString();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public LocalDateTime getRegistrationDate() {
+        return registrationDate;
+    }
+
+    public void setRegistrationDate(LocalDateTime registrationDate) {
+        this.registrationDate = registrationDate;
+    }
+
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/Doc5Repository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/Doc5Repository.java
@@ -1,0 +1,13 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import com.redis.om.spring.fixtures.document.model.Doc5;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface Doc5Repository extends RedisDocumentRepository<Doc5, String> {
+    List<Doc5> findByRegistrationDateBetween(LocalDateTime from, LocalDateTime to);
+    List<Doc5> findByIsActive(boolean active);
+    List<Doc5> findByAge(int age);
+}


### PR DESCRIPTION
Add test cases to verify that findByIsActive and findByRegistrationDateBetween query methods work correctly with indexed Boolean and LocalDateTime fields.

  - Add Doc5 model with indexed Boolean and LocalDateTime fields
  - Add Doc5Repository with query methods
  - Add test methods to RepositoryIssuesTest for these query types