### PR TITLE
Ability to set read timeout for OpenAI Embedding Model Rest Client + design proposal

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisAiConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisAiConfiguration.java
@@ -14,34 +14,15 @@ import ai.djl.repository.zoo.ModelZoo;
 import ai.djl.repository.zoo.ZooModel;
 import ai.djl.translate.Pipeline;
 import ai.djl.translate.Translator;
-import com.azure.ai.openai.OpenAIClient;
-import com.azure.ai.openai.OpenAIClientBuilder;
-import com.azure.core.credential.AzureKeyCredential;
 import com.redis.om.spring.vectorize.DefaultEmbedder;
 import com.redis.om.spring.vectorize.Embedder;
+import com.redis.om.spring.vectorize.EmbeddingModelFactory;
+import com.redis.om.spring.vectorize.SpringAiProperties;
 import com.redis.om.spring.vectorize.face.FaceDetectionTranslator;
 import com.redis.om.spring.vectorize.face.FaceFeatureTranslator;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.springframework.ai.bedrock.cohere.BedrockCohereEmbeddingModel;
-import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi;
-import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi.CohereEmbeddingModel;
-import org.springframework.ai.bedrock.titan.BedrockTitanEmbeddingModel;
-import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi;
-import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi.TitanEmbeddingModel;
-import org.springframework.ai.document.MetadataMode;
-import org.springframework.ai.model.ModelOptionsUtils;
-import org.springframework.ai.openai.OpenAiEmbeddingModel;
-import org.springframework.ai.openai.OpenAiEmbeddingOptions;
-import org.springframework.ai.openai.api.OpenAiApi;
-import org.springframework.ai.retry.RetryUtils;
-import org.springframework.ai.transformers.TransformersEmbeddingModel;
-import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingConnectionDetails;
-import org.springframework.ai.vertexai.embedding.text.VertexAiTextEmbeddingModel;
-import org.springframework.ai.vertexai.embedding.text.VertexAiTextEmbeddingOptions;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationContext;
@@ -49,15 +30,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.lang.Nullable;
-import org.springframework.util.StringUtils;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
 
 import java.io.IOException;
 import java.net.InetAddress;
-import java.time.Duration;
 import java.util.Map;
 
 @ConditionalOnProperty(name = "redis.om.spring.ai.enabled")
@@ -66,6 +41,13 @@ import java.util.Map;
 public class RedisAiConfiguration {
 
   private static final Log logger = LogFactory.getLog(RedisAiConfiguration.class);
+
+  @Bean
+  public EmbeddingModelFactory embeddingModelFactory(
+          RedisOMAiProperties properties,
+          SpringAiProperties springAiProperties) {
+    return new EmbeddingModelFactory(properties, springAiProperties);
+  }
 
   @Bean(name = "djlImageFactory")
   public ImageFactory imageFactory() {
@@ -183,292 +165,6 @@ public class RedisAiConfiguration {
     }
   }
 
-  @Bean(name = "transformersEmbeddingModel")
-  public TransformersEmbeddingModel transformersEmbeddingModel(RedisOMAiProperties properties) {
-    TransformersEmbeddingModel embeddingModel = new TransformersEmbeddingModel();
-    if (properties.getTransformers().getTokenizerResource() != null) {
-      embeddingModel.setTokenizerResource(properties.getTransformers().getTokenizerResource());
-    }
-
-    if (properties.getTransformers().getModelResource() != null) {
-      embeddingModel.setModelResource(properties.getTransformers().getModelResource());
-    }
-
-    if (properties.getTransformers().getResourceCacheDirectory() != null) {
-      embeddingModel.setResourceCacheDirectory(properties.getTransformers().getResourceCacheDirectory());
-    }
-
-    if (!properties.getTransformers().getTokenizerOptions().isEmpty()) {
-      embeddingModel.setTokenizerOptions(properties.getTransformers().getTokenizerOptions());
-    }
-
-    return embeddingModel;
-  }
-
-  @ConditionalOnMissingBean
-  @Bean
-  public OpenAiEmbeddingModel openAITextVectorizer(RedisOMAiProperties properties,
-      @Value("${spring.ai.openai.api-key:}") String apiKey) {
-    if (!StringUtils.hasText(apiKey)) {
-      apiKey = properties.getOpenAi().getApiKey();
-      if (!StringUtils.hasText(apiKey)) {
-        // Fallback to environment variable
-        apiKey = System.getenv("OPENAI_API_KEY");
-
-        if (!StringUtils.hasText(apiKey)) {
-          // Fallback to system property
-          apiKey = System.getProperty("SPRING_AI_OPENAI_API_KEY");
-        }
-      }
-    }
-
-    if (StringUtils.hasText(apiKey)) {
-      properties.getOpenAi().setApiKey(apiKey);
-    }
-
-    if (StringUtils.hasText(apiKey)) {
-      var openAiApi = new OpenAiApi(apiKey);
-
-      // Rest of the configuration
-      return new OpenAiEmbeddingModel(openAiApi, MetadataMode.EMBED,
-          OpenAiEmbeddingOptions.builder().model("text-embedding-ada-002").build(),
-          RetryUtils.DEFAULT_RETRY_TEMPLATE);
-    } else {
-      return null;
-    }
-  }
-
-  @ConditionalOnMissingBean
-  @Bean
-  public OpenAIClient azureOpenAIClient(RedisOMAiProperties properties, //
-      @Value("${spring.ai.azure.openai.api-key:}") String apiKey,
-      @Value("${spring.ai.azure.openai.endpoint:}") String endpoint) {
-    if (!StringUtils.hasText(apiKey)) {
-      apiKey = properties.getAzureOpenAi().getApiKey();
-      if (!StringUtils.hasText(apiKey)) {
-        // Fallback to environment variable
-        apiKey = System.getenv("AZURE_OPENAI_API_KEY");
-
-        if (!StringUtils.hasText(apiKey)) {
-          // Fallback to system property
-          apiKey = System.getProperty("SPRING_AI_AZURE_OPENAI_API_KEY");
-        }
-      }
-    }
-
-    if (!StringUtils.hasText(endpoint)) {
-      endpoint = properties.getAzureOpenAi().getEndPoint();
-      if (!StringUtils.hasText(apiKey)) {
-        // Fallback to environment variable
-        endpoint = System.getenv("AZURE_OPENAI_ENDPOINT");
-
-        if (!StringUtils.hasText(apiKey)) {
-          // Fallback to system property
-          endpoint = System.getProperty("SPRING_AI_AZURE_OPENAI_ENDPOINT");
-        }
-      }
-    }
-
-    if (StringUtils.hasText(apiKey) && StringUtils.hasText(endpoint)) {
-      return new OpenAIClientBuilder().credential(new AzureKeyCredential(apiKey)).endpoint(endpoint).buildClient();
-    } else {
-      return null;
-    }
-  }
-
-  @ConditionalOnMissingBean
-  @Bean
-  VertexAiTextEmbeddingModel vertexAiEmbeddingModel(RedisOMAiProperties properties, //
-      @Value("${spring.ai.vertex.ai.api-key:}") String apiKey,
-      @Value("${spring.ai.vertex.ai.ai.base-url:}") String baseUrl) {
-    if (!StringUtils.hasText(apiKey)) {
-      apiKey = properties.getVertexAi().getApiKey();
-      if (!StringUtils.hasText(apiKey)) {
-        // Fallback to environment variable
-        apiKey = System.getenv("VERTEX_AI_API_KEY");
-
-        if (!StringUtils.hasText(apiKey)) {
-          // Fallback to system property
-          apiKey = System.getProperty("SPRING_AI_VERTEX_AI_API_KEY");
-        }
-      }
-    }
-
-    if (!StringUtils.hasText(baseUrl)) {
-      baseUrl = properties.getVertexAi().getEndPoint();
-      if (!StringUtils.hasText(apiKey)) {
-        // Fallback to environment variable
-        baseUrl = System.getenv("VERTEX_AI_ENDPOINT");
-
-        if (!StringUtils.hasText(apiKey)) {
-          // Fallback to system property
-          baseUrl = System.getProperty("SPRING_AI_VERTEX_AI_ENDPOINT");
-        }
-      }
-    }
-
-    if (StringUtils.hasText(apiKey) && StringUtils.hasText(baseUrl)) {
-
-      VertexAiEmbeddingConnectionDetails connectionDetails = VertexAiEmbeddingConnectionDetails.builder()
-          .projectId(System.getenv("VERTEX_AI_GEMINI_PROJECT_ID")).location(System.getenv("VERTEX_AI_GEMINI_LOCATION"))
-          .build();
-
-      VertexAiTextEmbeddingOptions options = VertexAiTextEmbeddingOptions.builder()
-          .model(VertexAiTextEmbeddingOptions.DEFAULT_MODEL_NAME).build();
-
-      return new VertexAiTextEmbeddingModel(connectionDetails, options);
-    } else {
-      return null;
-    }
-  }
-
-  @ConditionalOnMissingBean
-  @Bean
-  BedrockCohereEmbeddingModel bedrockCohereEmbeddingModel(RedisOMAiProperties properties, //
-      @Value("${spring.ai.bedrock.aws.region:}") String region,
-      @Value("${spring.ai.bedrock.aws.access-key:}") String accessKey,
-      @Value("${spring.ai.bedrock.aws.secret-key:}") String secretKey,
-      @Value("${spring.ai.bedrock.cohere.embedding.model:}") String model) {
-    if (!StringUtils.hasText(region)) {
-      region = properties.getBedrockCohere().getRegion();
-      if (!StringUtils.hasText(region)) {
-        // Fallback to environment variable
-        region = System.getenv("AWS_REGION");
-
-        if (!StringUtils.hasText(region)) {
-          // Fallback to system property
-          region = System.getProperty("SPRING_AI_AWS_REGION");
-        }
-        properties.getBedrockCohere().setRegion(region);
-      }
-    }
-    if (!StringUtils.hasText(secretKey)) {
-      region = Region.US_EAST_1.id();
-    }
-
-    if (!StringUtils.hasText(accessKey)) {
-      accessKey = properties.getBedrockCohere().getAccessKey();
-      if (!StringUtils.hasText(accessKey)) {
-        // Fallback to environment variable
-        accessKey = System.getenv("AWS_ACCESS_KEY_ID");
-
-        if (!StringUtils.hasText(accessKey)) {
-          // Fallback to system property
-          accessKey = System.getProperty("SPRING_AI_AWS_ACCESS_KEY_ID");
-        }
-
-        properties.getBedrockCohere().setAccessKey(accessKey);
-      }
-    }
-
-    if (!StringUtils.hasText(secretKey)) {
-      secretKey = properties.getBedrockCohere().getSecretKey();
-      if (!StringUtils.hasText(secretKey)) {
-        // Fallback to environment variable
-        secretKey = System.getenv("AWS_SECRET_ACCESS_KEY");
-
-        if (!StringUtils.hasText(secretKey)) {
-          // Fallback to system property
-          secretKey = System.getProperty("SPRING_AI_AWS_SECRET_ACCESS_KEY");
-        }
-
-        properties.getBedrockCohere().setSecretKey(secretKey);
-      }
-    }
-
-    if (!StringUtils.hasText(model)) {
-      model = properties.getBedrockCohere().getModel();
-      if (!StringUtils.hasText(model)) {
-        model = CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V3.id();
-        properties.getBedrockCohere().setModel(model);
-      }
-    }
-
-    if (StringUtils.hasText(accessKey) && StringUtils.hasText(secretKey)) {
-      AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
-      var cohereEmbeddingApi = new CohereEmbeddingBedrockApi(model, StaticCredentialsProvider.create(credentials),
-          region, ModelOptionsUtils.OBJECT_MAPPER);
-
-      return new BedrockCohereEmbeddingModel(cohereEmbeddingApi);
-    } else {
-      return null;
-    }
-  }
-
-  @ConditionalOnMissingBean
-  @Bean
-  BedrockTitanEmbeddingModel bedrockTitanEmbeddingModel(RedisOMAiProperties properties, //
-      @Value("${spring.ai.bedrock.aws.region:}") String region,
-      @Value("${spring.ai.bedrock.aws.access-key:}") String accessKey,
-      @Value("${spring.ai.bedrock.aws.secret-key:}") String secretKey,
-      @Value("${spring.ai.bedrock.titan.embedding.model:}") String model) {
-    if (!StringUtils.hasText(region)) {
-      region = properties.getBedrockCohere().getRegion();
-      if (!StringUtils.hasText(region)) {
-        // Fallback to environment variable
-        region = System.getenv("AWS_REGION");
-
-        if (!StringUtils.hasText(region)) {
-          // Fallback to system property
-          region = System.getProperty("SPRING_AI_AWS_REGION");
-        }
-        properties.getBedrockCohere().setRegion(region);
-      }
-    }
-    if (!StringUtils.hasText(secretKey)) {
-      region = Region.US_EAST_1.id();
-    }
-
-    if (!StringUtils.hasText(accessKey)) {
-      accessKey = properties.getBedrockTitan().getAccessKey();
-      if (!StringUtils.hasText(accessKey)) {
-        // Fallback to environment variable
-        accessKey = System.getenv("AWS_ACCESS_KEY_ID");
-
-        if (!StringUtils.hasText(accessKey)) {
-          // Fallback to system property
-          accessKey = System.getProperty("SPRING_AI_AWS_ACCESS_KEY_ID");
-        }
-
-        properties.getBedrockTitan().setAccessKey(accessKey);
-      }
-    }
-
-    if (!StringUtils.hasText(secretKey)) {
-      secretKey = properties.getBedrockTitan().getSecretKey();
-      if (!StringUtils.hasText(secretKey)) {
-        // Fallback to environment variable
-        secretKey = System.getenv("AWS_SECRET_ACCESS_KEY");
-
-        if (!StringUtils.hasText(secretKey)) {
-          // Fallback to system property
-          secretKey = System.getProperty("SPRING_AI_AWS_SECRET_ACCESS_KEY");
-        }
-
-        properties.getBedrockTitan().setSecretKey(secretKey);
-      }
-    }
-
-    if (!StringUtils.hasText(model)) {
-      model = properties.getBedrockTitan().getModel();
-      if (!StringUtils.hasText(model)) {
-        model = TitanEmbeddingModel.TITAN_EMBED_IMAGE_V1.id();
-        properties.getBedrockTitan().setModel(model);
-      }
-    }
-
-    if (StringUtils.hasText(accessKey) && StringUtils.hasText(secretKey)) {
-      AwsCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
-
-      var titanEmbeddingApi = new TitanEmbeddingBedrockApi(model, StaticCredentialsProvider.create(credentials), region,
-          ModelOptionsUtils.OBJECT_MAPPER, Duration.ofMinutes(5L));
-
-      return new BedrockTitanEmbeddingModel(titanEmbeddingApi);
-    } else {
-      return null;
-    }
-  }
-
   @Primary
   @Bean(name = "featureExtractor")
   public Embedder featureExtractor(
@@ -476,15 +172,15 @@ public class RedisAiConfiguration {
       @Nullable @Qualifier("djlFaceEmbeddingModel") ZooModel<Image, float[]> faceEmbeddingModel,
       @Nullable @Qualifier("djlImageFactory") ImageFactory imageFactory,
       @Nullable @Qualifier("djlDefaultImagePipeline") Pipeline defaultImagePipeline,
-      @Nullable @Qualifier("transformersEmbeddingModel") TransformersEmbeddingModel transformersEmbeddingModel,
-      @Nullable OpenAiEmbeddingModel openAITextVectorizer, @Nullable OpenAIClient azureOpenAIClient,
-      @Nullable VertexAiTextEmbeddingModel vertexAiTextEmbeddingModel,
-      @Nullable BedrockCohereEmbeddingModel bedrockCohereEmbeddingModel,
-      @Nullable BedrockTitanEmbeddingModel bedrockTitanEmbeddingModel,
       RedisOMAiProperties properties,
+      EmbeddingModelFactory embeddingModelFactory,
       ApplicationContext ac) {
-    return new DefaultEmbedder(ac, imageEmbeddingModel, faceEmbeddingModel, imageFactory, defaultImagePipeline,
-        transformersEmbeddingModel, openAITextVectorizer, azureOpenAIClient, vertexAiTextEmbeddingModel,
-            bedrockCohereEmbeddingModel, bedrockTitanEmbeddingModel, properties);
+    return new DefaultEmbedder(ac,
+        embeddingModelFactory,
+        imageEmbeddingModel,
+        faceEmbeddingModel,
+        imageFactory,
+        defaultImagePipeline,
+        properties);
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisOMAiProperties.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisOMAiProperties.java
@@ -1,12 +1,8 @@
 package com.redis.om.spring;
 
 import jakarta.validation.constraints.NotNull;
-import org.springframework.ai.openai.api.OpenAiApi.EmbeddingModel;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @ConditionalOnProperty(name = "redis.om.spring.ai.enabled")
 @ConfigurationProperties(
@@ -16,12 +12,10 @@ public class RedisOMAiProperties {
   private boolean enabled = false;
   private int embeddingBatchSize = 1000;
   private final Djl djl = new Djl();
-  private final Transformers transformers = new Transformers();
   private final OpenAi openAi = new OpenAi();
   private final AzureOpenAi azureOpenAi = new AzureOpenAi();
   private final VertexAi vertexAi = new VertexAi();
-  private final BedrockCohere bedrockCohere = new BedrockCohere();
-  private final BedrockTitan bedrockTitan = new BedrockTitan();
+  private final Aws aws = new Aws();
   private final Ollama ollama = new Ollama();
 
   public boolean isEnabled() {
@@ -36,10 +30,6 @@ public class RedisOMAiProperties {
     return djl;
   }
 
-  public Transformers getTransformers() {
-    return transformers;
-  }
-
   public OpenAi getOpenAi() {
     return openAi;
   }
@@ -52,48 +42,20 @@ public class RedisOMAiProperties {
     return vertexAi;
   }
 
-  public BedrockCohere getBedrockCohere() {
-    return bedrockCohere;
-  }
-
-  public BedrockTitan getBedrockTitan() {
-    return bedrockTitan;
+  public Aws getAws() {
+      return aws;
   }
 
   public Ollama getOllama() {
     return ollama;
   }
 
-    public int getEmbeddingBatchSize() {
-        return embeddingBatchSize;
-    }
+  public int getEmbeddingBatchSize() {
+      return embeddingBatchSize;
+  }
 
-    public void setEmbeddingBatchSize(int embeddingBatchSize) {
-        this.embeddingBatchSize = embeddingBatchSize;
-    }
-
-    // Transformer properties
-  public static class Transformers {
-    private String tokenizerResource;
-    private String modelResource;
-    private String resourceCacheDirectory;
-    private Map<String, String> tokenizerOptions = new HashMap<>();
-
-    public String getTokenizerResource() {
-      return tokenizerResource;
-    }
-
-    public String getModelResource() {
-      return modelResource;
-    }
-
-    public String getResourceCacheDirectory() {
-      return resourceCacheDirectory;
-    }
-
-    public Map<String, String> getTokenizerOptions() {
-      return tokenizerOptions;
-    }
+  public void setEmbeddingBatchSize(int embeddingBatchSize) {
+      this.embeddingBatchSize = embeddingBatchSize;
   }
 
   public static class Djl {
@@ -254,7 +216,7 @@ public class RedisOMAiProperties {
 
   public static class OpenAi {
     private String apiKey;
-    private String model = EmbeddingModel.TEXT_EMBEDDING_ADA_002.getValue();
+    private long responseTimeOut = 60;
 
     public String getApiKey() {
       return apiKey;
@@ -264,12 +226,12 @@ public class RedisOMAiProperties {
       this.apiKey = apiKey;
     }
 
-    public String getModel() {
-      return model;
+    public long getResponseTimeOut() {
+        return responseTimeOut;
     }
 
-    public void setModel(String model) {
-      this.model = model;
+    public void setResponseTimeOut(long responseTimeOut) {
+        this.responseTimeOut = responseTimeOut;
     }
   }
 
@@ -287,8 +249,7 @@ public class RedisOMAiProperties {
 
   public static class AzureOpenAi {
     private String apiKey;
-    private String endPoint;
-    private String model;
+    private String endpoint;
 
     public String getApiKey() {
       return apiKey;
@@ -298,27 +259,18 @@ public class RedisOMAiProperties {
       this.apiKey = apiKey;
     }
 
-    public String getEndPoint() {
-      return endPoint;
+    public String getEndpoint() {
+      return endpoint;
     }
 
-    public void setEndPoint(String endPoint) {
-      this.endPoint = endPoint;
-    }
-
-    public String getModel() {
-      return model;
-    }
-
-    public void setModel(String model) {
-      this.model = model;
+    public void setEndpoint(String endpoint) {
+      this.endpoint = endpoint;
     }
   }
 
   public static class VertexAi {
     private String apiKey;
-    private String endPoint;
-    private String model;
+    private String endpoint;
     private String projectId;
     private String location;
 
@@ -346,28 +298,21 @@ public class RedisOMAiProperties {
       this.apiKey = apiKey;
     }
 
-    public String getEndPoint() {
-      return endPoint;
+    public String getEndpoint() {
+      return endpoint;
     }
 
-    public void setEndPoint(String endPoint) {
-      this.endPoint = endPoint;
-    }
-
-    public String getModel() {
-      return model;
-    }
-
-    public void setModel(String model) {
-      this.model = model;
+    public void setEndpoint(String endpoint) {
+      this.endpoint = endpoint;
     }
   }
 
-  public static class BedrockCohere {
+  public static class Aws {
     private String region;
     private String accessKey;
     private String secretKey;
-    private String model;
+    private BedrockCohere bedrockCohere = new BedrockCohere();
+    private BedrockTitan bedrockTitan = new BedrockTitan();
 
     public String getRegion() {
       return region;
@@ -393,52 +338,44 @@ public class RedisOMAiProperties {
       this.secretKey = secretKey;
     }
 
-    public String getModel() {
-      return model;
+    public BedrockCohere getBedrockCohere() {
+        return bedrockCohere;
     }
 
-    public void setModel(String model) {
-      this.model = model;
-    }
-  }
-
-  public static class BedrockTitan {
-    private String region;
-    private String accessKey;
-    private String secretKey;
-    private String model;
-
-    public String getRegion() {
-      return region;
+    public void setBedrockCohere(BedrockCohere bedrockCohere) {
+        this.bedrockCohere = bedrockCohere;
     }
 
-    public void setRegion(String region) {
-      this.region = region;
+    public BedrockTitan getBedrockTitan() {
+        return bedrockTitan;
     }
 
-    public String getAccessKey() {
-      return accessKey;
+    public void setBedrockTitan(BedrockTitan bedrockTitan) {
+        this.bedrockTitan = bedrockTitan;
     }
 
-    public void setAccessKey(String accessKey) {
-      this.accessKey = accessKey;
+    public static class BedrockCohere {
+      private int responseTimeOut = 60;
+
+      public int getResponseTimeOut() {
+        return responseTimeOut;
+      }
+
+      public void setResponseTimeOut(int responseTimeOut) {
+        this.responseTimeOut = responseTimeOut;
+      }
     }
 
-    public String getSecretKey() {
-      return secretKey;
-    }
+    public static class BedrockTitan {
+      private long responseTimeOut = 300;
 
-    public void setSecretKey(String secretKey) {
-      this.secretKey = secretKey;
-    }
+      public long getResponseTimeOut() {
+        return responseTimeOut;
+      }
 
-    public String getModel() {
-      return model;
-    }
-
-    public void setModel(String model) {
-      this.model = model;
+      public void setResponseTimeOut(long responseTimeOut) {
+        this.responseTimeOut = responseTimeOut;
+      }
     }
   }
-
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Vectorize.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Vectorize.java
@@ -17,13 +17,21 @@ public @interface Vectorize {
 
   EmbeddingProvider provider() default EmbeddingProvider.TRANSFORMERS;
 
+  String transformersModel() default "";
+
+  String transformersTokenizer() default "";
+
+  String transformersResourceCacheConfiguration() default "";
+
+  String[] transformersTokenizerOptions() default {};
+
   EmbeddingModel openAiEmbeddingModel() default EmbeddingModel.TEXT_EMBEDDING_ADA_002;
 
   OllamaModel ollamaEmbeddingModel() default OllamaModel.MISTRAL;
 
   String azureOpenAiDeploymentName() default "text-embedding-ada-002";
 
-  String vertexAiPaLm2ApiModel() default "text-embedding-004";
+  String vertexAiApiModel() default "text-embedding-004";
 
   CohereEmbeddingModel cohereEmbeddingModel() default CohereEmbeddingModel.COHERE_EMBED_MULTILINGUAL_V3;
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/EmbeddingModelFactory.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/EmbeddingModelFactory.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class EmbeddingModelFactory {
-
     private final RedisOMAiProperties properties;
     private final SpringAiProperties springAiProperties;
 
@@ -67,6 +66,12 @@ public class EmbeddingModelFactory {
                     .map(entry -> entry.split("=", 2))
                     .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));
             embeddingModel.setTokenizerOptions(options);
+        }
+
+        try {
+            embeddingModel.afterPropertiesSet();
+        } catch (Exception e) {
+            throw new RuntimeException("Error initializing TransformersEmbeddingModel", e);
         }
 
         return embeddingModel;

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/EmbeddingModelFactory.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/EmbeddingModelFactory.java
@@ -1,0 +1,248 @@
+package com.redis.om.spring.vectorize;
+
+import com.azure.ai.openai.OpenAIClient;
+import com.azure.ai.openai.OpenAIClientBuilder;
+import com.azure.core.credential.AzureKeyCredential;
+import com.redis.om.spring.RedisOMAiProperties;
+import com.redis.om.spring.annotations.Vectorize;
+import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingModel;
+import org.springframework.ai.azure.openai.AzureOpenAiEmbeddingOptions;
+import org.springframework.ai.bedrock.cohere.BedrockCohereEmbeddingModel;
+import org.springframework.ai.bedrock.cohere.api.CohereEmbeddingBedrockApi;
+import org.springframework.ai.bedrock.titan.BedrockTitanEmbeddingModel;
+import org.springframework.ai.bedrock.titan.api.TitanEmbeddingBedrockApi;
+import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.model.ModelOptionsUtils;
+import org.springframework.ai.ollama.OllamaEmbeddingModel;
+import org.springframework.ai.ollama.api.OllamaApi;
+import org.springframework.ai.ollama.api.OllamaOptions;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.ai.openai.api.OpenAiApi.EmbeddingModel;
+import org.springframework.ai.retry.RetryUtils;
+import org.springframework.ai.transformers.TransformersEmbeddingModel;
+import org.springframework.ai.vertexai.embedding.VertexAiEmbeddingConnectionDetails;
+import org.springframework.ai.vertexai.embedding.text.VertexAiTextEmbeddingModel;
+import org.springframework.ai.vertexai.embedding.text.VertexAiTextEmbeddingOptions;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EmbeddingModelFactory {
+
+    private final RedisOMAiProperties properties;
+    private final SpringAiProperties springAiProperties;
+
+    public EmbeddingModelFactory(RedisOMAiProperties properties, SpringAiProperties springAiProperties) {
+        this.properties = properties;
+        this.springAiProperties = springAiProperties;
+    }
+
+    public TransformersEmbeddingModel createTransformersEmbeddingModel(Vectorize vectorize) {
+        TransformersEmbeddingModel embeddingModel = new TransformersEmbeddingModel();
+
+        if (!vectorize.transformersModel().isEmpty()) {
+            embeddingModel.setModelResource(vectorize.transformersModel());
+        }
+
+        if (!vectorize.transformersTokenizer().isEmpty()) {
+            embeddingModel.setTokenizerResource(vectorize.transformersTokenizer());
+        }
+
+        if (!vectorize.transformersResourceCacheConfiguration().isEmpty()) {
+            embeddingModel.setResourceCacheDirectory(vectorize.transformersResourceCacheConfiguration());
+        }
+
+        if (vectorize.transformersTokenizerOptions().length > 0) {
+            Map<String, String> options = Arrays.stream(vectorize.transformersTokenizerOptions())
+                    .map(entry -> entry.split("=", 2))
+                    .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));
+            embeddingModel.setTokenizerOptions(options);
+        }
+
+        return embeddingModel;
+    }
+
+    public OpenAiEmbeddingModel createOpenAiEmbeddingModel(EmbeddingModel model) {
+        return createOpenAiEmbeddingModel(model.value);
+    }
+
+    public OpenAiEmbeddingModel createOpenAiEmbeddingModel(String model) {
+        String apiKey = properties.getOpenAi().getApiKey();
+        if (!StringUtils.hasText(apiKey)) {
+            apiKey = springAiProperties.getOpenai().getApiKey();
+            properties.getOpenAi().setApiKey(apiKey);
+        }
+
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setReadTimeout(Duration.ofSeconds(properties.getOpenAi().getResponseTimeOut()));
+
+        OpenAiApi openAiApi = OpenAiApi.builder()
+                .apiKey(properties.getOpenAi().getApiKey())
+                .restClientBuilder(RestClient.builder().requestFactory(factory))
+                .build();
+
+        return new OpenAiEmbeddingModel(
+                openAiApi,
+                MetadataMode.EMBED,
+                OpenAiEmbeddingOptions.builder()
+                        .model(model)
+                        .build(),
+                RetryUtils.DEFAULT_RETRY_TEMPLATE
+        );
+    }
+
+    public AzureOpenAiEmbeddingModel createAzureOpenAiEmbeddingModel(String deploymentName) {
+        String apiKey = properties.getAzureOpenAi().getApiKey();
+        if (!StringUtils.hasText(apiKey)) {
+            apiKey = springAiProperties.getAzure().getApiKey(); // Fallback to Spring AI property
+            properties.getAzureOpenAi().setApiKey(apiKey);
+        }
+
+        String endpoint = properties.getAzureOpenAi().getEndpoint();
+        if (!StringUtils.hasText(endpoint)) {
+            endpoint = springAiProperties.getAzure().getEndpoint(); // Fallback to Spring AI property
+            properties.getAzureOpenAi().setEndpoint(endpoint);
+        }
+
+        OpenAIClient openAIClientBuilder = new OpenAIClientBuilder()
+                .credential(new AzureKeyCredential(properties.getAzureOpenAi().getApiKey()))
+                .endpoint(properties.getAzureOpenAi().getEndpoint())
+                .buildClient();
+
+        AzureOpenAiEmbeddingOptions options = AzureOpenAiEmbeddingOptions.builder()
+                .deploymentName(deploymentName)
+                .build();
+
+        return new AzureOpenAiEmbeddingModel(openAIClientBuilder, MetadataMode.EMBED, options);
+    }
+
+    public VertexAiTextEmbeddingModel createVertexAiTextEmbeddingModel(String model) {
+        String apiKey = properties.getVertexAi().getApiKey();
+        if (!StringUtils.hasText(apiKey)) {
+            apiKey = springAiProperties.getVertexAi().getApiKey(); // Fallback to Spring AI property
+            if (!StringUtils.hasText(apiKey)) {
+                apiKey = System.getenv("VERTEX_AI_API_KEY"); // Fallback to environment variable
+
+                if (!StringUtils.hasText(apiKey)) {
+                    apiKey = System.getProperty("SPRING_AI_VERTEX_AI_API_KEY"); // Fallback to system property
+                }
+            }
+            properties.getVertexAi().setApiKey(apiKey);
+        }
+
+        String baseUrl = properties.getVertexAi().getEndpoint();
+        if (!StringUtils.hasText(baseUrl)) {
+            baseUrl = springAiProperties.getVertexAi().getEndpoint();
+            properties.getVertexAi().setEndpoint(baseUrl);
+        }
+
+        String projectId = properties.getVertexAi().getProjectId();
+        if (!StringUtils.hasText(projectId)) {
+            projectId = springAiProperties.getVertexAi().getProjectId(); // Fallback to Spring AI property
+            properties.getVertexAi().setProjectId(projectId);
+        }
+
+        String location = properties.getVertexAi().getLocation();
+        if (!StringUtils.hasText(location)) {
+            location = springAiProperties.getVertexAi().getLocation(); // Fallback to Spring AI property
+            properties.getVertexAi().setLocation(location);
+        }
+
+        VertexAiEmbeddingConnectionDetails connectionDetails = VertexAiEmbeddingConnectionDetails.builder()
+                .projectId(properties.getVertexAi().getProjectId())
+                .location(properties.getVertexAi().getLocation())
+                .apiEndpoint(properties.getVertexAi().getEndpoint())
+                .build();
+
+        VertexAiTextEmbeddingOptions options = VertexAiTextEmbeddingOptions.builder()
+                .model(model)
+                .build();
+
+        return new VertexAiTextEmbeddingModel(connectionDetails, options);
+    }
+
+    public OllamaEmbeddingModel createOllamaEmbeddingModel(String model) {
+        OllamaApi api = new OllamaApi(properties.getOllama().getBaseUrl());
+
+        OllamaOptions options = OllamaOptions.builder()
+                .model(model)
+                .truncate(false)
+                .build();
+
+        return OllamaEmbeddingModel.builder()
+                .ollamaApi(api)
+                .defaultOptions(options)
+                .build();
+    }
+
+    private AwsCredentials getAwsCredentials() {
+        String accessKey = properties.getAws().getAccessKey();
+        if (!StringUtils.hasText(accessKey)) {
+            accessKey = springAiProperties.getBedrock().getAws().getAccessKey(); // Fallback to Spring AI property
+            properties.getAws().setAccessKey(accessKey);
+        }
+
+        String secretKet = properties.getAws().getSecretKey();
+        if (!StringUtils.hasText(secretKet)) {
+            secretKet = springAiProperties.getBedrock().getAws().getSecretKey(); // Fallback to Spring AI property
+            properties.getAws().setSecretKey(secretKet);
+        }
+
+        String region = properties.getAws().getRegion();
+        if (!StringUtils.hasText(region)) {
+            region = springAiProperties.getBedrock().getAws().getRegion(); // Fallback to Spring AI property
+            properties.getAws().setRegion(region);
+        }
+
+        return AwsBasicCredentials.create(
+                properties.getAws().getAccessKey(),
+                properties.getAws().getSecretKey()
+        );
+    }
+
+    public BedrockCohereEmbeddingModel createCohereEmbeddingModel(String model) {
+        String region = properties.getAws().getRegion();
+        if (!StringUtils.hasText(region)) {
+            region = springAiProperties.getBedrock().getAws().getRegion(); // Fallback to Spring AI property
+            properties.getAws().setRegion(region);
+        }
+
+        var cohereEmbeddingApi = new CohereEmbeddingBedrockApi(
+                model,
+                StaticCredentialsProvider.create(getAwsCredentials()),
+                properties.getAws().getRegion(),
+                ModelOptionsUtils.OBJECT_MAPPER,
+                Duration.ofMinutes(properties.getAws().getBedrockCohere().getResponseTimeOut())
+        );
+
+        return new BedrockCohereEmbeddingModel(cohereEmbeddingApi);
+    }
+
+    public BedrockTitanEmbeddingModel createTitanEmbeddingModel(String model) {
+        String region = properties.getAws().getRegion();
+        if (!StringUtils.hasText(region)) {
+            region = springAiProperties.getBedrock().getAws().getRegion(); // Fallback to Spring AI property
+            properties.getAws().setRegion(region);
+        }
+
+        var titanEmbeddingApi = new TitanEmbeddingBedrockApi(
+                model,
+                StaticCredentialsProvider.create(getAwsCredentials()),
+                properties.getAws().getRegion(),
+                ModelOptionsUtils.OBJECT_MAPPER,
+                Duration.ofMinutes(properties.getAws().getBedrockTitan().getResponseTimeOut())
+        );
+
+        return new BedrockTitanEmbeddingModel(titanEmbeddingApi);
+    }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/SpringAiProperties.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/SpringAiProperties.java
@@ -1,0 +1,283 @@
+package com.redis.om.spring.vectorize;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+
+@ConditionalOnProperty(name = "redis.om.spring.ai.enabled")
+@ConfigurationProperties(prefix = "spring.ai")
+public class SpringAiProperties {
+
+  private OpenAi openai = new OpenAi();
+  private AzureOpenAi azure = new AzureOpenAi();
+  private Vertex vertex = new Vertex();
+  private Bedrock bedrock = new Bedrock();
+  private Transformers transformers = new Transformers();
+
+  public OpenAi getOpenai() {
+      return openai;
+  }
+
+  public void setOpenai(OpenAi openai) {
+      this.openai = openai;
+  }
+
+  public AzureOpenAi getAzure() {
+      return azure;
+  }
+
+  public void setAzure(AzureOpenAi azure) {
+      this.azure = azure;
+  }
+
+  public Vertex.Ai.Gemini getVertexAi() {
+      return vertex.getAi().getGemini();
+  }
+
+  public void setVertex(Vertex vertex) {
+      this.vertex = vertex;
+  }
+
+  public Transformers getTransformers() {
+      return transformers;
+  }
+
+  public void setTransformers(Transformers transformers) {
+      this.transformers = transformers;
+  }
+
+  public Bedrock getBedrock() {
+      return bedrock;
+  }
+
+  public void setBedrock(Bedrock bedrock) {
+      this.bedrock = bedrock;
+  }
+
+  public static class OpenAi {
+  private String apiKey;
+
+  public String getApiKey() {
+    if (!StringUtils.hasText(apiKey)) {
+      apiKey = System.getenv("OPENAI_API_KEY"); // Fallback to environment variable
+
+      if (!StringUtils.hasText(apiKey)) {
+        apiKey = System.getProperty("SPRING_AI_OPENAI_API_KEY");  // Fallback to system property
+      }
+    }
+    return apiKey;
+  }
+
+  public void setApiKey(String apiKey) {
+      this.apiKey = apiKey;
+  }
+}
+
+  public static class AzureOpenAi {
+    private String apiKey;
+    private String endpoint;
+
+      public String getApiKey() {
+        if (!StringUtils.hasText(apiKey)) {
+          apiKey = System.getenv("AZURE_OPENAI_API_KEY"); // Fallback to environment variable
+
+          if (!StringUtils.hasText(apiKey)) {
+            apiKey = System.getProperty("SPRING_AI_AZURE_OPENAI_API_KEY");  // Fallback to system property
+          }
+        }
+        return apiKey;
+      }
+
+      public void setApiKey(String apiKey) {
+          this.apiKey = apiKey;
+      }
+
+      public String getEndpoint() {
+        if (!StringUtils.hasText(apiKey)) {
+          endpoint = System.getenv("AZURE_OPENAI_ENDPOINT"); // Fallback to environment variable
+
+          if (!StringUtils.hasText(endpoint)) {
+            endpoint = System.getProperty("SPRING_AI_AZURE_OPENAI_ENDPOINT");  // Fallback to system property
+          }
+        }
+        return endpoint;
+      }
+
+      public void setEndpoint(String endpoint) {
+          this.endpoint = endpoint;
+      }
+  }
+
+  public static class Vertex {
+    private Ai ai = new Ai();
+
+    public Ai getAi() {
+        return ai;
+    }
+
+    public void setAi(Ai ai) {
+        this.ai = ai;
+    }
+
+    public static class Ai {
+      private Gemini gemini = new Gemini();
+
+      public Gemini getGemini() {
+          return gemini;
+      }
+
+      public void setGemini(Gemini gemini) {
+          this.gemini = gemini;
+      }
+
+      public static class Gemini {
+        private String apiKey;
+        private String endpoint;
+        private String projectId;
+        private String location;
+
+        public String getApiKey() {
+          if (!StringUtils.hasText(apiKey)) {
+            apiKey = System.getenv("VERTEX_AI_API_KEY"); // Fallback to environment variable
+          }
+          return apiKey;
+        }
+
+        public void setApiKey(String apiKey) {
+          this.apiKey = apiKey;
+        }
+
+        public String getEndpoint() {
+          return endpoint;
+        }
+
+        public void setEndpoint(String endpoint) {
+          this.endpoint = endpoint;
+        }
+
+        public String getProjectId() {
+          if (!StringUtils.hasText(projectId)) {
+            projectId = System.getenv("VERTEX_AI_GEMINI_PROJECT_ID");
+          }
+          return projectId;
+        }
+
+        public void setProjectId(String projectId) {
+          this.projectId = projectId;
+        }
+
+        public String getLocation() {
+          if (!StringUtils.hasText(location)) {
+            location = System.getenv("VERTEX_AI_GEMINI_LOCATION");
+          }
+          return location;
+        }
+
+        public void setLocation(String location) {
+          this.location = location;
+        }
+      }
+    }
+  }
+
+  public static class Bedrock {
+    private Aws aws = new Aws();
+
+    public Aws getAws() {
+        return aws;
+    }
+
+    public void setAws(Aws aws) {
+        this.aws = aws;
+    }
+
+    public static class Aws {
+      private String region;
+      private String accessKey;
+      private String secretKey;
+
+      public String getRegion() {
+        if (!StringUtils.hasText(region)) {
+          region = System.getProperty("aws.region");
+          if (!StringUtils.hasText(region)) {
+            region = System.getenv("AWS_REGION");
+          }
+        }
+        return region;
+      }
+
+      public void setRegion(String region) {
+        this.region = region;
+      }
+
+      public String getAccessKey() {
+        if (!StringUtils.hasText(accessKey)) {
+          accessKey = System.getProperty("aws.accessKeyId");
+          if (!StringUtils.hasText(accessKey)) {
+            accessKey = System.getenv("AWS_ACCESS_KEY_ID");
+          }
+        }
+        return accessKey;
+      }
+
+      public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+      }
+
+      public String getSecretKey() {
+        if (!StringUtils.hasText(secretKey)) {
+          secretKey = System.getProperty("aws.secretAccessKey");
+          if (!StringUtils.hasText(secretKey)) {
+            secretKey = System.getenv("AWS_SECRET_ACCESS_KEY");
+          }
+        }
+        return secretKey;
+      }
+
+      public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+      }
+    }
+  }
+
+  public static class Transformers {
+    private String modelResource;
+    private String tokenizerResource;
+    private String resourceCacheDirectory;
+    private Map<String, Object> tokenizerOptions;
+
+    public String getModelResource() {
+        return modelResource;
+    }
+
+    public void setModelResource(String modelResource) {
+        this.modelResource = modelResource;
+    }
+
+    public String getTokenizerResource() {
+        return tokenizerResource;
+    }
+
+    public void setTokenizerResource(String tokenizerResource) {
+        this.tokenizerResource = tokenizerResource;
+    }
+
+    public String getResourceCacheDirectory() {
+        return resourceCacheDirectory;
+    }
+
+    public void setResourceCacheDirectory(String resourceCacheDirectory) {
+        this.resourceCacheDirectory = resourceCacheDirectory;
+    }
+
+    public Map<String, Object> getTokenizerOptions() {
+        return tokenizerOptions;
+    }
+
+    public void setTokenizerOptions(Map<String, Object> tokenizerOptions) {
+        this.tokenizerOptions = tokenizerOptions;
+    }
+  }
+}

--- a/redis-om-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/redis-om-spring/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,4 @@
 # Auto Configure
 com.redis.om.spring.RedisModulesConfiguration
 com.redis.om.spring.RedisAiConfiguration
+com.redis.om.spring.vectorize.SpringAiProperties


### PR DESCRIPTION
- I've been playing with embedding in bulk and constantly facing read timeouts. 
- Default read timeout configured for OpenAI Embedding Model is 10 seconds
- I tried to overwrite the OpenAiEmbeddingModel bean, but find out that it only matters if we're using the default Embedding Model. 
- If using a different embedding model, the DefaultEmbedder bean will create a new OpenAiEmbeddingModel that cannot be overwritten. 

Therefore I suggest: 
- We get rid of the default embedding model beans and replace them with:
- We create an EmbeddingModelFactory where we have the blueprint of what the embedding models should look like. The creation methods receive the model which the created EmbeddingModel will serve. 
- We support specifying the embedding model only through the Vectorize annotation since it will allow us to use different models for different fields.
- Default models are defined in the Vectorize annotation class. 

Besides that, I: 
- Centralized SpringAI properties in a ConfigurationProperties class.
- Corrected Spring AI Environment properties according to latest documentation