### PR TITLE
feat: annotation for count min sketch

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -11,6 +11,7 @@ import com.redis.om.spring.mapping.RedisEnhancedMappingContext;
 import com.redis.om.spring.ops.RedisModulesOperations;
 import com.redis.om.spring.ops.json.JSONOperations;
 import com.redis.om.spring.ops.pds.BloomOperations;
+import com.redis.om.spring.ops.pds.CountMinSketchOperations;
 import com.redis.om.spring.ops.pds.CuckooFilterOperations;
 import com.redis.om.spring.search.stream.EntityStream;
 import com.redis.om.spring.search.stream.EntityStreamImpl;
@@ -123,6 +124,11 @@ public class RedisModulesConfiguration {
   @Bean(name = "redisCuckooOperations")
   CuckooFilterOperations<?> redisCuckooFilterOperations(RedisModulesOperations<?> redisModulesOperations) {
     return redisModulesOperations.opsForCuckoFilter();
+  }
+
+  @Bean(name = "redisCountminOperations")
+  CountMinSketchOperations<?> redisCountMinOperations(RedisModulesOperations<?> redisModulesOperations) {
+    return redisModulesOperations.opsForCountMinSketch();
   }
 
   @Bean(name = "redisOmTemplate")

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/CountMin.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/CountMin.java
@@ -1,0 +1,51 @@
+package com.redis.om.spring.annotations;
+
+import java.lang.annotation.*;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+public @interface CountMin {
+  String name() default "";
+
+  /**
+   * Initialization mode for the Count-min Sketch.
+   * DIMENSIONS: Initialize by width and depth
+   * PROBABILITY: Initialize by error rate and probability
+   */
+  InitMode initMode() default InitMode.PROBABILITY;
+
+  /**
+   * Number of counter in each array. Reduces the error size.
+   * Only used when initMode is DIMENSIONS.
+   */
+  long width() default 0;
+
+  /**
+   * Number of counter-arrays. Reduces the probability for an error of a certain size.
+   * Only used when initMode is DIMENSIONS.
+   */
+  long depth() default 0;
+
+  /**
+   * Estimate size of error. The error is a percent of total counted items.
+   * This affects the width of the sketch.
+   * Only used when initMode is PROBABILITY.
+   */
+  double errorRate() default 0.001;
+
+  /**
+   * The desired probability for inflated count. This should be a decimal value between 0 and 1.
+   * This affects the depth of the sketch.
+   * Only used when initMode is PROBABILITY.
+   */
+  double probability() default 0.99;
+
+  /**
+   * Initialization mode for Count-min Sketch
+   */
+  enum InitMode {
+    DIMENSIONS,
+    PROBABILITY
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/countmin/CountMinAspect.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/countmin/CountMinAspect.java
@@ -1,0 +1,238 @@
+package com.redis.om.spring.countmin;
+
+import com.redis.om.spring.annotations.CountMin;
+import com.redis.om.spring.ops.pds.CountMinSketchOperations;
+import com.redis.om.spring.tuple.Pair;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.core.Ordered;
+import org.springframework.data.keyvalue.repository.KeyValueRepository;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.beans.IntrospectionException;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+
+@Aspect
+@Component
+public class CountMinAspect implements Ordered {
+  private static final Log logger = LogFactory.getLog(CountMinAspect.class);
+  private final CountMinSketchOperations<String> ops;
+  private final StringRedisTemplate stringRedisTemplate;
+
+  public CountMinAspect(CountMinSketchOperations<String> ops, StringRedisTemplate stringRedisTemplate) {
+    this.ops = ops;
+    this.stringRedisTemplate = stringRedisTemplate;
+  }
+
+  @Pointcut("execution(public * org.springframework.data.repository.CrudRepository+.save(..))")
+  public void inCrudRepositorySave() {
+  }
+
+  @Pointcut("execution(public * com.redis.om.spring.repository.RedisDocumentRepository+.save(..))")
+  public void inRedisDocumentRepositorySave() {
+  }
+
+  @Pointcut("inCrudRepositorySave() || inRedisDocumentRepositorySave()")
+  private void inSaveOperation() {
+  }
+
+  @AfterReturning("inSaveOperation() && args(entity,..)")
+  public void addToCountMin(JoinPoint jp, Object entity) {
+    for (Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(entity.getClass())) {
+      if (field.isAnnotationPresent(CountMin.class)) {
+        CountMin countMin = field.getAnnotation(CountMin.class);
+        String sketchName = !ObjectUtils.isEmpty(countMin.name()) ?
+            countMin.name() :
+            String.format("cms:%s:%s", entity.getClass().getSimpleName(), field.getName());
+        
+        try {
+          PropertyDescriptor pd = new PropertyDescriptor(field.getName(), entity.getClass());
+          Object fieldValue = pd.getReadMethod().invoke(entity);
+          
+          if (fieldValue != null) {
+            // Initialize the Count-min Sketch if it doesn't exist
+            initializeCountMinSketch(sketchName, countMin);
+            
+            // Increment the count for the field value
+            if (fieldValue instanceof Pair<?, ?> pair && pair.getFirst() instanceof String && pair.getSecond() instanceof Number) {
+              ops.cmsIncrBy(sketchName, (String) pair.getFirst(), ((Number) pair.getSecond()).longValue());
+            } else if (fieldValue instanceof Iterable<?> iterable) {
+              for (Object item : iterable) {
+                if (item instanceof Pair<?, ?> p && p.getFirst() instanceof String && p.getSecond() instanceof Number) {
+                  ops.cmsIncrBy(sketchName, (String) p.getFirst(), ((Number) p.getSecond()).longValue());
+                } else {
+                  ops.cmsIncrBy(sketchName, item.toString(), 1);
+                }
+              }
+            } else {
+              ops.cmsIncrBy(sketchName, fieldValue.toString(), 1);
+            }
+          }
+        } catch (IllegalArgumentException | IllegalAccessException | IntrospectionException |
+                 InvocationTargetException e) {
+          logger.error(String.format("Could not add value to Count-min Sketch %s", sketchName), e);
+        }
+      }
+    }
+  }
+
+  @Pointcut("execution(public * org.springframework.data.repository.CrudRepository+.saveAll(..))")
+  public void inCrudRepositorySaveAll() {
+  }
+
+  @Pointcut("execution(public * com.redis.om.spring.repository.RedisDocumentRepository+.saveAll(..))")
+  public void inRedisDocumentRepositorySaveAll() {
+  }
+
+  @Pointcut("inCrudRepositorySaveAll() || inRedisDocumentRepositorySaveAll()")
+  private void inSaveAllOperation() {
+  }
+
+  @Pointcut("execution(public * org.springframework.data.repository.CrudRepository+.deleteAll())")
+  public void inCrudRepositoryDeleteAllNoArgs() {}
+
+  @Pointcut("execution(public * com.redis.om.spring.repository.RedisDocumentRepository+.deleteAll())")
+  public void inRedisDocumentRepositoryDeleteAllNoArgs() {}
+
+  @Pointcut("inCrudRepositoryDeleteAllNoArgs() || inRedisDocumentRepositoryDeleteAllNoArgs()")
+  private void inDeleteAllNoArgsOperation() {}
+
+  @AfterReturning("inSaveAllOperation() && args(entities,..)")
+  public void addAllToCountMin(JoinPoint jp, List<Object> entities) {
+    for (Object entity : entities) {
+      for (Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(entity.getClass())) {
+        if (field.isAnnotationPresent(CountMin.class)) {
+          CountMin countMin = field.getAnnotation(CountMin.class);
+          String sketchName = !ObjectUtils.isEmpty(countMin.name()) ?
+              countMin.name() :
+              String.format("cms:%s:%s", entity.getClass().getSimpleName(), field.getName());
+          
+          try {
+            PropertyDescriptor pd = new PropertyDescriptor(field.getName(), entity.getClass());
+            Object fieldValue = pd.getReadMethod().invoke(entity);
+            
+            if (fieldValue != null) {
+              // Initialize the Count-min Sketch if it doesn't exist
+              initializeCountMinSketch(sketchName, countMin);
+              
+              // Increment the count for the field value
+              if (fieldValue instanceof Pair<?, ?> pair && pair.getFirst() instanceof String && pair.getSecond() instanceof Number) {
+                ops.cmsIncrBy(sketchName, (String) pair.getFirst(), ((Number) pair.getSecond()).longValue());
+              } else if (fieldValue instanceof Iterable<?> iterable) {
+                for (Object item : iterable) {
+                  if (item instanceof Pair<?, ?> p && p.getFirst() instanceof String && p.getSecond() instanceof Number) {
+                    ops.cmsIncrBy(sketchName, (String) p.getFirst(), ((Number) p.getSecond()).longValue());
+                  } else {
+                    ops.cmsIncrBy(sketchName, item.toString(), 1);
+                  }
+                }
+              } else {
+                ops.cmsIncrBy(sketchName, fieldValue.toString(), 1);
+              }
+            }
+          } catch (IllegalArgumentException | IllegalAccessException | IntrospectionException |
+                   InvocationTargetException e) {
+            logger.error(String.format("Could not add value to Count-min Sketch %s", sketchName), e);
+          }
+        }
+      }
+    }
+  }
+
+  private void initializeCountMinSketch(String sketchName, CountMin countMin) {
+    try {
+      // Check if the sketch already exists by querying its info
+      ops.cmsInfo(sketchName);
+    } catch (Exception e) {
+      // Sketch doesn't exist, initialize it based on the specified mode
+      if (countMin.initMode() == CountMin.InitMode.DIMENSIONS) {
+        if (countMin.width() > 0 && countMin.depth() > 0) {
+          ops.cmsInitByDim(sketchName, countMin.width(), countMin.depth());
+        } else {
+          logger.error(String.format("Invalid dimensions for Count-min Sketch %s: width=%d, depth=%d", 
+              sketchName, countMin.width(), countMin.depth()));
+        }
+      } else {
+        // Initialize by probability
+        ops.cmsInitByProb(sketchName, countMin.errorRate(), countMin.probability());
+      }
+    }
+  }
+
+  @AfterReturning("inDeleteAllNoArgsOperation()")
+  public void deleteCMSOnDeleteAll(JoinPoint jp) {
+    // Try to infer entity class from repository generics
+    Object target = jp.getTarget();
+
+    Class<?> entityClass = resolveEntityClassFromRepository(target.getClass());
+    if (entityClass == null) {
+      logger.warn("Could not determine entity class for repository: " + target.getClass());
+      return;
+    }
+
+    for (Field field : com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively(entityClass)) {
+      if (field.isAnnotationPresent(CountMin.class)) {
+        CountMin countMin = field.getAnnotation(CountMin.class);
+        String sketchName = !ObjectUtils.isEmpty(countMin.name()) ?
+                countMin.name() :
+                String.format("cms:%s:%s", entityClass.getSimpleName(), field.getName());
+
+        try {
+          stringRedisTemplate.delete(sketchName);
+        } catch (Exception e) {
+          logger.warn(String.format("Failed to delete Count-Min Sketch %s", sketchName), e);
+        }
+      }
+    }
+  }
+
+  private boolean isKeyValueRepositoryInterface(Class<?> clazz) {
+    if (clazz == null) return false;
+    if (clazz == KeyValueRepository.class) return true;
+    for (Class<?> iface : clazz.getInterfaces()) {
+      if (isKeyValueRepositoryInterface(iface)) return true;
+    }
+    return false;
+  }
+
+  private Class<?> resolveEntityClassFromRepository(Class<?> repoClass) {
+    for (Type genericInterface : repoClass.getGenericInterfaces()) {
+      if (genericInterface instanceof ParameterizedType pType) {
+        Type raw = pType.getRawType();
+        if (raw instanceof Class<?> rawClass && isKeyValueRepositoryInterface(rawClass)) {
+          Type[] typeArgs = pType.getActualTypeArguments();
+          if (typeArgs.length > 0 && typeArgs[0] instanceof Class<?> entityClass) {
+            return entityClass;
+          }
+        }
+      } else if (genericInterface instanceof Class<?> rawInterface) {
+        // Look recursively
+        Class<?> found = resolveEntityClassFromRepository(rawInterface);
+        if (found != null) return found;
+      }
+    }
+
+    Class<?> superClass = repoClass.getSuperclass();
+    if (superClass != null && superClass != Object.class) {
+      return resolveEntityClassFromRepository(superClass);
+    }
+
+    return null;
+  }
+
+  @Override
+  public int getOrder() {
+    return 1;
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -12,6 +12,7 @@ import com.redis.om.spring.ops.search.SearchOperations;
 import com.redis.om.spring.repository.query.autocomplete.AutoCompleteQueryExecutor;
 import com.redis.om.spring.repository.query.bloom.BloomQueryExecutor;
 import com.redis.om.spring.repository.query.clause.QueryClause;
+import com.redis.om.spring.repository.query.countmin.CountMinQueryExecutor;
 import com.redis.om.spring.repository.query.cuckoo.CuckooQueryExecutor;
 import com.redis.om.spring.util.ObjectUtils;
 import org.apache.commons.logging.Log;
@@ -70,6 +71,7 @@ public class RediSearchQuery implements RepositoryQuery {
   private final boolean isANDQuery;
   private final BloomQueryExecutor bloomQueryExecutor;
   private final CuckooQueryExecutor cuckooQueryExecutor;
+  private final CountMinQueryExecutor countMinQueryExecutor;
   private final AutoCompleteQueryExecutor autoCompleteQueryExecutor;
   private final GsonBuilder gsonBuilder;
   private final RediSearchIndexer indexer;
@@ -112,6 +114,7 @@ public class RediSearchQuery implements RepositoryQuery {
 
     bloomQueryExecutor = new BloomQueryExecutor(this, modulesOperations);
     cuckooQueryExecutor = new CuckooQueryExecutor(this, modulesOperations);
+    countMinQueryExecutor = new CountMinQueryExecutor(this, modulesOperations);
     autoCompleteQueryExecutor = new AutoCompleteQueryExecutor(this, modulesOperations);
 
     Class<?> repoClass = metadata.getRepositoryInterface();
@@ -380,11 +383,14 @@ public class RediSearchQuery implements RepositoryQuery {
   public Object execute(Object[] parameters) {
     Optional<String> maybeBloomFilter = bloomQueryExecutor.getBloomFilter();
     Optional<String> maybeCuckooFilter = cuckooQueryExecutor.getCuckooFilter();
+    Optional<String> maybeCountMinFilter = countMinQueryExecutor.getCountMinSketch();
 
     if (maybeBloomFilter.isPresent()) {
       return bloomQueryExecutor.executeBloomQuery(parameters, maybeBloomFilter.get());
     } else if (maybeCuckooFilter.isPresent()) {
       return cuckooQueryExecutor.executeCuckooQuery(parameters, maybeCuckooFilter.get());
+    } else if (maybeCountMinFilter.isPresent()) {
+      return countMinQueryExecutor.executeCountMinQuery(parameters, maybeCountMinFilter.get());
     } else if (type == RediSearchQueryType.QUERY) {
       return !isNullParamQuery ? executeQuery(parameters) : executeNullQuery(parameters);
     } else if (type == RediSearchQueryType.AGGREGATION) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/countmin/CountMinQueryExecutor.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/countmin/CountMinQueryExecutor.java
@@ -1,0 +1,71 @@
+package com.redis.om.spring.repository.query.countmin;
+
+import com.redis.om.spring.annotations.CountMin;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.ops.pds.CountMinSketchOperations;
+import com.redis.om.spring.util.ObjectUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.data.repository.query.RepositoryQuery;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
+public class CountMinQueryExecutor {
+
+  public static final String COUNT_BY_PREFIX = "countBy";
+  private static final Log logger = LogFactory.getLog(CountMinQueryExecutor.class);
+  final RepositoryQuery query;
+  final RedisModulesOperations<String> modulesOperations;
+
+  public CountMinQueryExecutor(RepositoryQuery query, RedisModulesOperations<String> modulesOperations) {
+    this.query = query;
+    this.modulesOperations = modulesOperations;
+  }
+
+  public Optional<String> getCountMinSketch() {
+    String methodName = query.getQueryMethod().getName();
+    boolean hasCountByPrefix = methodName.startsWith(COUNT_BY_PREFIX);
+
+    Class<?> returnType = query.getQueryMethod().getReturnedObjectType();
+    boolean isLong = long.class.isAssignableFrom(returnType) || Long.class.isAssignableFrom(returnType);
+
+    if (hasCountByPrefix && isLong) {
+      String targetProperty = ObjectUtils.firstToLowercase(methodName.substring(COUNT_BY_PREFIX.length()));
+      logger.debug(String.format("Target Property : %s", targetProperty));
+      Class<?> entityClass = query.getQueryMethod().getEntityInformation().getJavaType();
+
+      try {
+        Field field = ReflectionUtils.findField(entityClass, targetProperty);
+        if (field == null) {
+          return Optional.empty();
+        }
+        if (field.isAnnotationPresent(CountMin.class)) {
+          CountMin countMin = field.getAnnotation(CountMin.class);
+          return Optional.of(!org.apache.commons.lang3.ObjectUtils.isEmpty(countMin.name()) ?
+                  countMin.name() :
+              String.format("cms:%s:%s", entityClass.getSimpleName(), field.getName()));
+        }
+      } catch (SecurityException e) {
+        // NO-OP
+      }
+    }
+    return Optional.empty();
+  }
+
+  public Object executeCountMinQuery(Object[] parameters, String countMinSketch) {
+    logger.debug(String.format("filter:%s, params:%s", countMinSketch, Arrays.toString(parameters)));
+    CountMinSketchOperations<String> ops = modulesOperations.opsForCountMinSketch();
+    if (parameters[0] instanceof Iterable<?> iterable) {
+      String[] array = StreamSupport
+              .stream(iterable.spliterator(), false)
+              .map(Object::toString)
+              .toArray(String[]::new);
+      return ops.cmsQuery(countMinSketch, array);
+    }
+    return ops.cmsQuery(countMinSketch, parameters[0].toString()).get(0);
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/countmin/CountMinTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/countmin/CountMinTest.java
@@ -1,0 +1,102 @@
+package com.redis.om.spring.annotations.countmin;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.fixtures.hash.model.SearchEvent;
+import com.redis.om.spring.fixtures.hash.repository.SearchEventRepository;
+import com.redis.om.spring.tuple.Tuples;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CountMinTest extends AbstractBaseEnhancedRedisTest {
+
+  @Autowired
+  SearchEventRepository repository;
+
+  @BeforeEach
+  void loadSearchEvents() {
+    SearchEvent event1 = SearchEvent.of("guy.royse@redis.com", "What's cache?", List.of("cache"), List.of(Tuples.of("What's", 1L), Tuples.of("cache", 1L)));
+    SearchEvent event2 = SearchEvent.of("guy.royse@redis.com", "What's new in Redis 8?", List.of("Redis"), List.of(Tuples.of("What's", 1L), Tuples.of("new", 1L), Tuples.of("in", 1L), Tuples.of("Redis", 1L), Tuples.of("8", 1L)));
+    SearchEvent event3 = SearchEvent.of("raphael.delio@redis.com", "Is Redis Search part of Redis 8?", List.of("Redis"), List.of(Tuples.of("Is", 1L), Tuples.of("Redis", 2L), Tuples.of("Search", 1L), Tuples.of("part", 1L), Tuples.of("of", 1L), Tuples.of("8", 1L)));
+    SearchEvent event4 = SearchEvent.of("kyle.banker@redis.com", "Is Redis the fastest vector database?", List.of("database"), List.of(Tuples.of("Is", 1L), Tuples.of("Redis", 1L), Tuples.of("the", 1L), Tuples.of("fastest", 1L), Tuples.of("vector", 1L), Tuples.of("database", 1L)));
+    SearchEvent event5 = SearchEvent.of("brian.sambodden@redis.com", "What's cache?", List.of("cache"), List.of(Tuples.of("What's", 1L), Tuples.of("cache", 1L)));
+
+    List<SearchEvent> persons = List.of(event1, event2, event3, event4, event5);
+
+    repository.saveAll(persons);
+  }
+
+  @AfterEach
+  void clear() {
+      repository.deleteAll();
+  }
+
+  @Test
+  void testCountSingleString() {
+    long count = repository.getUserIdCountCustom("guy.royse@redis.com");
+    assertEquals(2, count);
+
+    long count2 = repository.getUserIdCountCustom("brian.sambodden@redis.com");
+    assertEquals(1, count2);
+
+    // Test non-existent value
+    long count3 = repository.getUserIdCountCustom("salvatore.sanfilippo@redis.com");
+    assertEquals(0, count3);
+  }
+
+  @Test
+  void testCountSingleStringDynamic() {
+    long count = repository.countBySearchSentence("What's cache?");
+    assertEquals(2, count);
+
+    long count2 = repository.countBySearchSentence("What's new in Redis 8?");
+    assertEquals(1, count2);
+
+    List<Long> count3 = repository.countBySearchSentence(List.of("What's cache?", "What's new in Redis 8?"));
+    assertEquals(2, count3.get(0));
+    assertEquals(1, count3.get(1));
+
+    // Test non-existent value
+    long count4 = repository.countBySearchSentence("Was Redis released in 2009?");
+    assertEquals(0, count4);
+  }
+
+  @Test
+  void testCountMultipleString() {
+    long count = repository.countByHotTerms("Redis");
+    assertEquals(2, count);
+
+    long count2 = repository.countByHotTerms("cache");
+    assertEquals(2, count2);
+
+    List<Long> count3 = repository.countByHotTerms(List.of("Redis", "cache"));
+    assertEquals(2, count3.get(0));
+    assertEquals(2, count3.get(1));
+
+    // Test non-existent value
+    long count4 = repository.countByHotTerms("vector");
+    assertEquals(0, count4);
+  }
+
+  @Test
+  void testCountMultiplePair() {
+    long count = repository.countBySearchWord("Redis");
+    assertEquals(4, count);
+
+    long count2 = repository.countBySearchWord("cache");
+    assertEquals(2, count2);
+
+    List<Long> count3 = repository.countBySearchWord(List.of("Redis", "cache"));
+    assertEquals(4, count3.get(0));
+    assertEquals(2, count3.get(1));
+
+    // Test non-existent value
+    long count4 = repository.countBySearchWord("Brazil");
+    assertEquals(0, count4);
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/SearchEvent.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/SearchEvent.java
@@ -1,0 +1,36 @@
+package com.redis.om.spring.fixtures.hash.model;
+
+import com.redis.om.spring.annotations.CountMin;
+import com.redis.om.spring.tuple.Pair;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash("searchEvent")
+public class SearchEvent {
+
+  @Id
+  String id;
+
+  @NonNull
+  @CountMin(name = "cms_user_id_count", initMode = CountMin.InitMode.DIMENSIONS, width = 1000, depth = 10)
+  String userId;
+
+  @NonNull
+  @CountMin
+  String searchSentence;
+
+  @NonNull
+  @CountMin(errorRate = 0.001, probability = 0.999)
+  List<String> hotTerms;
+
+  @NonNull
+  @CountMin(name = "cms_search_words")
+  List<Pair<String, Long>> searchWord;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/SearchEventRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/SearchEventRepository.java
@@ -1,0 +1,22 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import com.redis.om.spring.fixtures.hash.model.SearchEvent;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SearchEventRepository extends RedisEnhancedRepository<SearchEvent, String>, UserIdCount {
+  long countBySearchSentence(String sentence);
+
+  List<Long> countBySearchSentence(List<String> sentences);
+
+  long countByHotTerms(String term);
+
+  List<Long> countByHotTerms(List<String> terms);
+
+  long countBySearchWord(String word);
+
+  List<Long> countBySearchWord(List<String> words);
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/UserIdCount.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/UserIdCount.java
@@ -1,0 +1,5 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+public interface UserIdCount {
+  long getUserIdCountCustom(String userId);
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/UserIdCountImpl.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/UserIdCountImpl.java
@@ -1,0 +1,18 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.ops.pds.CountMinSketchOperations;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@SuppressWarnings("ALL")
+public class UserIdCountImpl implements UserIdCount {
+
+  @Autowired
+  RedisModulesOperations<String> modulesOperations;
+
+  @Override
+  public long getUserIdCountCustom(String userId) {
+    CountMinSketchOperations<String> ops = modulesOperations.opsForCountMinSketch();
+    return ops.cmsQuery("cms_user_id_count", userId).get(0);
+  }
+}


### PR DESCRIPTION
This PR adds support for the Count-min Sketch probabilistic data structure to Redis OM Spring as an annotation, complementing the existing Bloom and Cuckoo filter annotation implementations.

- New @CountMin annotation for entity fields
- Support for two initialization modes:
   - By dimensions (width and depth)
   - By probability (error rate and probability)
- Automatic sketch creation and deletion (when deleteAll is invoked)
- Support for counting single values and collections
- Dynamic repository methods for count queries
- Custom repository implementations for advanced use cases
