### PR TITLE
fix: Trim query string to handle spaces with DIALECT parameter (#579)

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -380,9 +380,11 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
   @Override
   public long count() {
     if (!rootNode.toString().isBlank()) {
-      Query query = new Query(rootNode.toString());
+      // Trim any leading/trailing spaces from the query to avoid syntax errors with DIALECT
+      String queryString = rootNode.toString().trim();
+      Query query = new Query(queryString);
       query.limit(0, 0);
-      query.dialect(Dialect.TWO.getValue());
+      query.dialect(dialect); // Use the configured dialect value
       SearchResult searchResult = search.search(query);
       resolvedStream = Stream.empty();
 

--- a/tests/src/test/java/com/redis/om/spring/search/stream/DialectSpaceFilterTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/DialectSpaceFilterTest.java
@@ -1,0 +1,85 @@
+package com.redis.om.spring.search.stream;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.TestResultRedisModel;
+import com.redis.om.spring.fixtures.document.model.TestResultRedisModel$;
+import com.redis.om.spring.fixtures.document.repository.TestResultRedisRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import redis.clients.jedis.JedisPooled;
+import redis.clients.jedis.UnifiedJedis;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class DialectSpaceFilterTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  TestResultRedisRepository testResultRedisRepository;
+
+  @Autowired
+  JedisConnectionFactory jedisConnectionFactory;
+
+  @Autowired
+  EntityStream es;
+
+  private UnifiedJedis jedis;
+  private static final String TEST_UUID = UUID.randomUUID().toString();
+
+  @BeforeEach
+  void cleanUp() {
+    flushSearchIndexFor(TestResultRedisModel.class);
+
+    if (testResultRedisRepository.count() == 0) {
+      testResultRedisRepository.save(TestResultRedisModel.of(123L, TEST_UUID, "test-file.xml", "REJECTED"));
+      testResultRedisRepository.save(TestResultRedisModel.of(456L, "456-456-456-456-456", "other-file.xml", "ACCEPTED"));
+    }
+
+    jedis = new JedisPooled(Objects.requireNonNull(jedisConnectionFactory.getPoolConfig()),
+        jedisConnectionFactory.getHostName(), jedisConnectionFactory.getPort());
+  }
+
+  /**
+   * This test verifies that count() can handle queries with spaces in filter conditions.
+   * The issue was occurring in v0.9.11 when the DIALECT parameter was added to count queries.
+   */
+  @Test
+  void testCountWithSpaceInFilterQuery() {
+    // This simulates the same issue reported in GitHub issue #579
+    // The filter creates a query with a space which combined with DIALECT 2 produces a syntax error
+    final SearchStream<TestResultRedisModel> searchStream = es.of(TestResultRedisModel.class)
+        .filter(TestResultRedisModel$.UUID.eq(TEST_UUID));
+
+    // The count operation was failing with: Syntax error at offset 16 near mapConfigId
+    assertDoesNotThrow(() -> {
+      long count = searchStream.count();
+      assertThat(count).isEqualTo(1); // Should find one match
+    });
+  }
+
+  /**
+   * This test verifies that the count() method works correctly with multiple filter conditions
+   * and properly handles the spaces between intersection conditions.
+   */
+  @Test
+  void testCountWithMultipleFilterConditions() {
+    // First add another test model with same status but different UUID
+    testResultRedisRepository.save(TestResultRedisModel.of(789L, "another-uuid", "test-file.xml", "REJECTED"));
+
+    // Create a search with multiple conditions (UUID AND status)
+    final SearchStream<TestResultRedisModel> searchStream = es.of(TestResultRedisModel.class)
+        .filter(TestResultRedisModel$.UUID.eq(TEST_UUID))
+        .filter(TestResultRedisModel$.STATUS.eq("REJECTED"));
+
+    // This should return exactly one result that matches both conditions
+    assertDoesNotThrow(() -> {
+      long count = searchStream.count();
+      assertThat(count).isEqualTo(1);
+    });
+  }
+}


### PR DESCRIPTION
- Fixes issue #579 where spaces at the beginning of query strings caused syntax errors
- The fix trims leading/trailing spaces from query strings before adding the DIALECT parameter
- Uses configured dialect value instead of hardcoded value
- Added test cases to verify proper handling of spaces in filter queries