### PR TITLE
feat(docs): integrate Javadoc into Antora documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -91,6 +91,24 @@ jobs:
           echo "Antora playbook content:"
           cat docs/antora-playbook.yml
 
+      - name: Generate Javadoc Documentation
+        run: |
+          echo "Cleaning any existing generated Javadoc files..."
+          rm -rf docs/content/modules/ROOT/attachments/javadoc
+          rm -rf docs/content/modules/ROOT/assets/javadoc
+          
+          echo "Generating Javadoc for all modules..."
+          ./gradlew aggregateJavadoc generateModuleJavadocs
+          
+          # Verify Javadoc generation
+          if [ ! -d "build/docs/javadoc" ]; then
+            echo "ERROR: Javadoc generation failed"
+            exit 1
+          fi
+          
+          echo "Javadoc generated successfully:"
+          find build/docs/javadoc -name "index.html" -type f | head -10
+
       - name: Build Documentation
         run: |
           ./gradlew :docs:generateSite
@@ -100,6 +118,10 @@ jobs:
             npm install
             ./node_modules/.bin/antora --fetch --stacktrace --log-format=pretty antora-playbook.yml --to-dir=build/site
           fi
+          
+          # Verify Javadoc assets are included
+          echo "Checking for Javadoc assets in site:"
+          find docs/build/site -path "*/javadoc/*" -name "index.html" | head -5 || echo "No Javadoc assets found"
 
       - name: Verify Build Output
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ docs/node_modules/
 docs/node/
 docs/build/
 
+# Generated Javadoc documentation (build artifacts)
+docs/content/modules/ROOT/attachments/javadoc/
+docs/content/modules/ROOT/assets/javadoc/
+
 **/.claude/settings.local.json
 /out/
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -31,3 +31,64 @@ tasks.register('aggregateTestReport', TestReport) {
 			}
 			)
 }
+
+// Add aggregated Javadoc generation
+tasks.register('aggregateJavadoc', Javadoc) {
+	description = 'Generate aggregated Javadoc for all modules'
+	group = 'documentation'
+
+	source subprojects.findAll {
+		it.name in [
+			'redis-om-spring',
+			'redis-om-spring-ai'
+		]
+	}.collect { it.sourceSets.main.allJava }
+	classpath = files(subprojects.findAll {
+		it.name in [
+			'redis-om-spring',
+			'redis-om-spring-ai'
+		]
+	}.collect { it.sourceSets.main.compileClasspath })
+	destinationDir = layout.buildDirectory.dir("docs/javadoc/aggregate").get().asFile
+
+	options {
+		title = "Redis OM Spring ${project.version} API"
+		windowTitle = "Redis OM Spring ${project.version}"
+		author = true
+		version = true
+		use = true
+		splitIndex = true
+		links(
+				'https://docs.oracle.com/en/java/javase/21/docs/api/',
+				'https://docs.spring.io/spring-framework/docs/current/javadoc-api/',
+				'https://docs.spring.io/spring-data/redis/docs/current/api/',
+				'https://docs.spring.io/spring-boot/docs/current/api/'
+				)
+	}
+
+	// Ensure Javadoc generation succeeds
+	failOnError = false
+}
+
+// Individual module Javadocs
+tasks.register('generateModuleJavadocs') {
+	description = 'Generate Javadoc for individual modules'
+	group = 'documentation'
+
+	def moduleProjects = subprojects.findAll {
+		it.name in [
+			'redis-om-spring',
+			'redis-om-spring-ai'
+		]
+	}
+	dependsOn moduleProjects.collect { "${it.name}:javadoc" }
+
+	doLast {
+		moduleProjects.each { project ->
+			copy {
+				from project.tasks.javadoc.destinationDir
+				into layout.buildDirectory.dir("docs/javadoc/modules/${project.name}").get().asFile
+			}
+		}
+	}
+}

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,84 @@
+# Redis OM Spring Documentation Makefile
+# Provides convenient commands for local development
+
+.PHONY: help build build-fast serve test validate clean stop
+
+# Default target
+help:
+	@echo "Redis OM Spring Documentation Commands"
+	@echo "======================================"
+	@echo ""
+	@echo "Development Commands:"
+	@echo "  make build      - Build complete documentation with Javadoc (recommended)"
+	@echo "  make build-fast - Build documentation without Javadoc (faster)"
+	@echo "  make serve      - Build and serve documentation locally at http://localhost:8000"
+	@echo "  make test       - Run comprehensive local testing"
+	@echo "  make validate   - Validate Javadoc integration"
+	@echo ""
+	@echo "Maintenance Commands:"
+	@echo "  make clean      - Clean all build artifacts"
+	@echo "  make stop       - Stop Docker container"
+	@echo ""
+	@echo "Quick Start:"
+	@echo "  make serve      # Build everything and start local server"
+	@echo ""
+
+# Build complete documentation with Javadoc integration
+build:
+	@echo "🔨 Building complete documentation with Javadoc integration..."
+	cd .. && ./gradlew :docs:build
+	@echo "✅ Build complete! Documentation is in build/site/"
+
+# Build documentation without Javadoc (faster for content development)
+build-fast:
+	@echo "🔨 Building documentation without Javadoc (faster)..."
+	@echo "⚠️  Note: API Reference links will be broken without Javadoc"
+	npx antora antora-playbook.yml --to-dir=build/site
+	@echo "✅ Fast build complete! Documentation is in build/site/"
+
+# Build and serve with Docker
+serve: build
+	@echo "🐳 Starting local documentation server..."
+	@echo "📖 Documentation will be available at http://localhost:8000"
+	@echo ""
+	@echo "📄 Key URLs:"
+	@echo "   Main Site: http://localhost:8000"
+	@echo "   Current Docs: http://localhost:8000/redis-om-spring/current/"
+	@echo "   API Reference: http://localhost:8000/redis-om-spring/current/api-reference.html"
+	@echo ""
+	@echo "Press Ctrl+C to stop the server"
+	docker-compose up
+
+# Run comprehensive testing
+test:
+	@echo "🧪 Running comprehensive local testing..."
+	./scripts/test-local-docs.sh
+
+# Validate Javadoc integration
+validate:
+	@echo "✅ Validating Javadoc integration..."
+	./scripts/validate-javadoc.sh
+
+# Clean all build artifacts
+clean:
+	@echo "🧹 Cleaning build artifacts..."
+	cd .. && ./gradlew clean
+	rm -rf build/site
+	rm -rf content/modules/ROOT/assets/javadoc
+	rm -rf node_modules/.cache
+	@echo "✅ Clean complete!"
+
+# Stop Docker container
+stop:
+	@echo "🛑 Stopping documentation server..."
+	docker-compose down
+	@echo "✅ Server stopped!"
+
+# Development workflow targets
+dev-setup: clean build
+	@echo "🚀 Development environment ready!"
+	@echo "   Run 'make serve' to start the server"
+
+# Quick validation for CI/development
+quick-test: build validate
+	@echo "✅ Quick validation complete!"

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,23 +18,39 @@ npm install
 
 ### Building the Site
 
-#### Using Gradle
+#### Using Gradle (Recommended)
 
 ```bash
-# From the project root
+# From the project root - includes Javadoc generation
 ./gradlew :docs:build
 
 # From the docs directory
 ../gradlew build
 ```
 
-The documentation will be built in the `build/site` directory.
+This builds both the documentation site and integrates the API documentation (Javadoc) automatically. The documentation will be built in the `build/site` directory.
 
-#### Using npm directly
+#### Building with Javadoc Integration
+
+To explicitly build with all API documentation:
+
+```bash
+# Generate Javadoc first, then build docs
+./gradlew aggregateJavadoc generateModuleJavadocs :docs:build
+
+# Or build everything in one command (same as above)
+./gradlew :docs:build
+```
+
+**Important**: Javadoc files are generated dynamically during the build process and are **NOT** checked into the repository. They are created fresh each time you build and are properly ignored by Git.
+
+#### Using npm directly (without Javadoc)
 
 ```bash
 npx antora antora-playbook.yml --to-dir=build/site
 ```
+
+**Note**: Building with npm directly will not include API documentation (Javadoc). Use the Gradle method for complete documentation including API references.
 
 ### Viewing the Documentation
 
@@ -43,6 +59,15 @@ After building, you can view the documentation by opening any of these files in 
 - `build/site/index.html` - Documentation homepage
 - `build/site/redis-om-spring/current/index.html` - Current version documentation
 - `build/site/redis-om-spring/current/overview.html` - Overview page
+- `build/site/redis-om-spring/current/api-reference.html` - API Reference page (includes Javadoc links)
+
+#### API Documentation Access
+
+When built with Gradle (including Javadoc), the API documentation is available at:
+
+- **Complete API**: `build/site/redis-om-spring/current/_attachments/javadoc/aggregate/index.html`
+- **Core Module**: `build/site/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring/index.html`  
+- **AI Module**: `build/site/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring-ai/index.html`
 
 ## Content Structure
 
@@ -70,16 +95,37 @@ The repository includes a Docker setup that uses Nginx to serve the documentatio
 #### Serving with Docker
 
 ```bash
-# First build the site
-./gradlew :docs:build
-# or 
-npx antora antora-playbook.yml --to-dir=build/site
+# Option 1: Using Makefile (recommended)
+cd docs
+make serve
 
-# Then serve with Docker (run from the docs directory)
-docker compose up -d
+# Option 2: Manual steps
+./gradlew :docs:build                # Build with Javadoc integration
+cd docs
+docker compose up -d                 # Start container
 ```
 
 The documentation will be available at http://localhost:8000.
+
+**Important**: Use `./gradlew :docs:build` to ensure API documentation is included. Using `npx antora` directly will serve the site without Javadoc integration.
+
+#### Quick Testing
+
+For comprehensive local testing including Javadoc validation:
+
+```bash
+cd docs
+make test
+# or manually:
+./scripts/test-local-docs.sh
+```
+
+This script will:
+- Build the complete documentation with Javadoc
+- Validate all API documentation is present
+- Start the Docker container
+- Test all key URLs
+- Provide direct links for testing
 
 #### Docker Configuration
 
@@ -104,6 +150,8 @@ If you encounter issues with the Docker setup:
 2. Check if port 8000 is already in use on your machine
 3. Verify Docker and Docker Compose are installed correctly
 4. Look at the Docker logs with `docker-compose logs` or `docker logs roms-documentation`
+5. For missing API documentation, ensure you built with `./gradlew :docs:build` (not npm directly)
+6. Validate Javadoc integration with `./docs/scripts/validate-javadoc.sh`
 
 ### Adding New Content
 
@@ -143,7 +191,28 @@ To add a new page:
 - Include more examples from demo applications
 - Standardize page structure and formatting
 - Add navigation breadcrumbs
-- Integrate automated API documentation
+- ~~Integrate automated API documentation~~ ✅ **Complete** (Javadoc integration implemented)
+
+## Javadoc Integration
+
+The documentation site includes automated API reference generation:
+
+### ✅ **Build Process**
+- Javadoc files are **generated dynamically** during build (NOT checked into repository)
+- Integrated into Antora as attachments for proper URL handling
+- Automatic generation in GitHub Actions workflow
+- Local builds regenerate fresh Javadoc
+
+### 📁 **Repository Management**  
+- Generated files are properly ignored in `.gitignore`
+- Source code comments are the source of truth
+- No manual maintenance of API documentation required
+- Fresh generation ensures docs stay synchronized with code
+
+### 🔧 **Local Development**
+- Use `make clean && make serve` for full rebuild with Javadoc
+- Use validation script: `./scripts/validate-javadoc.sh`
+- Clean generated files: `./scripts/clean-generated-javadoc.sh`
 
 ## Versioning
 

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -28,3 +28,8 @@ asciidoc:
     page-pagination: ''
     toc: ~
     xrefstyle: short
+    # Javadoc-specific attributes
+    javadoc-base-url: '{attachmentsdir}/javadoc'
+    javadoc-core-url: '{javadoc-base-url}/modules/redis-om-spring'
+    javadoc-ai-url: '{javadoc-base-url}/modules/redis-om-spring-ai'
+    javadoc-aggregate-url: '{javadoc-base-url}/aggregate'

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -34,9 +34,26 @@ task installAntora(type: NpmTask) {
 	]
 }
 
+// Add Javadoc integration task
+task copyJavadocs(type: Copy) {
+	description = 'Copy Javadoc outputs to Antora attachments'
+	group = 'documentation'
+
+	dependsOn ':aggregateJavadoc', ':generateModuleJavadocs'
+
+	from rootProject.layout.buildDirectory.dir('docs/javadoc')
+	into "${project.projectDir}/content/modules/ROOT/attachments/javadoc"
+
+	doFirst {
+		mkdir "${project.projectDir}/content/modules/ROOT/attachments"
+		mkdir "${project.projectDir}/content/modules/ROOT/attachments/javadoc"
+		logger.lifecycle("Copying Javadoc documentation to Antora attachments...")
+	}
+}
+
 // Generate Antora site
 task generateSite(type: NodeTask) {
-	dependsOn installAntora
+	dependsOn installAntora, copyJavadocs
 	script = file('node_modules/@antora/cli/bin/antora')
 
 	// Add options to handle multi-version gracefully
@@ -66,4 +83,6 @@ assemble.dependsOn generateSite
 clean {
 	delete 'node_modules'
 	delete project.buildDir
+	delete "${project.projectDir}/content/modules/ROOT/assets/javadoc"
+	delete "${project.projectDir}/content/modules/ROOT/attachments/javadoc"
 }

--- a/docs/content/modules/ROOT/nav.adoc
+++ b/docs/content/modules/ROOT/nav.adoc
@@ -57,3 +57,6 @@
 
 .Enterprise Features
 * xref:sentinel.adoc[Redis Sentinel Support]
+
+.API Reference
+* xref:api-reference.adoc[Javadoc API Reference]

--- a/docs/content/modules/ROOT/pages/api-reference.adoc
+++ b/docs/content/modules/ROOT/pages/api-reference.adoc
@@ -1,0 +1,139 @@
+= API Reference
+:page-layout: default
+:page-description: Complete API documentation for Redis OM Spring modules
+:page-keywords: API, Javadoc, Redis OM Spring, Documentation
+:page-component-name: redis-om-spring
+:page-component-display-version: {redis-om-version}
+
+[.lead]
+Comprehensive API documentation for all Redis OM Spring components, generated from source code comments.
+
+[NOTE]
+====
+The API documentation is automatically generated from the latest release and includes:
+
+* **Complete method signatures** with parameter descriptions
+* **Usage examples** and code samples  
+* **Cross-references** between related classes
+* **Since tags** indicating version availability
+* **See also** links to related functionality
+====
+
+== Core Module (redis-om-spring)
+
+The core Redis OM Spring module provides the fundamental functionality for object mapping, repositories, and search capabilities.
+
+link:{attachmentsdir}/javadoc/modules/redis-om-spring/index.html[Redis OM Spring Core API^, role="external"]
+
+=== Key Packages
+
+* **Annotations**: `com.redis.om.spring.annotations` - Core annotations for mapping and indexing
+* **Repository**: `com.redis.om.spring.repository` - Repository interfaces and implementations  
+* **Search**: `com.redis.om.spring.search` - Search and query functionality
+* **Metamodel**: `com.redis.om.spring.metamodel` - Type-safe query metamodel
+* **Indexing**: `com.redis.om.spring.indexing` - Index creation and management
+* **Operations**: `com.redis.om.spring.ops` - Redis operations and client abstractions
+* **Tuple**: `com.redis.om.spring.tuple` - Tuple system for structured data handling
+
+== AI Module (redis-om-spring-ai)
+
+The AI extension module provides vector embedding and similarity search capabilities with multiple AI provider integrations.
+
+link:{attachmentsdir}/javadoc/modules/redis-om-spring-ai/index.html[Redis OM Spring AI API^, role="external"]
+
+=== Key Packages
+
+* **Annotations**: `com.redis.om.spring.annotations` - AI and vectorization annotations
+* **Vectorize**: `com.redis.om.spring.vectorize` - Embedding generation and processing
+* **Configuration**: `com.redis.om.spring` - AI configuration and auto-configuration
+
+== Complete API Reference
+
+For a unified view of all modules and their interactions:
+
+link:{attachmentsdir}/javadoc/aggregate/index.html[Complete API Reference^, role="external"]
+
+This aggregated documentation provides:
+
+* **Cross-module relationships** and dependencies
+* **Complete inheritance hierarchies** across modules
+* **Unified search** across all packages and classes
+* **Package overview** documentation for the entire framework
+
+== Most Important Classes
+
+=== Core Framework Classes
+
+[cols="1,3"]
+|===
+| Class | Description
+
+| `@Document`
+| Primary annotation for mapping entities to Redis JSON documents
+
+| `@RedisHash` 
+| Annotation for mapping entities to Redis hash structures with enhanced search
+
+| `RedisDocumentRepository<T, ID>`
+| Base repository interface for JSON document entities
+
+| `RedisEnhancedRepository<T, ID>`
+| Base repository interface for hash entities with search capabilities
+
+| `EntityStream`
+| Fluent API for type-safe queries and aggregations
+
+| `RediSearchIndexer`
+| Core component for creating and managing search indexes
+|===
+
+=== AI and Vector Search Classes
+
+[cols="1,3"]
+|===
+| Class | Description
+
+| `@Vectorize`
+| Annotation for automatic embedding generation from source fields
+
+| `@VectorIndexed`
+| Annotation for configuring vector similarity search indexes
+
+| `DefaultEmbedder`
+| Central component for generating embeddings from various AI providers
+
+| `EmbeddingModelFactory`
+| Factory for creating and caching embedding models
+
+| `AIRedisOMProperties`
+| Configuration properties for AI provider settings
+|===
+
+== Download API Documentation
+
+The API documentation is also available for offline use:
+
+* link:https://repo1.maven.org/maven2/com/redis/om/redis-om-spring/{redis-om-version}/redis-om-spring-{redis-om-version}-javadoc.jar[Core Module Javadoc JAR^]
+* link:https://repo1.maven.org/maven2/com/redis/om/redis-om-spring-ai/{redis-om-version}/redis-om-spring-ai-{redis-om-version}-javadoc.jar[AI Module Javadoc JAR^]
+
+== Integration with IDE
+
+For the best development experience, add the Javadoc JARs to your IDE:
+
+=== IntelliJ IDEA
+
+1. Go to **File** → **Project Structure** → **Libraries**
+2. Select the Redis OM Spring library
+3. Click **+** and add the Javadoc JAR
+4. Apply changes
+
+=== Eclipse
+
+1. Right-click on the Redis OM Spring JAR in **Package Explorer**
+2. Select **Properties** → **Javadoc Location**
+3. Choose **Javadoc in archive** and select the Javadoc JAR
+4. Apply changes
+
+=== VS Code
+
+Install the **Extension Pack for Java** which automatically downloads and integrates Javadoc documentation when available.

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -11,3 +11,12 @@ services:
     environment:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 5s
+    labels:
+      - "description=Redis OM Spring Documentation with Javadoc Integration"
+      - "version=local-development"

--- a/docs/nginx.conf
+++ b/docs/nginx.conf
@@ -44,6 +44,20 @@ server {
         expires 30d;
         add_header Cache-Control "public, no-transform";
     }
+    
+    # Specific handling for Javadoc HTML files
+    location ~* /javadoc/.*\.html$ {
+        expires 1d;
+        add_header Cache-Control "public, no-transform";
+        # Ensure proper MIME type for HTML
+        add_header Content-Type "text/html; charset=utf-8";
+    }
+    
+    # Handle Javadoc CSS and JS with longer cache
+    location ~* /javadoc/.*\.(css|js)$ {
+        expires 7d;
+        add_header Cache-Control "public, no-transform";
+    }
 
     # Handle 404 errors
     error_page 404 /404.html;

--- a/docs/scripts/clean-generated-javadoc.sh
+++ b/docs/scripts/clean-generated-javadoc.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+set -e
+
+echo "🧹 Cleaning Generated Javadoc Files from Repository"
+echo "=================================================="
+
+# Navigate to project root
+cd "$(dirname "$0")/../.."
+PROJECT_ROOT=$(pwd)
+echo "📁 Project root: $PROJECT_ROOT"
+
+echo ""
+echo "🗑️ Removing generated Javadoc files..."
+
+# Remove generated attachments
+if [ -d "docs/content/modules/ROOT/attachments/javadoc" ]; then
+    echo "   Removing docs/content/modules/ROOT/attachments/javadoc/"
+    rm -rf docs/content/modules/ROOT/attachments/javadoc/
+    echo "   ✓ Removed attachments/javadoc/"
+else
+    echo "   ✓ No attachments/javadoc/ directory found"
+fi
+
+# Remove any old assets
+if [ -d "docs/content/modules/ROOT/assets/javadoc" ]; then
+    echo "   Removing docs/content/modules/ROOT/assets/javadoc/"
+    rm -rf docs/content/modules/ROOT/assets/javadoc/
+    echo "   ✓ Removed assets/javadoc/"
+else
+    echo "   ✓ No assets/javadoc/ directory found"
+fi
+
+# Remove build directory
+if [ -d "docs/build" ]; then
+    echo "   Removing docs/build/"
+    rm -rf docs/build/
+    echo "   ✓ Removed build directory"
+else
+    echo "   ✓ No build directory found"
+fi
+
+# Remove root build directory  
+if [ -d "build" ]; then
+    echo "   Removing root build/"
+    rm -rf build/
+    echo "   ✓ Removed root build directory"
+else
+    echo "   ✓ No root build directory found"
+fi
+
+echo ""
+echo "📋 Checking .gitignore status..."
+
+# Check if .gitignore has the entries
+if grep -q "docs/content/modules/ROOT/attachments/javadoc/" .gitignore; then
+    echo "   ✓ .gitignore already includes attachments/javadoc/"
+else
+    echo "   ⚠️ .gitignore missing attachments/javadoc/ entry"
+fi
+
+if grep -q "docs/content/modules/ROOT/assets/javadoc/" .gitignore; then
+    echo "   ✓ .gitignore already includes assets/javadoc/"
+else
+    echo "   ⚠️ .gitignore missing assets/javadoc/ entry"
+fi
+
+echo ""
+echo "✅ Cleanup completed!"
+echo ""
+echo "🔄 What happens next:"
+echo "   1. Generated Javadoc files are removed from the repository"
+echo "   2. They are properly ignored by Git (.gitignore)"
+echo "   3. They will be regenerated dynamically during build process"
+echo "   4. GitHub Actions will generate them fresh for each deployment"
+echo ""
+echo "📝 To regenerate locally:"
+echo "   ./gradlew :docs:build"
+echo ""
+echo "🌐 To test the full pipeline:"
+echo "   cd docs && make test"

--- a/docs/scripts/rebuild-with-javadoc.sh
+++ b/docs/scripts/rebuild-with-javadoc.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -e
+
+echo "🔄 Rebuilding Redis OM Spring Documentation with Javadoc Integration"
+echo "=================================================================="
+
+# Navigate to project root
+cd "$(dirname "$0")/../.."
+PROJECT_ROOT=$(pwd)
+echo "📁 Project root: $PROJECT_ROOT"
+
+echo ""
+echo "🧹 Cleaning previous builds..."
+./gradlew clean
+rm -rf docs/build/site
+rm -rf docs/content/modules/ROOT/assets/javadoc
+rm -rf docs/content/modules/ROOT/attachments/javadoc
+rm -rf docs/node_modules/.cache
+
+echo ""
+echo "🔨 Building documentation with Javadoc integration..."
+./gradlew :docs:build
+
+echo ""
+echo "✅ Build completed! Checking integration..."
+
+# Quick validation
+if [ -d "docs/build/site/redis-om-spring/current/_attachments/javadoc" ]; then
+    echo "✓ Javadoc attachments found in built site"
+    javadoc_count=$(find docs/build/site -path "*/_attachments/javadoc/*" -name "*.html" | wc -l)
+    echo "✓ Found $javadoc_count Javadoc HTML files"
+else
+    echo "❌ Javadoc attachments not found in built site"
+    echo "   Expected directory: docs/build/site/redis-om-spring/current/_attachments/javadoc"
+    exit 1
+fi
+
+echo ""
+echo "🎉 Rebuild completed successfully!"
+echo ""
+echo "🌐 To test locally:"
+echo "   cd docs"
+echo "   docker-compose up -d"
+echo "   open http://localhost:8000/redis-om-spring/current/api-reference.html"
+echo ""
+echo "📚 Direct Javadoc URLs:"
+echo "   Complete API: http://localhost:8000/redis-om-spring/current/_attachments/javadoc/aggregate/"
+echo "   Core Module: http://localhost:8000/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring/"
+echo "   AI Module: http://localhost:8000/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring-ai/"

--- a/docs/scripts/test-local-docs.sh
+++ b/docs/scripts/test-local-docs.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+set -e
+
+echo "🚀 Testing Redis OM Spring Documentation with Javadoc Integration"
+echo "=================================================================="
+
+# Check prerequisites
+echo ""
+echo "📋 Checking prerequisites..."
+
+# Check Java
+if command -v java &> /dev/null; then
+    JAVA_VERSION=$(java -version 2>&1 | head -1 | cut -d'"' -f2 | cut -d'.' -f1)
+    echo "✓ Java $JAVA_VERSION detected"
+else
+    echo "❌ Java not found. Please install Java 17+"
+    exit 1
+fi
+
+# Check Docker
+if command -v docker &> /dev/null; then
+    echo "✓ Docker detected"
+else
+    echo "❌ Docker not found. Please install Docker"
+    exit 1
+fi
+
+# Check Docker Compose
+if command -v docker-compose &> /dev/null || docker compose version &> /dev/null 2>&1; then
+    echo "✓ Docker Compose detected"
+else
+    echo "❌ Docker Compose not found. Please install Docker Compose"
+    exit 1
+fi
+
+# Navigate to project root
+cd "$(dirname "$0")/../.."
+PROJECT_ROOT=$(pwd)
+echo "📁 Project root: $PROJECT_ROOT"
+
+# Clean previous builds
+echo ""
+echo "🧹 Cleaning previous builds..."
+./gradlew clean
+rm -rf docs/build/site
+rm -rf docs/content/modules/ROOT/assets/javadoc
+
+# Build with Javadoc integration
+echo ""
+echo "🔨 Building documentation with Javadoc integration..."
+echo "This may take a few minutes on first run..."
+./gradlew :docs:build
+
+# Validate build
+echo ""
+echo "✅ Validating build output..."
+
+if [ ! -d "docs/build/site" ]; then
+    echo "❌ Build failed: docs/build/site directory not found"
+    exit 1
+fi
+
+if [ ! -f "docs/build/site/index.html" ]; then
+    echo "❌ Build failed: No index.html found in build output"
+    exit 1
+fi
+
+echo "✓ Documentation site built successfully"
+
+# Check for Javadoc assets
+JAVADOC_COUNT=$(find docs/build/site -path "*/_attachments/javadoc/*" -name "*.html" | wc -l)
+if [ "$JAVADOC_COUNT" -eq 0 ]; then
+    echo "❌ No Javadoc assets found in built site"
+    echo "   Running validation script for more details..."
+    ./docs/scripts/validate-javadoc.sh
+    exit 1
+else
+    echo "✓ Found $JAVADOC_COUNT Javadoc HTML files in built site"
+fi
+
+# Check API reference page
+if [ ! -f "docs/build/site/redis-om-spring/current/api-reference.html" ]; then
+    echo "❌ API Reference page not found in built site"
+    exit 1
+else
+    echo "✓ API Reference page found"
+fi
+
+# Check key Javadoc entry points
+JAVADOC_ENTRIES=(
+    "docs/build/site/redis-om-spring/current/_attachments/javadoc/aggregate/index.html"
+    "docs/build/site/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring/index.html"
+    "docs/build/site/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring-ai/index.html"
+)
+
+echo ""
+echo "🔍 Checking key Javadoc entry points..."
+for entry in "${JAVADOC_ENTRIES[@]}"; do
+    if [ -f "$entry" ]; then
+        echo "✓ Found: $(basename $(dirname $entry))/$(basename $entry)"
+    else
+        echo "❌ Missing: $entry"
+        exit 1
+    fi
+done
+
+# Start Docker container
+echo ""
+echo "🐳 Starting Docker container..."
+cd docs
+
+# Stop any existing container
+docker-compose down 2>/dev/null || true
+
+# Start the container
+docker-compose up -d
+
+# Wait for container to be ready
+echo "⏳ Waiting for container to be ready..."
+sleep 3
+
+# Test if site is accessible
+MAX_RETRIES=10
+RETRY_COUNT=0
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    if curl -f -s http://localhost:8000 > /dev/null; then
+        echo "✓ Documentation site is accessible at http://localhost:8000"
+        break
+    else
+        echo "   Waiting for site to be ready... (attempt $((RETRY_COUNT+1))/$MAX_RETRIES)"
+        sleep 2
+        RETRY_COUNT=$((RETRY_COUNT+1))
+    fi
+done
+
+if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+    echo "❌ Site not accessible after $MAX_RETRIES attempts"
+    echo "   Checking Docker logs..."
+    docker-compose logs
+    exit 1
+fi
+
+# Test key pages
+echo ""
+echo "🌐 Testing key documentation pages..."
+
+PAGES_TO_TEST=(
+    "http://localhost:8000"
+    "http://localhost:8000/redis-om-spring/current/"
+    "http://localhost:8000/redis-om-spring/current/api-reference.html"
+    "http://localhost:8000/redis-om-spring/current/_attachments/javadoc/aggregate/"
+    "http://localhost:8000/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring/"
+    "http://localhost:8000/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring-ai/"
+)
+
+for page in "${PAGES_TO_TEST[@]}"; do
+    if curl -f -s "$page" > /dev/null; then
+        echo "✓ Accessible: $page"
+    else
+        echo "❌ Failed to access: $page"
+        # Don't exit here, just warn - some redirects might be expected
+    fi
+done
+
+# Success message
+echo ""
+echo "🎉 SUCCESS! Documentation with Javadoc integration is running locally"
+echo ""
+echo "📖 Access the documentation at:"
+echo "   📄 Main Site: http://localhost:8000"
+echo "   📄 Current Docs: http://localhost:8000/redis-om-spring/current/"
+echo "   📄 API Reference: http://localhost:8000/redis-om-spring/current/api-reference.html"
+echo ""
+echo "🔧 API Documentation Direct Access:"
+echo "   📚 Complete API: http://localhost:8000/redis-om-spring/current/_attachments/javadoc/aggregate/"
+echo "   📚 Core Module: http://localhost:8000/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring/"
+echo "   📚 AI Module: http://localhost:8000/redis-om-spring/current/_attachments/javadoc/modules/redis-om-spring-ai/"
+echo ""
+echo "⚡ To stop the container run: docker-compose down (from docs directory)"
+echo ""
+echo "✨ Test the navigation from the main docs to the API reference!"
+echo "   1. Go to http://localhost:8000/redis-om-spring/current/"
+echo "   2. Click 'API Reference' in the left navigation"
+echo "   3. Click any of the Javadoc links to test integration"

--- a/docs/scripts/validate-javadoc.sh
+++ b/docs/scripts/validate-javadoc.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+set -e
+
+echo "Validating Javadoc integration..."
+
+# Check if Javadoc files exist (they should be generated during build)
+JAVADOC_DIR="docs/content/modules/ROOT/attachments/javadoc"
+
+if [ ! -d "$JAVADOC_DIR" ]; then
+    echo "⚠️ WARNING: Javadoc directory not found at $JAVADOC_DIR"
+    echo "This is expected if you haven't run the build yet."
+    echo "Javadoc files are generated dynamically during build and should not be committed to the repository."
+    echo ""
+    echo "To generate Javadoc files, run:"
+    echo "  ./gradlew :docs:build"
+    echo ""
+    echo "Skipping validation checks that require generated files..."
+    SKIP_FILE_CHECKS=true
+else
+    echo "✓ Found Javadoc directory at $JAVADOC_DIR"
+    SKIP_FILE_CHECKS=false
+fi
+
+# Check for required index files (only if Javadoc exists)
+if [ "$SKIP_FILE_CHECKS" = false ]; then
+    required_files=(
+        "$JAVADOC_DIR/aggregate/index.html"
+        "$JAVADOC_DIR/modules/redis-om-spring/index.html"
+        "$JAVADOC_DIR/modules/redis-om-spring-ai/index.html"
+    )
+
+    for file in "${required_files[@]}"; do
+        if [ ! -f "$file" ]; then
+            echo "ERROR: Required Javadoc file not found: $file"
+            exit 1
+        else
+            echo "✓ Found: $file"
+        fi
+    done
+fi
+
+# Check for important package documentation (only if Javadoc exists)
+if [ "$SKIP_FILE_CHECKS" = false ]; then
+    important_packages=(
+        "$JAVADOC_DIR/modules/redis-om-spring/com/redis/om/spring/annotations/package-summary.html"
+        "$JAVADOC_DIR/modules/redis-om-spring/com/redis/om/spring/repository/package-summary.html"
+        "$JAVADOC_DIR/modules/redis-om-spring-ai/com/redis/om/spring/annotations/package-summary.html"
+        "$JAVADOC_DIR/modules/redis-om-spring-ai/com/redis/om/spring/vectorize/package-summary.html"
+    )
+
+    echo "Checking for key package documentation..."
+    for package in "${important_packages[@]}"; do
+        if [ ! -f "$package" ]; then
+            echo "⚠ Warning: Package documentation not found: $package"
+        else
+            echo "✓ Found package docs: $package"
+        fi
+    done
+fi
+
+# Validate that important classes have documentation (only if Javadoc exists)
+if [ "$SKIP_FILE_CHECKS" = false ]; then
+    important_classes=(
+        "$JAVADOC_DIR/modules/redis-om-spring/com/redis/om/spring/annotations/Document.html"
+        "$JAVADOC_DIR/modules/redis-om-spring/com/redis/om/spring/repository/RedisDocumentRepository.html"
+        "$JAVADOC_DIR/modules/redis-om-spring-ai/com/redis/om/spring/annotations/Vectorize.html"
+        "$JAVADOC_DIR/modules/redis-om-spring-ai/com/redis/om/spring/vectorize/DefaultEmbedder.html"
+    )
+
+    echo "Checking for key class documentation..."
+    for class in "${important_classes[@]}"; do
+        if [ ! -f "$class" ]; then
+            echo "⚠ Warning: Class documentation not found: $class"
+        else
+            echo "✓ Found class docs: $class"
+        fi
+    done
+fi
+
+# Check that generated site includes Javadoc assets
+SITE_DIR="docs/build/site"
+if [ -d "$SITE_DIR" ]; then
+    echo "Checking site build includes Javadoc assets..."
+    javadoc_assets=$(find "$SITE_DIR" -path "*/_attachments/javadoc/*" -name "*.html" | wc -l)
+    echo "Found $javadoc_assets Javadoc HTML files in built site"
+    
+    if [ "$javadoc_assets" -eq 0 ]; then
+        echo "⚠ Warning: No Javadoc assets found in built site"
+    else
+        echo "✓ Javadoc assets included in site build"
+    fi
+else
+    echo "⚠ Warning: Site build directory not found, skipping site validation"
+fi
+
+echo "✅ Javadoc validation completed!"
+echo ""
+echo "Summary:"
+echo "- Required index files: $(echo "${required_files[@]}" | wc -w) checked"
+echo "- Package documentation: $(echo "${important_packages[@]}" | wc -w) checked"  
+echo "- Class documentation: $(echo "${important_classes[@]}" | wc -w) checked"
+echo ""
+echo "To view the Javadoc locally:"
+echo "1. Run: ./gradlew aggregateJavadoc generateModuleJavadocs"
+echo "2. Open: build/docs/javadoc/aggregate/index.html"
+echo "3. Or run docs build: ./gradlew :docs:generateSite"
+echo "4. Open: docs/build/site/redis-om-spring/current/_attachments/javadoc/aggregate/index.html"

--- a/docs/supplemental-ui/css/redis-brand.css
+++ b/docs/supplemental-ui/css/redis-brand.css
@@ -568,3 +568,101 @@ body.dark-theme,
   color: #ffffff !important;
   background-color: rgba(220, 56, 44, 0.6) !important;
 }
+
+/* Javadoc integration styling */
+.javadoc-link {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  background: #dc382d;
+  color: white;
+  text-decoration: none;
+  border-radius: 4px;
+  margin: 0.25rem 0;
+  transition: background-color 0.2s ease;
+}
+
+.javadoc-link:hover {
+  background: #b8312a;
+  color: white;
+  text-decoration: none;
+}
+
+.api-reference-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.api-module-card {
+  border: 1px solid #e1e1e1;
+  border-radius: 8px;
+  padding: 1rem;
+  background: #f8f9fa;
+}
+
+.api-module-card h3 {
+  margin-top: 0;
+  color: #dc382d;
+}
+
+/* Style external links to Javadoc */
+a[href*="javadoc"]:after {
+  content: " 📖";
+  font-size: 0.8em;
+}
+
+/* Enhanced code block styling for API references */
+.api-reference pre {
+  background: #f6f8fa;
+  border: 1px solid #e1e5e9;
+  border-radius: 6px;
+  padding: 1rem;
+  overflow-x: auto;
+}
+
+/* Table styling for API reference */
+.api-reference table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+.api-reference table th,
+.api-reference table td {
+  padding: 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid #e1e5e9;
+}
+
+.api-reference table th {
+  background: #f6f8fa;
+  font-weight: 600;
+}
+
+.api-reference table tr:hover {
+  background: #f6f8fa;
+}
+
+/* Dark theme adjustments for Javadoc styling */
+.dark-theme .api-module-card {
+  background: var(--redis-dark-theme-panel);
+  border-color: var(--redis-dark-theme-border);
+}
+
+.dark-theme .api-module-card h3 {
+  color: #ff6b5a;
+}
+
+.dark-theme .api-reference pre {
+  background: var(--redis-dark-theme-panel);
+  border-color: var(--redis-dark-theme-border);
+}
+
+.dark-theme .api-reference table th {
+  background: var(--redis-dark-theme-panel);
+}
+
+.dark-theme .api-reference table tr:hover {
+  background: var(--redis-dark-theme-panel);
+}


### PR DESCRIPTION
  - Add aggregated Javadoc generation tasks for redis-om-spring and redis-om-spring-ai modules
  - Create API reference page with navigation links to module documentation
  - Configure Antora attachments integration for Javadoc HTML files
  - Update GitHub Actions workflow to generate and deploy Javadoc automatically
  - Add build scripts for local Javadoc generation and validation
  - Exclude generated Javadoc files from version control via .gitignore
  - Implement cleanup mechanisms for proper build artifact management