### PR TITLE
docs: add documentation for numeric array containment search methods

### DIFF
--- a/docs/content/modules/ROOT/pages/entity-streams.adoc
+++ b/docs/content/modules/ROOT/pages/entity-streams.adoc
@@ -91,6 +91,30 @@ List<Company> specificYears = entityStream.of(Company.class)
     .collect(Collectors.toList());
 ----
 
+=== Numeric Array Queries
+
+For numeric array fields (indexed with `@Indexed` or `@NumericIndexed`), you can search for entities where the array contains any of the specified values:
+
+[source,java]
+----
+// Find entities where double array contains any of the specified values
+List<DataAnalysis> highScores = entityStream.of(DataAnalysis.class)
+    .filter(DataAnalysis$.SCORES.containsDouble(85.5, 92.3, 95.0))
+    .collect(Collectors.toList());
+
+// Find entities where long array contains any of the specified values  
+List<Statistics> largeCounts = entityStream.of(Statistics.class)
+    .filter(Statistics$.COUNTS.containsLong(1000L, 5000L, 10000L))
+    .collect(Collectors.toList());
+
+// Find entities where integer array contains any of the specified values
+List<Survey> topRated = entityStream.of(Survey.class)
+    .filter(Survey$.RATINGS.containsInt(4, 5))
+    .collect(Collectors.toList());
+----
+
+NOTE: These methods work similarly to `TagField.in()` but are specifically designed for numeric arrays, providing type-safe array containment searches.
+
 === String Operations
 
 [source,java]

--- a/docs/content/modules/ROOT/pages/index-annotations.adoc
+++ b/docs/content/modules/ROOT/pages/index-annotations.adoc
@@ -221,8 +221,15 @@ public class Company {
     
     @Indexed  // Complex objects in collections
     private Set<Employee> employees;
-}
+    
+    @Indexed  // Numeric arrays support containment searches
+    private List<Double> scores;
+    
+    @Indexed  // Works with primitive arrays too
+    private int[] ratings;
 ----
+
+NOTE: Numeric arrays and collections indexed with `@Indexed` support containment searches using `containsDouble()`, `containsLong()`, and `containsInt()` methods on the generated metamodel fields. See xref:entity-streams.adoc#_numeric_array_queries[Numeric Array Queries] for examples.
 
 == Index Configuration
 

--- a/docs/content/modules/ROOT/pages/metamodel.adoc
+++ b/docs/content/modules/ROOT/pages/metamodel.adoc
@@ -137,6 +137,39 @@ public List<Product> findGamingLaptops() {
 }
 ----
 
+=== Numeric Array Field Methods
+
+For `NumericField` instances that represent arrays or collections, additional methods are available for array containment queries:
+
+[source,java]
+----
+@Document
+public class DataAnalysis {
+    @Id
+    private String id;
+    
+    @Indexed
+    private List<Double> measurements;
+    
+    @Indexed
+    private List<Long> counts; 
+    
+    @Indexed
+    private List<Integer> ratings;
+}
+
+// Generated metamodel provides specialized methods for numeric arrays
+public List<DataAnalysis> findByArrayContents() {
+    return entityStream.of(DataAnalysis.class)
+        .filter(DataAnalysis$.MEASUREMENTS.containsDouble(1.5, 2.5, 3.5))  // For double arrays
+        .filter(DataAnalysis$.COUNTS.containsLong(100L, 200L, 300L))       // For long arrays  
+        .filter(DataAnalysis$.RATINGS.containsInt(4, 5))                   // For int arrays
+        .collect(Collectors.toList());
+}
+----
+
+These methods work similarly to `TagField.in()` but provide type-safe containment searches specifically for numeric arrays.
+
 
 == Metamodel with Entity Streams
 


### PR DESCRIPTION
Added comprehensive documentation for the new NumericField array search capabilities:

1. **entity-streams.adoc**: Added "Numeric Array Queries" section with examples of containsDouble(), containsLong(), and containsInt() methods for EntityStream filtering

2. **metamodel.adoc**: Added "Numeric Array Field Methods" section explaining the generated metamodel methods for type-safe numeric array containment searches

3. **index-annotations.adoc**: Added examples of indexing numeric arrays/collections and cross-referenced to the numeric array query documentation

These methods provide functionality similar to TagField.in() but specifically designed for numeric arrays, addressing GitHub issue #400.