### PR TITLE
test: add metamodel generation tests for @NumericIndexed annotation (#613)

### DIFF
--- a/tests/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
+++ b/tests/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
@@ -443,4 +443,120 @@ class MetamodelGeneratorTest {
   private List<String> getErrorStrings(Results results) {
     return results.find().errors().list().stream().map(w -> w.getMessage(Locale.US)).collect(Collectors.toList());
   }
+
+  @Test
+  @Classpath(
+    "data.metamodel.ValidDocumentNumericIndexedComplex"
+  )
+  void testValidDocumentNumericIndexedComplex(Results results) throws IOException {
+    List<String> warnings = getWarningStrings(results);
+    assertThat(warnings).isEmpty();
+
+    List<String> errors = getErrorStrings(results);
+    assertThat(errors).isEmpty();
+
+    assertThat(results.generated).hasSize(1);
+    JavaFileObject metamodel = results.generated.get(0);
+    assertThat(metamodel.getName()).isEqualTo("/SOURCE_OUTPUT/valid/ValidDocumentNumericIndexedComplex$.java");
+
+    var fileContents = metamodel.getCharContent(true);
+
+    assertAll( //
+        // Test the exact case from the GitHub issue
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Double> ISSUE_REPORTED_FIELD;"),
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Double> INDEXED_FIELD;"),
+
+        // Test all numeric types work with @NumericIndexed
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Integer> INTEGER_FIELD;"),
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Long> LONG_FIELD;"),
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Float> FLOAT_FIELD;"),
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, BigDecimal> BIG_DECIMAL_FIELD;"),
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, BigInteger> BIG_INTEGER_FIELD;"),
+
+        // Test primitive types
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Integer> PRIMITIVE_INT;"),
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Long> PRIMITIVE_LONG;"),
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Double> PRIMITIVE_DOUBLE;"),
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexedComplex, Float> PRIMITIVE_FLOAT;")
+    );
+  }
+
+  @Test
+  @Classpath(
+    "data.metamodel.ValidDocumentNumericIndexed"
+  )
+  void testValidDocumentNumericIndexed(Results results) throws IOException {
+    List<String> warnings = getWarningStrings(results);
+    assertThat(warnings).isEmpty();
+
+    List<String> errors = getErrorStrings(results);
+    assertThat(errors).isEmpty();
+
+    assertThat(results.generated).hasSize(1);
+    JavaFileObject metamodel = results.generated.get(0);
+    assertThat(metamodel.getName()).isEqualTo("/SOURCE_OUTPUT/valid/ValidDocumentNumericIndexed$.java");
+
+    var fileContents = metamodel.getCharContent(true);
+
+    assertAll( //
+
+        // test package matches source package
+        () -> assertThat(fileContents).contains("package valid;"), //
+
+        // test Fields generation
+        () -> assertThat(fileContents).contains("public static Field id;"), //
+        () -> assertThat(fileContents).contains("public static Field price;"), //
+        () -> assertThat(fileContents).contains("public static Field quantity;"), //
+        () -> assertThat(fileContents).contains("public static Field rating;"), //
+
+        // test fields initialization
+        () -> assertThat(fileContents).contains(
+            "id = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentNumericIndexed.class, \"id\");"),
+        //
+        () -> assertThat(fileContents).contains(
+            "price = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentNumericIndexed.class, \"price\");"),
+        //
+        () -> assertThat(fileContents).contains(
+            "quantity = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentNumericIndexed.class, \"quantity\");"),
+        //
+        () -> assertThat(fileContents).contains(
+            "rating = com.redis.om.spring.util.ObjectUtils.getDeclaredFieldTransitively(ValidDocumentNumericIndexed.class, \"rating\");"),
+        //
+
+        // test Metamodel Field generation
+        () -> assertThat(fileContents).contains("public static TextTagField<ValidDocumentNumericIndexed, String> ID;"), //
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexed, Double> PRICE;"), //
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexed, Integer> QUANTITY;"), //
+        () -> assertThat(fileContents).contains(
+            "public static NumericField<ValidDocumentNumericIndexed, Float> RATING;"), //
+
+        // test Metamodel Field initialization - verify aliases are used
+        () -> assertThat(fileContents).contains(
+            "ID = new TextTagField<ValidDocumentNumericIndexed, String>(new SearchFieldAccessor(\"id\", \"$.id\", id),true);"),
+        //
+        () -> assertThat(fileContents).contains(
+            "PRICE = new NumericField<ValidDocumentNumericIndexed, Double>(new SearchFieldAccessor(\"price\", \"$.price\", price),true);"),
+        //
+        () -> assertThat(fileContents).contains(
+            "QUANTITY = new NumericField<ValidDocumentNumericIndexed, Integer>(new SearchFieldAccessor(\"qty\", \"$.quantity\", quantity),true);"),
+        //
+        () -> assertThat(fileContents).contains(
+            "RATING = new NumericField<ValidDocumentNumericIndexed, Float>(new SearchFieldAccessor(\"rating\", \"$.rating\", rating),true);"),
+        //
+        () -> assertThat(fileContents).contains(
+            "_KEY = new MetamodelField<ValidDocumentNumericIndexed, String>(\"__key\", String.class, true);"));
+  }
 }

--- a/tests/src/test/resources/data/metamodel/InvalidDocumentNumericIndexedWithSchemaFieldType.java
+++ b/tests/src/test/resources/data/metamodel/InvalidDocumentNumericIndexedWithSchemaFieldType.java
@@ -1,0 +1,31 @@
+package valid;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.NumericIndexed;
+import com.redis.om.spring.annotations.SchemaFieldType;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Document
+public class InvalidDocumentNumericIndexedWithSchemaFieldType {
+  @Id
+  private String id;
+
+  // This is INVALID - @NumericIndexed does not have a schemaFieldType parameter
+  // This will cause a compilation error
+  /*
+  @NumericIndexed(
+    schemaFieldType = SchemaFieldType.NUMERIC, 
+    sortable = true
+  )
+  private Double invalidField;
+  */
+  
+  // This is the correct way to use @NumericIndexed
+  @NumericIndexed(sortable = true)
+  private Double validField;
+}

--- a/tests/src/test/resources/data/metamodel/ValidDocumentNumericIndexed.java
+++ b/tests/src/test/resources/data/metamodel/ValidDocumentNumericIndexed.java
@@ -1,0 +1,28 @@
+package valid;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.NumericIndexed;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Document
+public class ValidDocumentNumericIndexed {
+  @Id
+  private String id;
+
+  @NonNull
+  @NumericIndexed(sortable = true)
+  private Double price;
+
+  @NonNull
+  @NumericIndexed(alias = "qty")
+  private Integer quantity;
+
+  @NonNull
+  @NumericIndexed(sortable = true, alias = "rating")
+  private Float rating;
+}

--- a/tests/src/test/resources/data/metamodel/ValidDocumentNumericIndexedComplex.java
+++ b/tests/src/test/resources/data/metamodel/ValidDocumentNumericIndexedComplex.java
@@ -1,0 +1,63 @@
+package valid;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.NumericIndexed;
+import com.redis.om.spring.annotations.SchemaFieldType;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Document
+public class ValidDocumentNumericIndexedComplex {
+  @Id
+  private String id;
+
+  // Test case from the GitHub issue - but corrected (schemaFieldType is not valid for @NumericIndexed)
+  @NumericIndexed(
+    sortable = true
+  )
+  private Double issueReportedField;
+
+  // Compare with @Indexed annotation
+  @Indexed(
+    schemaFieldType = SchemaFieldType.NUMERIC,
+    sortable = true
+  )
+  private Double indexedField;
+
+  // Test various numeric types with @NumericIndexed
+  @NumericIndexed
+  private Integer integerField;
+
+  @NumericIndexed
+  private Long longField;
+
+  @NumericIndexed
+  private Float floatField;
+
+  @NumericIndexed
+  private BigDecimal bigDecimalField;
+
+  @NumericIndexed
+  private BigInteger bigIntegerField;
+
+  // Test primitive types
+  @NumericIndexed
+  private int primitiveInt;
+
+  @NumericIndexed
+  private long primitiveLong;
+
+  @NumericIndexed
+  private double primitiveDouble;
+
+  @NumericIndexed
+  private float primitiveFloat;
+}


### PR DESCRIPTION


Add comprehensive tests to verify that @NumericIndexed annotation correctly generates NumericField metamodel fields. Tests cover:
- Basic numeric types (Double, Integer, Float)
- Primitive numeric types
- BigDecimal and BigInteger
- Alias functionality