### PR TITLE
fix: handle missing @Reference entities gracefully (#607)

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/ops/json/JSONOperationsImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/ops/json/JSONOperationsImpl.java
@@ -61,7 +61,9 @@ public class JSONOperationsImpl<K> implements JSONOperations<K> {
   @Override
   public String get(K key) {
     var result = client.clientForJSON().jsonGet(key.toString(), Path2.ROOT_PATH);
-    if (result instanceof JSONArray jsonArray) {
+    if (result == null) {
+      return null;
+    } else if (result instanceof JSONArray jsonArray) {
       return !jsonArray.isEmpty() ? jsonArray.get(0).toString() : null;
     } else if (result instanceof LinkedTreeMap<?, ?> linkedTreeMap) {
       return getGson().toJson(linkedTreeMap);


### PR DESCRIPTION
- Add null checks in ReferenceDeserializer to prevent NPE when referenced entities are missing
- Add null check in JSONOperationsImpl.get() to handle null results from Redis
- Log warnings when referenced entities cannot be found
- Filter out missing references from collections instead of throwing NPE
- Add tests to verify proper handling of missing single and collection references