### PR TITLE
feat: add @RedisKey annotation to populate entity fields with Redis  keys during search operations (#538)

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/RedisKey.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/RedisKey.java
@@ -1,0 +1,43 @@
+package com.redis.om.spring.annotations;
+
+import java.lang.annotation.*;
+
+/**
+ * Marks a field to be populated with the Redis key during search operations.
+ * <p>
+ * When a field is annotated with @RedisKey, it will automatically be populated
+ * with the full Redis key (including prefix) when the entity is retrieved
+ * through search operations.
+ * </p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * {@code
+ * @Document
+ * public class MyDocument {
+ * 
+ * @Id
+ *     private String id;
+ *
+ * @RedisKey
+ *           private String redisKey;
+ *
+ *           // other fields...
+ *           }
+ *           }
+ *           </pre>
+ *
+ *           <p>Note: Only one field per entity should be annotated with @RedisKey.</p>
+ *
+ * @author Brian Sam-Bodden
+ * @since 1.0.0
+ */
+@Documented
+@Retention(
+  RetentionPolicy.RUNTIME
+)
+@Target(
+  { ElementType.FIELD, ElementType.METHOD }
+)
+public @interface RedisKey {
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/RediSearchQuery.java
@@ -597,11 +597,13 @@ public class RediSearchQuery implements RepositoryQuery {
 
     Gson gsonInstance = getGson();
 
-    return switch (dialect) {
+    Object entity = switch (dialect) {
       case ONE, TWO -> gsonInstance.fromJson(SafeEncoder.encode((byte[]) doc.get("$")), domainType);
       case THREE -> gsonInstance.fromJson(gsonInstance.fromJson(SafeEncoder.encode((byte[]) doc.get("$")),
           JsonArray.class).get(0), domainType);
     };
+
+    return ObjectUtils.populateRedisKey(entity, doc.getId());
   }
 
   private Object executeDeleteQuery(Object[] parameters) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -600,8 +600,10 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
       Gson gson = gsonBuilder.create();
 
       if (searchResult.getTotalResults() > 0) {
-        List<T> content = searchResult.getDocuments().stream().map(d -> gson.fromJson(SafeEncoder.encode((byte[]) d.get(
-            "$")), metadata.getJavaType())).toList();
+        List<T> content = searchResult.getDocuments().stream().map(d -> {
+          T entity = gson.fromJson(SafeEncoder.encode((byte[]) d.get("$")), metadata.getJavaType());
+          return ObjectUtils.populateRedisKey(entity, d.getId());
+        }).toList();
 
         return new PageImpl<>(content, pageable, searchResult.getTotalResults());
       } else {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
@@ -255,7 +255,10 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
         @SuppressWarnings(
           "unchecked"
         ) List<T> content = (List<T>) searchResult.getDocuments().stream() //
-            .map(d -> ObjectUtils.documentToObject(d, metadata.getJavaType(), mappingConverter)) //
+            .map(d -> {
+              Object entity = ObjectUtils.documentToObject(d, metadata.getJavaType(), mappingConverter);
+              return ObjectUtils.populateRedisKey(entity, d.getId());
+            }) //
             .toList();
         return new PageImpl<>(content, pageable, searchResult.getTotalResults());
       } else {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -648,11 +648,15 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
     if (projections.isEmpty()) {
       if (isDocument) {
         Gson g = getGson();
-        return searchResult.getDocuments().stream().map(d -> g.fromJson(SafeEncoder.encode((byte[]) d.get("$")),
-            entityClass)).toList();
+        return searchResult.getDocuments().stream().map(d -> {
+          E entity = g.fromJson(SafeEncoder.encode((byte[]) d.get("$")), entityClass);
+          return ObjectUtils.populateRedisKey(entity, d.getId());
+        }).toList();
       } else {
-        return searchResult.getDocuments().stream().map(d -> (E) ObjectUtils.documentToObject(d, entityClass,
-            mappingConverter)).toList();
+        return searchResult.getDocuments().stream().map(d -> {
+          E entity = (E) ObjectUtils.documentToObject(d, entityClass, mappingConverter);
+          return ObjectUtils.populateRedisKey(entity, d.getId());
+        }).toList();
       }
     } else {
       List<E> projectedEntities = new ArrayList<>();

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/RedisKeyCustomPrefixTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/RedisKeyCustomPrefixTest.java
@@ -1,0 +1,129 @@
+package com.redis.om.spring.annotations.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.DocWithCustomPrefixAndRedisKey;
+import com.redis.om.spring.fixtures.document.repository.DocWithCustomPrefixAndRedisKeyRepository;
+
+class RedisKeyCustomPrefixTest extends AbstractBaseDocumentTest {
+  
+  @Autowired
+  DocWithCustomPrefixAndRedisKeyRepository repository;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixOnFindById() {
+    // Given
+    DocWithCustomPrefixAndRedisKey doc = new DocWithCustomPrefixAndRedisKey();
+    doc.setId("test-id-1");
+    doc.setName("Test Document");
+    doc.setDescription("Testing @RedisKey with custom prefix");
+    repository.save(doc);
+
+    // When
+    Optional<DocWithCustomPrefixAndRedisKey> found = repository.findById("test-id-1");
+
+    // Then
+    assertThat(found).isPresent();
+    assertThat(found.get().getRedisKey()).isNotNull();
+    assertThat(found.get().getRedisKey()).isEqualTo("custom:doc:test-id-1");
+    assertThat(found.get().getName()).isEqualTo("Test Document");
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixOnFindAll() {
+    // Given
+    DocWithCustomPrefixAndRedisKey doc1 = new DocWithCustomPrefixAndRedisKey();
+    doc1.setId("test-id-1");
+    doc1.setName("Document 1");
+    repository.save(doc1);
+
+    DocWithCustomPrefixAndRedisKey doc2 = new DocWithCustomPrefixAndRedisKey();
+    doc2.setId("test-id-2");
+    doc2.setName("Document 2");
+    repository.save(doc2);
+
+    // When
+    List<DocWithCustomPrefixAndRedisKey> all = repository.findAll();
+
+    // Then
+    assertThat(all).hasSize(2);
+    assertThat(all).allSatisfy(doc -> {
+      assertThat(doc.getRedisKey()).isNotNull();
+      assertThat(doc.getRedisKey()).startsWith("custom:doc:");
+    });
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixOnCustomQuery() {
+    // Given
+    DocWithCustomPrefixAndRedisKey doc = new DocWithCustomPrefixAndRedisKey();
+    doc.setId("test-id-1");
+    doc.setName("Searchable Document");
+    doc.setDescription("This should be searchable");
+    repository.save(doc);
+
+    // When
+    List<DocWithCustomPrefixAndRedisKey> found = repository.findByName("Searchable Document");
+
+    // Then
+    assertThat(found).hasSize(1);
+    assertThat(found.get(0).getRedisKey()).isNotNull();
+    assertThat(found.get(0).getRedisKey()).isEqualTo("custom:doc:test-id-1");
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixOnPageQuery() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      DocWithCustomPrefixAndRedisKey doc = new DocWithCustomPrefixAndRedisKey();
+      doc.setId("test-id-" + i);
+      doc.setName("Document " + i);
+      repository.save(doc);
+    }
+
+    // When
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<DocWithCustomPrefixAndRedisKey> page = repository.findAll(pageable);
+
+    // Then
+    assertThat(page.getContent()).hasSize(3);
+    assertThat(page.getContent()).allSatisfy(doc -> {
+      assertThat(doc.getRedisKey()).isNotNull();
+      assertThat(doc.getRedisKey()).startsWith("custom:doc:");
+    });
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixNotOverwrittenOnSave() {
+    // Given
+    DocWithCustomPrefixAndRedisKey doc = new DocWithCustomPrefixAndRedisKey();
+    doc.setId("test-id-1");
+    doc.setName("Test Document");
+    doc.setRedisKey("should-be-overwritten");
+    repository.save(doc);
+
+    // When
+    Optional<DocWithCustomPrefixAndRedisKey> found = repository.findById("test-id-1");
+
+    // Then
+    assertThat(found).isPresent();
+    // The RedisKey should be populated with the actual Redis key, not the one we set
+    assertThat(found.get().getRedisKey()).isEqualTo("custom:doc:test-id-1");
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/RedisKeyTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/RedisKeyTest.java
@@ -1,0 +1,129 @@
+package com.redis.om.spring.annotations.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.DocWithRedisKey;
+import com.redis.om.spring.fixtures.document.repository.DocWithRedisKeyRepository;
+
+class RedisKeyTest extends AbstractBaseDocumentTest {
+  
+  @Autowired
+  DocWithRedisKeyRepository repository;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void testRedisKeyPopulatedOnFindById() {
+    // Given
+    DocWithRedisKey doc = new DocWithRedisKey();
+    doc.setId("test-id-1");
+    doc.setName("Test Document");
+    doc.setDescription("Testing @RedisKey functionality");
+    repository.save(doc);
+
+    // When
+    Optional<DocWithRedisKey> found = repository.findById("test-id-1");
+
+    // Then
+    assertThat(found).isPresent();
+    assertThat(found.get().getRedisKey()).isNotNull();
+    assertThat(found.get().getRedisKey()).isEqualTo("com.redis.om.spring.fixtures.document.model.DocWithRedisKey:test-id-1");
+    assertThat(found.get().getName()).isEqualTo("Test Document");
+  }
+
+  @Test
+  void testRedisKeyPopulatedOnFindAll() {
+    // Given
+    DocWithRedisKey doc1 = new DocWithRedisKey();
+    doc1.setId("test-id-1");
+    doc1.setName("Document 1");
+    repository.save(doc1);
+
+    DocWithRedisKey doc2 = new DocWithRedisKey();
+    doc2.setId("test-id-2");
+    doc2.setName("Document 2");
+    repository.save(doc2);
+
+    // When
+    List<DocWithRedisKey> all = repository.findAll();
+
+    // Then
+    assertThat(all).hasSize(2);
+    assertThat(all).allSatisfy(doc -> {
+      assertThat(doc.getRedisKey()).isNotNull();
+      assertThat(doc.getRedisKey()).startsWith("com.redis.om.spring.fixtures.document.model.DocWithRedisKey:");
+    });
+  }
+
+  @Test
+  void testRedisKeyPopulatedOnCustomQuery() {
+    // Given
+    DocWithRedisKey doc = new DocWithRedisKey();
+    doc.setId("test-id-1");
+    doc.setName("Searchable Document");
+    doc.setDescription("This should be searchable");
+    repository.save(doc);
+
+    // When
+    List<DocWithRedisKey> found = repository.findByName("Searchable Document");
+
+    // Then
+    assertThat(found).hasSize(1);
+    assertThat(found.get(0).getRedisKey()).isNotNull();
+    assertThat(found.get(0).getRedisKey()).isEqualTo("com.redis.om.spring.fixtures.document.model.DocWithRedisKey:test-id-1");
+  }
+
+  @Test
+  void testRedisKeyPopulatedOnPageQuery() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      DocWithRedisKey doc = new DocWithRedisKey();
+      doc.setId("test-id-" + i);
+      doc.setName("Document " + i);
+      repository.save(doc);
+    }
+
+    // When
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<DocWithRedisKey> page = repository.findAll(pageable);
+
+    // Then
+    assertThat(page.getContent()).hasSize(3);
+    assertThat(page.getContent()).allSatisfy(doc -> {
+      assertThat(doc.getRedisKey()).isNotNull();
+      assertThat(doc.getRedisKey()).startsWith("com.redis.om.spring.fixtures.document.model.DocWithRedisKey:");
+    });
+  }
+
+  @Test
+  void testRedisKeyNotOverwrittenOnSave() {
+    // Given
+    DocWithRedisKey doc = new DocWithRedisKey();
+    doc.setId("test-id-1");
+    doc.setName("Test Document");
+    doc.setRedisKey("should-be-overwritten");
+    repository.save(doc);
+
+    // When
+    Optional<DocWithRedisKey> found = repository.findById("test-id-1");
+
+    // Then
+    assertThat(found).isPresent();
+    // The RedisKey should be populated with the actual Redis key, not the one we set
+    assertThat(found.get().getRedisKey()).isEqualTo("com.redis.om.spring.fixtures.document.model.DocWithRedisKey:test-id-1");
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/hash/RedisKeyCustomPrefixHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/hash/RedisKeyCustomPrefixHashTest.java
@@ -1,0 +1,111 @@
+package com.redis.om.spring.annotations.hash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.fixtures.hash.model.HashWithCustomPrefixAndRedisKey;
+import com.redis.om.spring.fixtures.hash.repository.HashWithCustomPrefixAndRedisKeyRepository;
+
+class RedisKeyCustomPrefixHashTest extends AbstractBaseEnhancedRedisTest {
+  
+  @Autowired
+  HashWithCustomPrefixAndRedisKeyRepository repository;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixOnFindById() {
+    // Given
+    HashWithCustomPrefixAndRedisKey hash = new HashWithCustomPrefixAndRedisKey();
+    hash.setId("test-id-1");
+    hash.setName("Test Hash");
+    hash.setDescription("Testing @RedisKey with custom prefix");
+    repository.save(hash);
+
+    // When
+    Optional<HashWithCustomPrefixAndRedisKey> found = repository.findById("test-id-1");
+
+    // Then
+    assertThat(found).isPresent();
+    assertThat(found.get().getRedisKey()).isNotNull();
+    assertThat(found.get().getRedisKey()).isEqualTo("custom:hash:test-id-1");
+    assertThat(found.get().getName()).isEqualTo("Test Hash");
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixOnFindAll() {
+    // Given
+    HashWithCustomPrefixAndRedisKey hash1 = new HashWithCustomPrefixAndRedisKey();
+    hash1.setId("test-id-1");
+    hash1.setName("Hash 1");
+    repository.save(hash1);
+
+    HashWithCustomPrefixAndRedisKey hash2 = new HashWithCustomPrefixAndRedisKey();
+    hash2.setId("test-id-2");
+    hash2.setName("Hash 2");
+    repository.save(hash2);
+
+    // When
+    List<HashWithCustomPrefixAndRedisKey> all = repository.findAll();
+
+    // Then
+    assertThat(all).hasSize(2);
+    assertThat(all).allSatisfy(hash -> {
+      assertThat(hash.getRedisKey()).isNotNull();
+      assertThat(hash.getRedisKey()).startsWith("custom:hash:");
+    });
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixOnCustomQuery() {
+    // Given
+    HashWithCustomPrefixAndRedisKey hash = new HashWithCustomPrefixAndRedisKey();
+    hash.setId("test-id-1");
+    hash.setName("Searchable Hash");
+    hash.setDescription("This should be searchable");
+    repository.save(hash);
+
+    // When
+    List<HashWithCustomPrefixAndRedisKey> found = repository.findByName("Searchable Hash");
+
+    // Then
+    assertThat(found).hasSize(1);
+    assertThat(found.get(0).getRedisKey()).isNotNull();
+    assertThat(found.get(0).getRedisKey()).isEqualTo("custom:hash:test-id-1");
+  }
+
+  @Test
+  void testRedisKeyWithCustomPrefixOnPageQuery() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      HashWithCustomPrefixAndRedisKey hash = new HashWithCustomPrefixAndRedisKey();
+      hash.setId("test-id-" + i);
+      hash.setName("Hash " + i);
+      repository.save(hash);
+    }
+
+    // When
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<HashWithCustomPrefixAndRedisKey> page = repository.findAll(pageable);
+
+    // Then
+    assertThat(page.getContent()).hasSize(3);
+    assertThat(page.getContent()).allSatisfy(hash -> {
+      assertThat(hash.getRedisKey()).isNotNull();
+      assertThat(hash.getRedisKey()).startsWith("custom:hash:");
+    });
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/hash/RedisKeyHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/hash/RedisKeyHashTest.java
@@ -1,0 +1,111 @@
+package com.redis.om.spring.annotations.hash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.fixtures.hash.model.HashWithRedisKey;
+import com.redis.om.spring.fixtures.hash.repository.HashWithRedisKeyRepository;
+
+class RedisKeyHashTest extends AbstractBaseEnhancedRedisTest {
+  
+  @Autowired
+  HashWithRedisKeyRepository repository;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void testRedisKeyPopulatedOnFindById() {
+    // Given
+    HashWithRedisKey hash = new HashWithRedisKey();
+    hash.setId("test-id-1");
+    hash.setName("Test Hash");
+    hash.setDescription("Testing @RedisKey functionality");
+    repository.save(hash);
+
+    // When
+    Optional<HashWithRedisKey> found = repository.findById("test-id-1");
+
+    // Then
+    assertThat(found).isPresent();
+    assertThat(found.get().getRedisKey()).isNotNull();
+    assertThat(found.get().getRedisKey()).isEqualTo("com.redis.om.spring.fixtures.hash.model.HashWithRedisKey:test-id-1");
+    assertThat(found.get().getName()).isEqualTo("Test Hash");
+  }
+
+  @Test
+  void testRedisKeyPopulatedOnFindAll() {
+    // Given
+    HashWithRedisKey hash1 = new HashWithRedisKey();
+    hash1.setId("test-id-1");
+    hash1.setName("Hash 1");
+    repository.save(hash1);
+
+    HashWithRedisKey hash2 = new HashWithRedisKey();
+    hash2.setId("test-id-2");
+    hash2.setName("Hash 2");
+    repository.save(hash2);
+
+    // When
+    List<HashWithRedisKey> all = repository.findAll();
+
+    // Then
+    assertThat(all).hasSize(2);
+    assertThat(all).allSatisfy(hash -> {
+      assertThat(hash.getRedisKey()).isNotNull();
+      assertThat(hash.getRedisKey()).startsWith("com.redis.om.spring.fixtures.hash.model.HashWithRedisKey:");
+    });
+  }
+
+  @Test
+  void testRedisKeyPopulatedOnCustomQuery() {
+    // Given
+    HashWithRedisKey hash = new HashWithRedisKey();
+    hash.setId("test-id-1");
+    hash.setName("Searchable Hash");
+    hash.setDescription("This should be searchable");
+    repository.save(hash);
+
+    // When
+    List<HashWithRedisKey> found = repository.findByName("Searchable Hash");
+
+    // Then
+    assertThat(found).hasSize(1);
+    assertThat(found.get(0).getRedisKey()).isNotNull();
+    assertThat(found.get(0).getRedisKey()).isEqualTo("com.redis.om.spring.fixtures.hash.model.HashWithRedisKey:test-id-1");
+  }
+
+  @Test
+  void testRedisKeyPopulatedOnPageQuery() {
+    // Given
+    for (int i = 0; i < 5; i++) {
+      HashWithRedisKey hash = new HashWithRedisKey();
+      hash.setId("test-id-" + i);
+      hash.setName("Hash " + i);
+      repository.save(hash);
+    }
+
+    // When
+    Pageable pageable = PageRequest.of(0, 3);
+    Page<HashWithRedisKey> page = repository.findAll(pageable);
+
+    // Then
+    assertThat(page.getContent()).hasSize(3);
+    assertThat(page.getContent()).allSatisfy(hash -> {
+      assertThat(hash.getRedisKey()).isNotNull();
+      assertThat(hash.getRedisKey()).startsWith("com.redis.om.spring.fixtures.hash.model.HashWithRedisKey:");
+    });
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/DocWithCustomPrefixAndRedisKey.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/DocWithCustomPrefixAndRedisKey.java
@@ -1,0 +1,26 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.RedisKey;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.Data;
+
+@Data
+@Document("custom:doc")
+public class DocWithCustomPrefixAndRedisKey {
+  @Id
+  private String id;
+  
+  @RedisKey
+  private String redisKey;
+  
+  @Indexed
+  private String name;
+  
+  @Searchable
+  private String description;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/DocWithRedisKey.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/DocWithRedisKey.java
@@ -1,0 +1,26 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.RedisKey;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.Data;
+
+@Data
+@Document
+public class DocWithRedisKey {
+  @Id
+  private String id;
+  
+  @RedisKey
+  private String redisKey;
+  
+  @Indexed
+  private String name;
+  
+  @Searchable
+  private String description;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/DocWithCustomPrefixAndRedisKeyRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/DocWithCustomPrefixAndRedisKeyRepository.java
@@ -1,0 +1,10 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import java.util.List;
+
+import com.redis.om.spring.fixtures.document.model.DocWithCustomPrefixAndRedisKey;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface DocWithCustomPrefixAndRedisKeyRepository extends RedisDocumentRepository<DocWithCustomPrefixAndRedisKey, String> {
+  List<DocWithCustomPrefixAndRedisKey> findByName(String name);
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/DocWithRedisKeyRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/DocWithRedisKeyRepository.java
@@ -1,0 +1,10 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import java.util.List;
+
+import com.redis.om.spring.fixtures.document.model.DocWithRedisKey;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface DocWithRedisKeyRepository extends RedisDocumentRepository<DocWithRedisKey, String> {
+  List<DocWithRedisKey> findByName(String name);
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/HashWithCustomPrefixAndRedisKey.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/HashWithCustomPrefixAndRedisKey.java
@@ -1,0 +1,26 @@
+package com.redis.om.spring.fixtures.hash.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.RedisKey;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.Data;
+
+@Data
+@RedisHash("custom:hash")
+public class HashWithCustomPrefixAndRedisKey {
+  @Id
+  private String id;
+  
+  @RedisKey
+  private String redisKey;
+  
+  @Indexed
+  private String name;
+  
+  @Searchable
+  private String description;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/HashWithRedisKey.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/HashWithRedisKey.java
@@ -1,0 +1,26 @@
+package com.redis.om.spring.fixtures.hash.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.RedisKey;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.Data;
+
+@Data
+@RedisHash
+public class HashWithRedisKey {
+  @Id
+  private String id;
+  
+  @RedisKey
+  private String redisKey;
+  
+  @Indexed
+  private String name;
+  
+  @Searchable
+  private String description;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/HashWithCustomPrefixAndRedisKeyRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/HashWithCustomPrefixAndRedisKeyRepository.java
@@ -1,0 +1,10 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import java.util.List;
+
+import com.redis.om.spring.fixtures.hash.model.HashWithCustomPrefixAndRedisKey;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface HashWithCustomPrefixAndRedisKeyRepository extends RedisEnhancedRepository<HashWithCustomPrefixAndRedisKey, String> {
+  List<HashWithCustomPrefixAndRedisKey> findByName(String name);
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/HashWithRedisKeyRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/HashWithRedisKeyRepository.java
@@ -1,0 +1,10 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import java.util.List;
+
+import com.redis.om.spring.fixtures.hash.model.HashWithRedisKey;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface HashWithRedisKeyRepository extends RedisEnhancedRepository<HashWithRedisKey, String> {
+  List<HashWithRedisKey> findByName(String name);
+}


### PR DESCRIPTION
Add a new @RedisKey annotation that allows entities to capture their Redis key during retrieval operations. This feature enables entities to know their full Redis key, which is useful for operations that need the complete key, including custom prefixes.

- Add @RedisKey field annotation for marking fields to receive Redis keys
- Implement populateRedisKey utility method with class-level caching for performance
- Integrate key population into all entity retrieval paths (adapters, repositories, queries)
- Add optimized metadata caching in RedisEnhancedPersistentEntity with lazy initialization
- Support both Document and Hash entities with default and custom key prefixes
- Add comprehensive test coverage for all entity types and key prefix scenarios