### PR TITLE
Lexicographic repository search for TAG fields as well and EntityStream searches

### DIFF
--- a/docs/content/modules/ROOT/pages/entity-streams.adoc
+++ b/docs/content/modules/ROOT/pages/entity-streams.adoc
@@ -130,6 +130,54 @@ List<Company> prefixMatches = entityStream.of(Company.class)
     .collect(Collectors.toList());
 ----
 
+=== Lexicographic String Comparisons
+
+For fields marked with `@Indexed(lexicographic = true)` or `@Searchable(lexicographic = true)`, you can perform string range queries:
+
+[source,java]
+----
+@Document
+public class Product {
+    @Id
+    private String id;
+    
+    @Indexed(lexicographic = true)
+    private String sku;
+    
+    @Searchable(lexicographic = true)
+    private String name;
+}
+
+// Find products with SKU greater than a value
+List<Product> products = entityStream.of(Product.class)
+    .filter(Product$.SKU.gt("PROD-1000"))
+    .collect(Collectors.toList());
+
+// Find products with SKU less than a value
+List<Product> earlyProducts = entityStream.of(Product.class)
+    .filter(Product$.SKU.lt("PROD-0500"))
+    .collect(Collectors.toList());
+
+// Find products with SKU between two values
+List<Product> rangeProducts = entityStream.of(Product.class)
+    .filter(Product$.SKU.between("PROD-1000", "PROD-2000"))
+    .collect(Collectors.toList());
+
+// Combine with other predicates
+List<Product> filteredProducts = entityStream.of(Product.class)
+    .filter(Product$.SKU.gt("PROD-1000")
+        .and(Product$.NAME.containing("Premium")))
+    .sorted(Product$.SKU)
+    .collect(Collectors.toList());
+
+// Works with TextFields too (when lexicographic = true)
+List<Product> alphabeticalRange = entityStream.of(Product.class)
+    .filter(Product$.NAME.between("A", "M"))
+    .collect(Collectors.toList());
+----
+
+NOTE: Lexicographic comparisons use Redis sorted sets for efficient range queries. They're ideal for ID ranges, SKU comparisons, version strings, and alphabetical filtering.
+
 === Boolean Predicates
 
 [source,java]

--- a/docs/content/modules/ROOT/pages/index-annotations.adoc
+++ b/docs/content/modules/ROOT/pages/index-annotations.adoc
@@ -37,6 +37,42 @@ public class Company {
 }
 ----
 
+==== Configuration Options:
+
+* `sortable` - Whether the field can be used for sorting (default: false)
+* `fieldName` - Custom field name in the index
+* `alias` - Field alias for queries
+* `indexMissing` - Index missing/null values (default: false)
+* `indexEmpty` - Index empty string values (default: false)
+* `lexicographic` - Enable lexicographic string comparisons for TAG fields (default: false)
+
+==== Lexicographic String Comparisons
+
+The `lexicographic` parameter enables string range queries (>, <, >=, <=, between) on TAG-indexed string fields by creating an additional Redis sorted set index:
+
+[source,java]
+----
+@Document
+public class Product {
+    @Id
+    private String id;
+    
+    @Indexed(lexicographic = true)
+    private String sku;  // Enables findBySkuGreaterThan("ABC123")
+    
+    @Indexed(lexicographic = true)
+    private String productCode;  // Enables range queries on product codes
+}
+----
+
+When `lexicographic = true`:
+- An additional Redis sorted set is created for the field (e.g., `Product:sku:lex`)
+- Repository methods like `findBySkuGreaterThan`, `findBySkuLessThan`, and `findBySkuBetween` are supported
+- EntityStream operations like `Product$.SKU.gt("ABC")` and `Product$.SKU.between("A", "Z")` work
+- Useful for ID ranges, SKU comparisons, alphabetical ordering, and version strings
+
+NOTE: Lexicographic indexing requires additional storage for the sorted set. Only enable it for fields where you need string range queries.
+
 === @Searchable
 
 For full-text search on string fields, use `@Searchable` which provides rich text search capabilities:
@@ -67,6 +103,37 @@ public class Game {
 * `phonetic` - Enable phonetic matching using Double Metaphone algorithm (default: "")
 * `indexMissing` - Index missing/null values (default: false)
 * `indexEmpty` - Index empty string values (default: false)
+* `lexicographic` - Enable lexicographic string comparisons (default: false)
+
+==== Lexicographic String Comparisons with @Searchable
+
+The `lexicographic` parameter also works with `@Searchable` fields to enable string range queries:
+
+[source,java]
+----
+@Document
+public class Article {
+    @Id
+    private String id;
+    
+    @Searchable(lexicographic = true)
+    private String title;  // Enables alphabetical range queries
+    
+    @Searchable(lexicographic = true, sortable = true)
+    private String category;  // Range queries with sorting
+}
+
+// Repository methods
+public interface ArticleRepository extends RedisDocumentRepository<Article, String> {
+    // Find articles with titles alphabetically after "M"
+    List<Article> findByTitleGreaterThan(String title);
+    
+    // Find articles in category range
+    List<Article> findByCategoryBetween(String start, String end);
+}
+----
+
+NOTE: When using `lexicographic = true` on `@Searchable` fields, Redis OM Spring creates both a full-text index and a sorted set for range queries. This allows you to use both text search methods (like `findByTitleContaining`) and range queries (like `findByTitleGreaterThan`) on the same field.
 
 == Specialized Indexing Annotations
 

--- a/docs/content/modules/ROOT/pages/quickstart.adoc
+++ b/docs/content/modules/ROOT/pages/quickstart.adoc
@@ -961,6 +961,257 @@ It is important to understand that as opposed to a regular Java stream, most ope
 be executed server-side. On the query above the query is executed during and only during the terminal `collect` operation. At that point you
 will have a `List<Company>` objects now loaded in memory.
 
+== Step 21: Lexicographic String Comparisons
+
+Redis OM Spring supports lexicographic (alphabetical) string comparisons for range queries on string fields. This is useful for finding entities within ID ranges, SKU comparisons, or alphabetical filtering.
+
+Let's add a Product entity to demonstrate this feature:
+
+[source,java]
+----
+package com.example.demo.domain;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.*;
+
+@Data
+@NoArgsConstructor
+@RequiredArgsConstructor(staticName = "of")
+@Document
+public class Product {
+    @Id
+    private String id;
+
+    @NonNull
+    @Searchable
+    private String name;
+
+    @NonNull
+    @Indexed(lexicographic = true)  // Enable lexicographic comparisons
+    private String sku;
+
+    @NonNull
+    @Indexed
+    private Double price;
+
+    @Indexed(lexicographic = true)  // Version strings can be compared
+    private String version;
+}
+----
+
+Notice the `lexicographic = true` parameter on the `@Indexed` annotation. This tells Redis OM Spring to create an additional sorted set index for string range queries.
+
+== Step 22: Create the Product Repository
+
+[source,java]
+----
+package com.example.demo.repositories;
+
+import java.util.List;
+
+import com.example.demo.domain.Product;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface ProductRepository extends RedisDocumentRepository<Product, String> {
+    // Lexicographic string comparisons
+    List<Product> findBySkuGreaterThan(String sku);
+    List<Product> findBySkuLessThan(String sku);
+    List<Product> findBySkuBetween(String startSku, String endSku);
+    
+    // Combine with other conditions
+    List<Product> findBySkuGreaterThanAndPriceGreaterThan(String sku, Double price);
+    
+    // Order by lexicographic field
+    List<Product> findByNameContainingOrderBySkuAsc(String keyword);
+}
+----
+
+These repository methods leverage the lexicographic index to perform efficient string range queries.
+
+== Step 23: Product Service with Entity Streams
+
+[source,java]
+----
+package com.example.demo.service;
+
+import java.util.List;
+
+import com.example.demo.domain.Product;
+
+public interface ProductService {
+    List<Product> findProductsInSkuRange(String startSku, String endSku);
+    List<Product> findNewerVersions(String version);
+}
+----
+
+[source,java]
+----
+package com.example.demo.service.impl;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.example.demo.domain.Product;
+import com.example.demo.domain.Product$;
+import com.example.demo.service.ProductService;
+import com.redis.om.spring.search.stream.EntityStream;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductServiceImpl implements ProductService {
+
+    private final EntityStream entityStream;
+
+    @Override
+    public List<Product> findProductsInSkuRange(String startSku, String endSku) {
+        return entityStream
+            .of(Product.class)
+            .filter(Product$.SKU.between(startSku, endSku))
+            .sorted(Product$.SKU)  // Sort by SKU alphabetically
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Product> findNewerVersions(String version) {
+        return entityStream
+            .of(Product.class)
+            .filter(Product$.VERSION.gt(version))
+            .sorted(Product$.VERSION.desc())
+            .collect(Collectors.toList());
+    }
+}
+----
+
+The Entity Streams API provides type-safe methods for lexicographic comparisons:
+- `.gt(value)` - Greater than
+- `.lt(value)` - Less than  
+- `.between(start, end)` - Between two values (inclusive)
+
+== Step 24: Update Application to Load Product Data
+
+[source,java]
+----
+// Add to the Application class imports
+import com.example.demo.domain.Product;
+import com.example.demo.repositories.ProductRepository;
+
+// Add to the Application class fields
+@Autowired
+ProductRepository productRepo;
+
+// Add to the loadTestData() method
+// Clear and load Product data
+productRepo.deleteAll();
+
+// Create products with sequential SKUs
+productRepo.save(Product.of("Laptop Pro", "PROD-1001", 1299.99));
+productRepo.save(Product.of("Wireless Mouse", "PROD-1002", 29.99));
+productRepo.save(Product.of("USB-C Hub", "PROD-1003", 49.99));
+productRepo.save(Product.of("Monitor 4K", "PROD-2001", 599.99));
+productRepo.save(Product.of("Keyboard Mechanical", "PROD-2002", 149.99));
+
+// Products with versions
+Product software1 = Product.of("Analytics Suite", "SOFT-001", 499.99);
+software1.setVersion("2.1.0");
+productRepo.save(software1);
+
+Product software2 = Product.of("Database Manager", "SOFT-002", 799.99);
+software2.setVersion("3.0.1");
+productRepo.save(software2);
+
+Product software3 = Product.of("Cloud Platform", "SOFT-003", 999.99);
+software3.setVersion("1.9.5");
+productRepo.save(software3);
+----
+
+== Step 25: Create the Product Controller
+
+[source,java]
+----
+package com.example.demo.controllers;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.*;
+
+import com.example.demo.domain.Product;
+import com.example.demo.repositories.ProductRepository;
+import com.example.demo.service.ProductService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/products")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductRepository repository;
+    private final ProductService productService;
+
+    @GetMapping
+    public Iterable<Product> getAllProducts() {
+        return repository.findAll();
+    }
+
+    @GetMapping("sku/gt/{sku}")
+    public List<Product> bySkuGreaterThan(@PathVariable("sku") String sku) {
+        return repository.findBySkuGreaterThan(sku);
+    }
+
+    @GetMapping("sku/range/{start}/{end}")
+    public List<Product> bySkuRange(
+            @PathVariable("start") String start,
+            @PathVariable("end") String end) {
+        return productService.findProductsInSkuRange(start, end);
+    }
+
+    @GetMapping("version/newer/{version}")
+    public List<Product> newerVersions(@PathVariable("version") String version) {
+        return productService.findNewerVersions(version);
+    }
+}
+----
+
+== Testing Lexicographic Queries
+
+After adding the Product functionality, you can test the lexicographic string comparisons:
+
+Find products with SKU greater than a value:
+[source,bash]
+----
+curl http://localhost:8080/api/products/sku/gt/PROD-1002
+# Returns products with SKUs: PROD-1003, PROD-2001, PROD-2002, SOFT-001, etc.
+----
+
+Find products in a SKU range:
+[source,bash]
+----
+curl http://localhost:8080/api/products/sku/range/PROD-1001/PROD-2000
+# Returns products with SKUs between PROD-1001 and PROD-2000
+----
+
+Find software with version newer than 2.0.0:
+[source,bash]
+----
+curl http://localhost:8080/api/products/version/newer/2.0.0
+# Returns software with versions > 2.0.0 (e.g., 2.1.0, 3.0.1)
+----
+
+The lexicographic feature is particularly useful for:
+- **Product SKUs**: Finding products in specific code ranges
+- **Sequential IDs**: Querying entities with IDs in a certain range  
+- **Version strings**: Comparing semantic versions
+- **Alphabetical filtering**: Finding names within alphabetical ranges
+
 == Testing the REST API
 
 After starting your application with `./mvnw spring-boot:run`, you can test the various endpoints:

--- a/docs/content/modules/ROOT/pages/repository-queries.adoc
+++ b/docs/content/modules/ROOT/pages/repository-queries.adoc
@@ -65,11 +65,13 @@ public interface CompanyRepository extends RedisDocumentRepository<Company, Stri
 
 === Comparison Operations
 
-* `findBy<Property>LessThan` - Numeric field less than value
-* `findBy<Property>LessThanEqual` - Numeric field less than or equal to value
-* `findBy<Property>GreaterThan` - Numeric field greater than value
-* `findBy<Property>GreaterThanEqual` - Numeric field greater than or equal to value
-* `findBy<Property>Between` - Numeric field between two values
+* `findBy<Property>LessThan` - Field less than value (numeric or string with lexicographic=true)
+* `findBy<Property>LessThanEqual` - Field less than or equal to value
+* `findBy<Property>GreaterThan` - Field greater than value
+* `findBy<Property>GreaterThanEqual` - Field greater than or equal to value
+* `findBy<Property>Between` - Field between two values
+
+NOTE: String comparison operations require `@Indexed(lexicographic = true)` or `@Searchable(lexicographic = true)` on the field. See xref:index-annotations.adoc#_lexicographic_string_comparisons[Lexicographic String Comparisons] for details.
 
 === Logical Operations
 
@@ -140,6 +142,51 @@ public interface CompanyRepository extends RedisDocumentRepository<Company, Stri
     List<Company> findByNameStartingWith(String prefix);
 }
 ----
+
+=== String Comparison Queries (Lexicographic)
+
+For string range queries, enable lexicographic indexing on your fields:
+
+[source,java]
+----
+@Document
+public class Product {
+    @Id
+    private String id;
+    
+    @Indexed(lexicographic = true)
+    private String sku;
+    
+    @Indexed(lexicographic = true)
+    private String productCode;
+    
+    @Searchable(lexicographic = true)
+    private String name;
+}
+
+public interface ProductRepository extends RedisDocumentRepository<Product, String> {
+    // Find products with SKU greater than a value
+    List<Product> findBySkuGreaterThan(String sku);
+    
+    // Find products with SKU less than or equal to a value
+    List<Product> findBySkuLessThanEqual(String sku);
+    
+    // Find products with SKU between two values (inclusive)
+    List<Product> findBySkuBetween(String startSku, String endSku);
+    
+    // Find products with code in a specific range, ordered
+    List<Product> findByProductCodeBetweenOrderByProductCodeAsc(String start, String end);
+    
+    // Combine with other conditions
+    List<Product> findBySkuGreaterThanAndNameContaining(String sku, String keyword);
+}
+----
+
+Common use cases for lexicographic string comparisons:
+* ID ranges (e.g., `findByUserIdBetween("USER1000", "USER2000")`)
+* SKU/Product code ranges
+* Version string comparisons
+* Alphabetical ordering and filtering
 
 === Collection Queries
 

--- a/docs/content/modules/ROOT/pages/search.adoc
+++ b/docs/content/modules/ROOT/pages/search.adoc
@@ -185,6 +185,89 @@ List<Game> results = entityStream
   .collect(Collectors.toList());
 ----
 
+== Lexicographic String Indexing
+
+Redis OM Spring supports lexicographic (alphabetical) string comparisons through the `lexicographic` parameter on `@Indexed` and `@Searchable` annotations. This feature enables string range queries using Redis sorted sets.
+
+=== Enabling Lexicographic Indexing
+
+[source,java]
+----
+@Document
+public class Product {
+  @Id
+  private String id;
+  
+  @Indexed(lexicographic = true)
+  private String sku;
+  
+  @Searchable(lexicographic = true)
+  private String productName;
+  
+  @Indexed(lexicographic = true)
+  private String version;
+}
+----
+
+=== How It Works
+
+When `lexicographic = true` is set:
+
+1. Redis OM Spring creates an additional sorted set index for the field
+2. The sorted set uses the field value as the score for lexicographic ordering
+3. Range queries (>, <, >=, <=, between) become available for string fields
+
+=== Query Examples
+
+==== Repository Methods
+
+[source,java]
+----
+public interface ProductRepository extends RedisDocumentRepository<Product, String> {
+  // Find products with SKU greater than a value
+  List<Product> findBySkuGreaterThan(String sku);
+  
+  // Find products with SKU in a range
+  List<Product> findBySkuBetween(String startSku, String endSku);
+  
+  // Combine with other conditions
+  List<Product> findBySkuGreaterThanAndProductNameContaining(String sku, String keyword);
+}
+----
+
+==== Entity Streams
+
+[source,java]
+----
+// Find products with SKU after "PROD-5000"
+List<Product> products = entityStream.of(Product.class)
+  .filter(Product$.SKU.gt("PROD-5000"))
+  .sorted(Product$.SKU)
+  .collect(Collectors.toList());
+
+// Version string comparisons
+List<Product> newerVersions = entityStream.of(Product.class)
+  .filter(Product$.VERSION.gt("2.0.0"))
+  .collect(Collectors.toList());
+----
+
+=== Use Cases
+
+Lexicographic indexing is ideal for:
+
+* **ID ranges**: Finding entities within specific ID ranges
+* **SKU/Product codes**: Filtering products by code ranges
+* **Version strings**: Comparing semantic versions
+* **Alphabetical filtering**: Finding names in alphabetical ranges
+* **Sequential identifiers**: Any field with ordered string values
+
+=== Performance Impact
+
+* Creates an additional Redis sorted set per indexed field
+* Minimal memory overhead (one entry per unique field value)
+* Very fast range queries using Redis ZRANGEBYLEX command
+* Only enable for fields where range queries are needed
+
 == Performance Considerations
 
 * Use `@Searchable` selectively on fields that need text search
@@ -192,6 +275,7 @@ List<Game> results = entityStream
 * For large result sets, use pagination
 * For complex queries, use the `@Query` annotation with the native query syntax
 * Consider using `weight` to adjust the importance of different fields
+* Enable `lexicographic=true` only for fields requiring string range queries
 
 == Next Steps
 

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -95,9 +95,10 @@
       }
     },
     "node_modules/@antora/cli/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -659,9 +660,10 @@
       }
     },
     "node_modules/@antora/site-generator-default/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -1122,9 +1124,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Indexed.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Indexed.java
@@ -230,4 +230,22 @@ public @interface Indexed {
    */
   boolean indexEmpty() default false;
 
+  /**
+   * Indicates whether this field should maintain a sorted set index for
+   * lexicographic range queries (greater than, less than, between).
+   * When enabled, creates and maintains a Redis sorted set alongside the
+   * regular RediSearch index, enabling efficient string range queries.
+   *
+   * <p>Note: This feature requires additional storage and maintenance overhead
+   * as it creates a secondary index structure. Use only when lexicographic
+   * range queries are needed.</p>
+   *
+   * <p>The sorted set key pattern will be: {entityPrefix}{fieldName}:lex
+   * where entityPrefix follows the same pattern as the main entity keys.</p>
+   *
+   * @return {@code true} if lexicographic indexing should be enabled, {@code false} otherwise
+   * @since 1.0.0
+   */
+  boolean lexicographic() default false;
+
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Searchable.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Searchable.java
@@ -104,4 +104,26 @@ public @interface Searchable {
    * @return true if empty values should be indexed, false otherwise
    */
   boolean indexEmpty() default false;
+
+  /**
+   * Indicates whether this field should maintain a sorted set index for
+   * lexicographic range queries (greater than, less than, between).
+   * When enabled, creates and maintains a Redis sorted set alongside the
+   * regular RediSearch full-text index, enabling efficient string range queries.
+   *
+   * <p>This is particularly useful for searchable fields where you need both
+   * full-text search capabilities AND lexicographic range queries (e.g.,
+   * product names, titles, descriptions that need alphabetical filtering).</p>
+   *
+   * <p>Note: This feature requires additional storage and maintenance overhead
+   * as it creates a secondary index structure. Use only when lexicographic
+   * range queries are needed.</p>
+   *
+   * <p>The sorted set key pattern will be: {entityPrefix}{fieldName}:lex
+   * where entityPrefix follows the same pattern as the main entity keys.</p>
+   *
+   * @return {@code true} if lexicographic indexing should be enabled, {@code false} otherwise
+   * @since 1.0.0
+   */
+  boolean lexicographic() default false;
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/LexicographicIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/LexicographicIndexer.java
@@ -1,0 +1,147 @@
+package com.redis.om.spring.indexing;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Handles maintenance of lexicographic sorted sets for fields marked with lexicographic=true.
+ * This component is responsible for keeping sorted sets in sync with entity changes
+ * during save, update, and delete operations.
+ *
+ * @author Redis OM Spring Team
+ * @since 1.0.0
+ * @author Brian Sam-Bodden
+ */
+public class LexicographicIndexer {
+  private static final Log logger = LogFactory.getLog(LexicographicIndexer.class);
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private final RediSearchIndexer indexer;
+
+  public LexicographicIndexer(RedisTemplate<String, String> redisTemplate, RediSearchIndexer indexer) {
+    this.redisTemplate = redisTemplate;
+    this.indexer = indexer;
+  }
+
+  /**
+   * Process entity before save/update to maintain lexicographic sorted sets.
+   * Removes old entries if updating and adds new entries.
+   *
+   * @param entity       the entity being saved
+   * @param entityId     the entity ID
+   * @param isNew        whether this is a new entity
+   * @param entityPrefix the Redis key prefix for the entity type
+   */
+  public void processEntity(Object entity, String entityId, boolean isNew, String entityPrefix) {
+    Class<?> entityClass = entity.getClass();
+    Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+
+    logger.debug(String.format("Processing entity %s with ID %s, isNew=%s, entityPrefix=%s", entityClass
+        .getSimpleName(), entityId, isNew, entityPrefix));
+    logger.debug(String.format("Lexicographic fields: %s", lexicographicFields));
+
+    if (lexicographicFields == null || lexicographicFields.isEmpty()) {
+      logger.debug("No lexicographic fields found, skipping processing");
+      return;
+    }
+
+    for (String fieldName : lexicographicFields) {
+      Field field = ReflectionUtils.findField(entityClass, fieldName);
+      if (field == null) {
+        logger.warn(String.format("Lexicographic field %s not found on class %s", fieldName, entityClass.getName()));
+        continue;
+      }
+
+      field.setAccessible(true);
+      Object fieldValue = ReflectionUtils.getField(field, entity);
+
+      if (fieldValue != null) {
+        String sortedSetKey = entityPrefix + fieldName + ":lex";
+        String member = fieldValue.toString() + "#" + entityId;
+
+        logger.debug(String.format("Processing field %s, value=%s, member=%s, isNew=%s", fieldName, fieldValue, member,
+            isNew));
+
+        // If updating, remove the old entry (we don't know the old value, so we need to find and remove it)
+        if (!isNew) {
+          removeOldEntry(sortedSetKey, entityId);
+        }
+
+        // Add the new entry with score 0 (all entries have same score for lexicographic ordering)
+        Boolean added = redisTemplate.opsForZSet().add(sortedSetKey, member, 0.0);
+        logger.debug(String.format("Added entry %s to sorted set %s (result: %s)", member, sortedSetKey, added));
+      }
+    }
+  }
+
+  /**
+   * Process entity deletion to remove entries from lexicographic sorted sets.
+   *
+   * @param entity       the entity being deleted
+   * @param entityId     the entity ID
+   * @param entityPrefix the Redis key prefix for the entity type
+   */
+  public void processEntityDeletion(Object entity, String entityId, String entityPrefix) {
+    Class<?> entityClass = entity.getClass();
+    Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+
+    if (lexicographicFields == null || lexicographicFields.isEmpty()) {
+      return;
+    }
+
+    for (String fieldName : lexicographicFields) {
+      String sortedSetKey = entityPrefix + fieldName + ":lex";
+      removeOldEntry(sortedSetKey, entityId);
+    }
+  }
+
+  /**
+   * Process entity deletion by ID when entity is not available.
+   *
+   * @param entityClass  the entity class
+   * @param entityId     the entity ID
+   * @param entityPrefix the Redis key prefix for the entity type
+   */
+  public void processEntityDeletionById(Class<?> entityClass, String entityId, String entityPrefix) {
+    Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+
+    if (lexicographicFields == null || lexicographicFields.isEmpty()) {
+      return;
+    }
+
+    for (String fieldName : lexicographicFields) {
+      String sortedSetKey = entityPrefix + fieldName + ":lex";
+      removeOldEntry(sortedSetKey, entityId);
+    }
+  }
+
+  /**
+   * Removes entries ending with the given entity ID from the sorted set.
+   * This is needed because we may not know the old field value during updates.
+   *
+   * @param sortedSetKey the sorted set key
+   * @param entityId     the entity ID to remove
+   */
+  private void removeOldEntry(String sortedSetKey, String entityId) {
+    // Get all members and remove those ending with #entityId
+    Set<String> members = redisTemplate.opsForZSet().range(sortedSetKey, 0, -1);
+    logger.debug(String.format("Removing old entries for entityId %s from %s", entityId, sortedSetKey));
+    logger.debug(String.format("Current members: %s", members));
+    if (members != null) {
+      String suffix = "#" + entityId;
+      logger.debug(String.format("Looking for entries ending with: %s", suffix));
+      for (String member : members) {
+        if (member.endsWith(suffix)) {
+          Long removed = redisTemplate.opsForZSet().remove(sortedSetKey, member);
+          logger.debug(String.format("Removed entry %s from sorted set %s (result: %s)", member, sortedSetKey,
+              removed));
+        }
+      }
+    }
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TextField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TextField.java
@@ -9,6 +9,9 @@ import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.search.stream.actions.StrLengthAction;
 import com.redis.om.spring.search.stream.actions.StringAppendAction;
 import com.redis.om.spring.search.stream.predicates.fulltext.*;
+import com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicBetweenMarker;
+import com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicGreaterThanMarker;
+import com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicLessThanMarker;
 
 /**
  * Represents a text field in the Redis OM Spring metamodel that supports
@@ -211,6 +214,57 @@ public class TextField<E, T> extends MetamodelField<E, T> {
    */
   public ToLongFunction<E> length() {
     return new StrLengthAction<>(searchFieldAccessor);
+  }
+
+  /**
+   * Creates a lexicographic greater-than predicate for this text field.
+   * <p>
+   * This predicate requires the field to be indexed with {@code lexicographic=true}
+   * in its {@code @Searchable} annotation. It matches text fields that are
+   * lexicographically greater than the specified value.
+   * </p>
+   *
+   * @param value the value to compare against
+   * @return a LexicographicGreaterThanMarker that matches entities where this field is lexicographically greater than
+   *         the specified value
+   * @since 1.0
+   */
+  public LexicographicGreaterThanMarker<E, T> gt(T value) {
+    return new LexicographicGreaterThanMarker<>(searchFieldAccessor, value);
+  }
+
+  /**
+   * Creates a lexicographic less-than predicate for this text field.
+   * <p>
+   * This predicate requires the field to be indexed with {@code lexicographic=true}
+   * in its {@code @Searchable} annotation. It matches text fields that are
+   * lexicographically less than the specified value.
+   * </p>
+   *
+   * @param value the value to compare against
+   * @return a LexicographicLessThanMarker that matches entities where this field is lexicographically less than the
+   *         specified value
+   * @since 1.0
+   */
+  public LexicographicLessThanMarker<E, T> lt(T value) {
+    return new LexicographicLessThanMarker<>(searchFieldAccessor, value);
+  }
+
+  /**
+   * Creates a lexicographic between predicate for this text field.
+   * <p>
+   * This predicate requires the field to be indexed with {@code lexicographic=true}
+   * in its {@code @Searchable} annotation. It matches text fields that are
+   * lexicographically between the specified min and max values (inclusive).
+   * </p>
+   *
+   * @param min the minimum value (inclusive)
+   * @param max the maximum value (inclusive)
+   * @return a LexicographicBetweenMarker that matches entities where this field is between min and max
+   * @since 1.0
+   */
+  public LexicographicBetweenMarker<E, T> between(T min, T max) {
+    return new LexicographicBetweenMarker<>(searchFieldAccessor, min, max);
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TextTagField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TextTagField.java
@@ -6,6 +6,9 @@ import java.util.function.ToLongFunction;
 import com.redis.om.spring.metamodel.SearchFieldAccessor;
 import com.redis.om.spring.search.stream.actions.StrLengthAction;
 import com.redis.om.spring.search.stream.actions.StringAppendAction;
+import com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicBetweenMarker;
+import com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicGreaterThanMarker;
+import com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicLessThanMarker;
 import com.redis.om.spring.search.stream.predicates.tag.EndsWithPredicate;
 import com.redis.om.spring.search.stream.predicates.tag.StartsWithPredicate;
 
@@ -96,5 +99,56 @@ public class TextTagField<E, T> extends TagField<E, T> {
   @Override
   public ToLongFunction<E> length() {
     return new StrLengthAction<>(searchFieldAccessor);
+  }
+
+  /**
+   * Creates a lexicographic greater-than predicate for this text-tag field.
+   * <p>
+   * This predicate requires the field to be indexed with {@code lexicographic=true}
+   * in its {@code @Indexed} annotation. It matches fields that are
+   * lexicographically greater than the specified value.
+   * </p>
+   *
+   * @param value the value to compare against
+   * @return a LexicographicGreaterThanMarker that matches entities where this field is lexicographically greater than
+   *         the specified value
+   * @since 1.0
+   */
+  public LexicographicGreaterThanMarker<E, T> gt(T value) {
+    return new LexicographicGreaterThanMarker<>(searchFieldAccessor, value);
+  }
+
+  /**
+   * Creates a lexicographic less-than predicate for this text-tag field.
+   * <p>
+   * This predicate requires the field to be indexed with {@code lexicographic=true}
+   * in its {@code @Indexed} annotation. It matches fields that are
+   * lexicographically less than the specified value.
+   * </p>
+   *
+   * @param value the value to compare against
+   * @return a LexicographicLessThanMarker that matches entities where this field is lexicographically less than the
+   *         specified value
+   * @since 1.0
+   */
+  public LexicographicLessThanMarker<E, T> lt(T value) {
+    return new LexicographicLessThanMarker<>(searchFieldAccessor, value);
+  }
+
+  /**
+   * Creates a lexicographic between predicate for this text-tag field.
+   * <p>
+   * This predicate requires the field to be indexed with {@code lexicographic=true}
+   * in its {@code @Indexed} annotation. It matches fields that are
+   * lexicographically between the specified min and max values (inclusive).
+   * </p>
+   *
+   * @param min the minimum value (inclusive)
+   * @param max the maximum value (inclusive)
+   * @return a LexicographicBetweenMarker that matches entities where this field is between min and max
+   * @since 1.0
+   */
+  public LexicographicBetweenMarker<E, T> between(T min, T max) {
+    return new LexicographicBetweenMarker<>(searchFieldAccessor, min, max);
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/clause/QueryClause.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/clause/QueryClause.java
@@ -107,6 +107,47 @@ public enum QueryClause {
   TEXT_IN( //
       QueryClauseTemplate.of(FieldType.TEXT, Part.Type.IN, QueryClause.FIELD_EQUAL, 1) //
   ),
+  /**
+   * Text field query clause for lexicographic "greater than" comparisons.
+   * Matches text fields whose values are lexicographically greater than the specified value.
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TEXT_GREATER_THAN( //
+      QueryClauseTemplate.of(FieldType.TEXT, Part.Type.GREATER_THAN, QueryClause.FIELD_LEXICOGRAPHIC, 1) //
+  ),
+  /**
+   * Text field query clause for lexicographic "less than" comparisons.
+   * Matches text fields whose values are lexicographically less than the specified value.
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TEXT_LESS_THAN( //
+      QueryClauseTemplate.of(FieldType.TEXT, Part.Type.LESS_THAN, QueryClause.FIELD_LEXICOGRAPHIC, 1) //
+  ),
+  /**
+   * Text field query clause for lexicographic "greater than or equal" comparisons.
+   * Matches text fields whose values are lexicographically greater than or equal to the specified value.
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TEXT_GREATER_THAN_EQUAL( //
+      QueryClauseTemplate.of(FieldType.TEXT, Part.Type.GREATER_THAN_EQUAL, QueryClause.FIELD_LEXICOGRAPHIC, 1) //
+  ),
+  /**
+   * Text field query clause for lexicographic "less than or equal" comparisons.
+   * Matches text fields whose values are lexicographically less than or equal to the specified value.
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TEXT_LESS_THAN_EQUAL( //
+      QueryClauseTemplate.of(FieldType.TEXT, Part.Type.LESS_THAN_EQUAL, QueryClause.FIELD_LEXICOGRAPHIC, 1) //
+  ),
+  /**
+   * Text field query clause for lexicographic range matching.
+   * Matches text fields whose values fall lexicographically between the specified minimum and maximum values
+   * (inclusive).
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TEXT_BETWEEN( //
+      QueryClauseTemplate.of(FieldType.TEXT, Part.Type.BETWEEN, QueryClause.FIELD_LEXICOGRAPHIC, 2) //
+  ),
   // NUMERIC
   /**
    * Numeric field query clause for exact value matching.
@@ -219,6 +260,47 @@ public enum QueryClause {
       QueryClauseTemplate.of(FieldType.TAG, Part.Type.SIMPLE_PROPERTY, QueryClause.FIELD_TAG_EQUAL, 1) //
   ),
   /**
+   * Tag field query clause for lexicographic "greater than" comparisons.
+   * Matches tag fields whose values are lexicographically greater than the specified value.
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TAG_GREATER_THAN( //
+      QueryClauseTemplate.of(FieldType.TAG, Part.Type.GREATER_THAN, QueryClause.FIELD_LEXICOGRAPHIC, 1) //
+  ),
+  /**
+   * Tag field query clause for lexicographic "less than" comparisons.
+   * Matches tag fields whose values are lexicographically less than the specified value.
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TAG_LESS_THAN( //
+      QueryClauseTemplate.of(FieldType.TAG, Part.Type.LESS_THAN, QueryClause.FIELD_LEXICOGRAPHIC, 1) //
+  ),
+  /**
+   * Tag field query clause for lexicographic "greater than or equal" comparisons.
+   * Matches tag fields whose values are lexicographically greater than or equal to the specified value.
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TAG_GREATER_THAN_EQUAL( //
+      QueryClauseTemplate.of(FieldType.TAG, Part.Type.GREATER_THAN_EQUAL, QueryClause.FIELD_LEXICOGRAPHIC, 1) //
+  ),
+  /**
+   * Tag field query clause for lexicographic "less than or equal" comparisons.
+   * Matches tag fields whose values are lexicographically less than or equal to the specified value.
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TAG_LESS_THAN_EQUAL( //
+      QueryClauseTemplate.of(FieldType.TAG, Part.Type.LESS_THAN_EQUAL, QueryClause.FIELD_LEXICOGRAPHIC, 1) //
+  ),
+  /**
+   * Tag field query clause for lexicographic range matching.
+   * Matches tag fields whose values fall lexicographically between the specified minimum and maximum values
+   * (inclusive).
+   * Only applicable to fields marked with lexicographic=true.
+   */
+  TAG_BETWEEN( //
+      QueryClauseTemplate.of(FieldType.TAG, Part.Type.BETWEEN, QueryClause.FIELD_LEXICOGRAPHIC, 2) //
+  ),
+  /**
    * Tag field query clause for exclusion testing.
    * Matches tag fields whose values are not in the specified collection of values.
    */
@@ -310,6 +392,7 @@ public enum QueryClause {
   private static final String FIELD_GEO_NEAR = "@$field:[$param_0 $param_1 $param_2]";
   private static final String FIELD_IS_NULL = "!exists(@$field)";
   private static final String FIELD_IS_NOT_NULL = "exists(@$field)";
+  private static final String FIELD_LEXICOGRAPHIC = "__LEXICOGRAPHIC__";
   private final QueryClauseTemplate clauseTemplate;
   private final MappingRedisOMConverter converter = new MappingRedisOMConverter();
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/lexicographic/LexicographicQueryExecutor.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/lexicographic/LexicographicQueryExecutor.java
@@ -1,0 +1,271 @@
+package com.redis.om.spring.repository.query.lexicographic;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.data.util.Pair;
+import org.springframework.util.ReflectionUtils;
+
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.repository.query.RediSearchQuery;
+import com.redis.om.spring.repository.query.clause.QueryClause;
+
+/**
+ * Executes lexicographic queries for repository methods.
+ * This executor handles GreaterThan, LessThan, Between operations on fields
+ * that have been marked with lexicographic=true.
+ */
+public class LexicographicQueryExecutor {
+  private static final Log logger = LogFactory.getLog(LexicographicQueryExecutor.class);
+
+  /**
+   * Set of QueryClause types that represent lexicographic operations.
+   */
+  private static final Set<QueryClause> LEXICOGRAPHIC_QUERY_CLAUSES = Set.of(QueryClause.TEXT_GREATER_THAN,
+      QueryClause.TEXT_LESS_THAN, QueryClause.TEXT_GREATER_THAN_EQUAL, QueryClause.TEXT_LESS_THAN_EQUAL,
+      QueryClause.TEXT_BETWEEN, QueryClause.TAG_GREATER_THAN, QueryClause.TAG_LESS_THAN,
+      QueryClause.TAG_GREATER_THAN_EQUAL, QueryClause.TAG_LESS_THAN_EQUAL, QueryClause.TAG_BETWEEN);
+
+  private final RediSearchQuery rediSearchQuery;
+  private final RedisModulesOperations<String> modulesOperations;
+  private final RediSearchIndexer indexer;
+
+  public LexicographicQueryExecutor(RediSearchQuery rediSearchQuery, RedisModulesOperations<String> modulesOperations,
+      RediSearchIndexer indexer) {
+    this.rediSearchQuery = rediSearchQuery;
+    this.modulesOperations = modulesOperations;
+    this.indexer = indexer;
+  }
+
+  /**
+   * Processes lexicographic query parts and builds the appropriate RediSearch query.
+   *
+   * @param queryOrParts the query parts to process
+   * @param parameters   the method parameters
+   * @param domainType   the entity type
+   * @return a prepared query string that uses ID-based filtering
+   */
+  public String processLexicographicQuery(List<List<Pair<String, QueryClause>>> queryOrParts, Object[] parameters,
+      Class<?> domainType) {
+    logger.debug(String.format("Processing lexicographic query with %d queryOrParts and %d parameters", queryOrParts
+        .size(), parameters.length));
+
+    List<Object> params = new ArrayList<>(Arrays.asList(parameters));
+    List<Set<String>> orResults = new ArrayList<>();
+    boolean hasLexicographicQuery = false;
+    boolean hasNonLexicographicQuery = false;
+    int paramIndex = 0;
+
+    for (List<Pair<String, QueryClause>> orPartParts : queryOrParts) {
+      Set<String> andResults = null;
+
+      for (Pair<String, QueryClause> pair : orPartParts) {
+        String fieldName = pair.getFirst();
+        QueryClause queryClause = pair.getSecond();
+        logger.debug(String.format("Processing field: %s with queryClause: %s", fieldName, queryClause));
+
+        // Check if this is a lexicographic query
+        if (isLexicographicQuery(queryClause)) {
+          hasLexicographicQuery = true;
+          int numParams = queryClause.getClauseTemplate().getNumberOfArguments();
+          Object[] queryParams = Arrays.copyOfRange(parameters, paramIndex, paramIndex + numParams);
+          paramIndex += numParams;
+
+          Set<String> entityIds = executeLexicographicQuery(fieldName, queryClause, queryParams, domainType);
+          if (andResults == null) {
+            andResults = new HashSet<>(entityIds);
+          } else {
+            // For AND queries within an OR part, we need to intersect
+            andResults.retainAll(entityIds);
+          }
+        } else {
+          hasNonLexicographicQuery = true;
+          // Skip parameters for non-lexicographic queries
+          int numParams = queryClause.getClauseTemplate().getNumberOfArguments();
+          paramIndex += numParams;
+        }
+      }
+
+      if (andResults != null && !andResults.isEmpty()) {
+        orResults.add(andResults);
+      }
+    }
+
+    // Remove the check for non-lexicographic queries since we only get called for all-lexicographic queries
+
+    if (hasLexicographicQuery && !orResults.isEmpty()) {
+      // Combine OR results
+      Set<String> finalResults = new HashSet<>();
+      for (Set<String> orResult : orResults) {
+        finalResults.addAll(orResult);
+      }
+
+      if (!finalResults.isEmpty()) {
+        String idQuery = buildIdQuery(finalResults);
+        logger.debug(String.format("Built ID-based query: %s", idQuery));
+        return idQuery;
+      } else {
+        return "@__id:{}"; // No matches
+      }
+    }
+
+    return null;
+  }
+
+  private boolean isLexicographicQuery(QueryClause queryClause) {
+    return LEXICOGRAPHIC_QUERY_CLAUSES.contains(queryClause);
+  }
+
+  private Set<String> executeLexicographicQuery(String fieldName, QueryClause queryClause, Object[] params,
+      Class<?> domainType) {
+    logger.debug(String.format("Executing lexicographic query for field: %s, queryClause: %s", fieldName, queryClause));
+
+    // Get the entity prefix
+    String entityPrefix = indexer.getKeyspaceForEntityClass(domainType);
+    if (entityPrefix == null) {
+      logger.debug("Entity prefix is null");
+      return Collections.emptySet();
+    }
+    logger.debug("Entity prefix: " + entityPrefix);
+
+    // Get the actual field name (without alias)
+    String actualFieldName = getActualFieldName(domainType, fieldName);
+    if (actualFieldName == null) {
+      logger.debug(String.format("Could not find actual field name for alias: %s", fieldName));
+      return Collections.emptySet();
+    }
+    logger.debug(String.format("Actual field name: %s", actualFieldName));
+
+    // Check if the field has lexicographic=true
+    if (!isFieldLexicographic(domainType, actualFieldName)) {
+      logger.debug(String.format("Field %s is not lexicographic", actualFieldName));
+      return Collections.emptySet();
+    }
+
+    // Construct the sorted set key
+    String sortedSetKey = entityPrefix + actualFieldName + ":lex";
+    logger.debug(String.format("Sorted set key: %s", sortedSetKey));
+
+    // Execute the appropriate range query
+    Set<String> matches = executeRangeQuery(sortedSetKey, queryClause, params);
+    logger.debug(String.format("Range query returned %d matches", matches.size()));
+
+    // Extract entity IDs from matches
+    Set<String> result = matches.stream().map(match -> {
+      int hashIndex = match.lastIndexOf('#');
+      return hashIndex >= 0 ? match.substring(hashIndex + 1) : null;
+    }).filter(Objects::nonNull).collect(Collectors.toSet());
+
+    logger.debug(String.format("Extracted %d entity IDs: %s", result.size(), result));
+    return result;
+  }
+
+  private Set<String> executeRangeQuery(String sortedSetKey, QueryClause queryClause, Object[] params) {
+    logger.debug(String.format("Executing range query on %s with clause %s and param: %s", sortedSetKey, queryClause,
+        params[0]));
+
+    switch (queryClause) {
+      case TEXT_GREATER_THAN:
+      case TAG_GREATER_THAN:
+        // When doing greater than, we need to exclude exact matches with the same prefix
+        // Since our format is "value#id", we append a high character to ensure we skip all entries with this prefix
+        String gtParam = params[0].toString() + "\uffff"; // Unicode max character
+        Set<String> results = modulesOperations.template().opsForZSet().rangeByLex(sortedSetKey,
+            org.springframework.data.redis.connection.RedisZSetCommands.Range.range().gt(gtParam),
+            org.springframework.data.redis.connection.RedisZSetCommands.Limit.unlimited());
+        logger.debug(String.format("ZRANGEBYLEX %s (%s +inf returned: %s", sortedSetKey, gtParam, results));
+        return results;
+
+      case TEXT_LESS_THAN:
+      case TAG_LESS_THAN:
+        // For less than, we need to ensure we don't include the value itself
+        // Since format is "value#id", we need to get everything before "value#" (excluded)
+        String ltParam = params[0].toString() + "#"; // Exclude exact matches with this prefix
+        return modulesOperations.template().opsForZSet().rangeByLex(sortedSetKey,
+            org.springframework.data.redis.connection.RedisZSetCommands.Range.range().lt(ltParam),
+            org.springframework.data.redis.connection.RedisZSetCommands.Limit.unlimited());
+
+      case TEXT_GREATER_THAN_EQUAL:
+      case TAG_GREATER_THAN_EQUAL:
+        // For greater than or equal, we include the value itself
+        // Since format is "value#id", we start from exactly "value#"
+        String gteParam = params[0].toString() + "#"; // Include exact matches with this prefix
+        return modulesOperations.template().opsForZSet().rangeByLex(sortedSetKey,
+            org.springframework.data.redis.connection.RedisZSetCommands.Range.range().gte(gteParam),
+            org.springframework.data.redis.connection.RedisZSetCommands.Limit.unlimited());
+
+      case TEXT_LESS_THAN_EQUAL:
+      case TAG_LESS_THAN_EQUAL:
+        // For less than or equal, we include all values with this prefix
+        // Since format is "value#id", we use high unicode char to include all IDs with this value
+        String lteParam = params[0].toString() + "\uffff"; // Include all exact matches with this prefix
+        return modulesOperations.template().opsForZSet().rangeByLex(sortedSetKey,
+            org.springframework.data.redis.connection.RedisZSetCommands.Range.range().lte(lteParam),
+            org.springframework.data.redis.connection.RedisZSetCommands.Limit.unlimited());
+
+      case TEXT_BETWEEN:
+      case TAG_BETWEEN:
+        // For between queries, we include both bounds
+        // Start from exactly "minValue#" (inclusive) to "maxValue\uffff" (inclusive of all with maxValue)
+        String minParam = params[0].toString() + "#";
+        String maxParam = params[1].toString() + "\uffff";
+        return modulesOperations.template().opsForZSet().rangeByLex(sortedSetKey,
+            org.springframework.data.redis.connection.RedisZSetCommands.Range.range().gte(minParam).lte(maxParam),
+            org.springframework.data.redis.connection.RedisZSetCommands.Limit.unlimited());
+
+      default:
+        return Collections.emptySet();
+    }
+  }
+
+  private String getActualFieldName(Class<?> domainType, String fieldAlias) {
+    // Try to find the field by alias or name
+    for (Field field : domainType.getDeclaredFields()) {
+      if (field.isAnnotationPresent(Indexed.class)) {
+        Indexed indexed = field.getAnnotation(Indexed.class);
+        String alias = indexed.alias().isBlank() ? field.getName() : indexed.alias();
+        if (alias.equals(fieldAlias) || field.getName().equals(fieldAlias)) {
+          return field.getName();
+        }
+      } else if (field.isAnnotationPresent(Searchable.class)) {
+        Searchable searchable = field.getAnnotation(Searchable.class);
+        String alias = searchable.alias().isBlank() ? field.getName() : searchable.alias();
+        if (alias.equals(fieldAlias) || field.getName().equals(fieldAlias)) {
+          return field.getName();
+        }
+      }
+    }
+    return null;
+  }
+
+  private boolean isFieldLexicographic(Class<?> domainType, String fieldName) {
+    Field field = ReflectionUtils.findField(domainType, fieldName);
+    if (field == null) {
+      return false;
+    }
+
+    if (field.isAnnotationPresent(Indexed.class)) {
+      return field.getAnnotation(Indexed.class).lexicographic();
+    } else if (field.isAnnotationPresent(Searchable.class)) {
+      return field.getAnnotation(Searchable.class).lexicographic();
+    }
+
+    return false;
+  }
+
+  private String buildIdQuery(Set<String> entityIds) {
+    if (entityIds.isEmpty()) {
+      return "@id:{}"; // No matches
+    }
+
+    // Build query like: @id:{id1|id2|id3}
+    String idList = entityIds.stream().collect(Collectors.joining("|"));
+    return "@id:{" + idList + "}";
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/BaseAbstractPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/BaseAbstractPredicate.java
@@ -134,4 +134,13 @@ public abstract class BaseAbstractPredicate<E, T> implements SearchFieldPredicat
     return false;
   }
 
+  /**
+   * Returns the search field accessor for this predicate.
+   *
+   * @return the search field accessor
+   */
+  public SearchFieldAccessor getSearchFieldAccessor() {
+    return field;
+  }
+
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicBetweenMarker.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicBetweenMarker.java
@@ -1,0 +1,41 @@
+package com.redis.om.spring.search.stream.predicates.lexicographic;
+
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+
+import redis.clients.jedis.search.querybuilder.Node;
+
+/**
+ * A marker predicate for lexicographic between operations.
+ * This predicate doesn't apply the query itself but signals to the SearchStream
+ * that a lexicographic range comparison is needed.
+ * 
+ * @param <E> the entity type being filtered
+ * @param <T> the field type (must be String or convertible to String)
+ * 
+ * @since 1.0
+ */
+public class LexicographicBetweenMarker<E, T> extends BaseAbstractPredicate<E, T> implements LexicographicPredicate {
+  private final T min;
+  private final T max;
+
+  public LexicographicBetweenMarker(SearchFieldAccessor field, T min, T max) {
+    super(field);
+    this.min = min;
+    this.max = max;
+  }
+
+  public T getMin() {
+    return min;
+  }
+
+  public T getMax() {
+    return max;
+  }
+
+  @Override
+  public Node apply(Node root) {
+    // This is a marker predicate - actual processing happens in SearchStream
+    throw new UnsupportedOperationException("Lexicographic predicates must be processed by SearchStream");
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicBetweenPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicBetweenPredicate.java
@@ -1,0 +1,163 @@
+package com.redis.om.spring.search.stream.predicates.lexicographic;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+
+import redis.clients.jedis.search.querybuilder.Node;
+import redis.clients.jedis.search.querybuilder.QueryBuilders;
+
+/**
+ * A lexicographic range predicate that filters entities where a string field value
+ * is lexicographically between two specified values (inclusive).
+ * 
+ * <p>This predicate works by querying the lexicographic sorted set maintained for
+ * fields marked with {@code lexicographic=true} in their {@code @Indexed} or
+ * {@code @Searchable} annotations. It uses Redis ZRANGEBYLEX to efficiently find
+ * matching entries within the specified range.</p>
+ * 
+ * <p>Example usage in entity streams:</p>
+ * <pre>
+ * // Find products with names between "A" and "M" alphabetically
+ * entityStream.filter(Product$.NAME.between("A", "M"))
+ * 
+ * // Find users with IDs between "user100" and "user500"
+ * entityStream.filter(User$.USER_ID.between("user100", "user500"))
+ * </pre>
+ * 
+ * @param <E> the entity type being filtered
+ * @param <T> the field type (must be String or convertible to String)
+ * 
+ * @since 1.0
+ * @see BaseAbstractPredicate
+ * @see LexicographicGreaterThanPredicate
+ * @see LexicographicLessThanPredicate
+ */
+public class LexicographicBetweenPredicate<E, T> extends BaseAbstractPredicate<E, T> {
+  /** The minimum value for the range (inclusive) */
+  private final T min;
+  /** The maximum value for the range (inclusive) */
+  private final T max;
+  private final RedisModulesOperations<String> rmo;
+  private final RediSearchIndexer indexer;
+
+  /**
+   * Creates a new LexicographicBetweenPredicate for the specified field and range.
+   * 
+   * @param field   the field accessor for the target string field
+   * @param min     the minimum value (inclusive)
+   * @param max     the maximum value (inclusive)
+   * @param rmo     the Redis operations helper
+   * @param indexer the RediSearch indexer containing field metadata
+   */
+  public LexicographicBetweenPredicate(SearchFieldAccessor field, T min, T max, RedisModulesOperations<String> rmo,
+      RediSearchIndexer indexer) {
+    super(field);
+    this.min = min;
+    this.max = max;
+    this.rmo = rmo;
+    this.indexer = indexer;
+  }
+
+  /**
+   * Returns the minimum value for the range.
+   * 
+   * @return the minimum value
+   */
+  public T getMin() {
+    return min;
+  }
+
+  /**
+   * Returns the maximum value for the range.
+   * 
+   * @return the maximum value
+   */
+  public T getMax() {
+    return max;
+  }
+
+  /**
+   * Applies this lexicographic between predicate to the given query node.
+   * 
+   * <p>This method queries the lexicographic sorted set to find entity IDs where
+   * the field value is lexicographically between the min and max values (inclusive).
+   * It then creates an ID-based query to match those specific entities.</p>
+   * 
+   * <p>If either value is empty or null, the predicate is ignored and the original
+   * root node is returned unchanged.</p>
+   * 
+   * @param root the base query node to apply this predicate to
+   * @return the modified query node with the lexicographic between condition applied,
+   *         or the original root if the predicate cannot be applied
+   */
+  @Override
+  public Node apply(Node root) {
+    if (isEmpty(getMin()) || isEmpty(getMax())) {
+      return root;
+    }
+
+    // Get the entity class and field name
+    Class<?> entityClass = getSearchFieldAccessor().getDeclaringClass();
+    String fieldName = getSearchFieldAccessor().getField().getName();
+
+    // Get the entity prefix
+    String entityPrefix = indexer.getKeyspaceForEntityClass(entityClass);
+    if (entityPrefix == null) {
+      return root;
+    }
+
+    // Construct the sorted set key
+    String sortedSetKey = entityPrefix + fieldName + ":lex";
+
+    // Use ZRANGEBYLEX to find matching entries
+    // For between queries, we include both bounds
+    // Start from exactly "minValue#" (inclusive) to "maxValue\uffff" (inclusive of all with maxValue)
+    String minParam = min.toString() + "#";
+    String maxParam = max.toString() + "\uffff";
+    Set<String> matches = rmo.template().opsForZSet().rangeByLex(sortedSetKey,
+        org.springframework.data.redis.connection.RedisZSetCommands.Range.range().gte(minParam).lte(maxParam),
+        org.springframework.data.redis.connection.RedisZSetCommands.Limit.unlimited());
+
+    if (matches == null || matches.isEmpty()) {
+      // No matches, return a query that matches nothing by using an impossible ID
+      if (root == null || root.toString().isEmpty()) {
+        return QueryBuilders.intersect().add("id", "{__NOMATCH__}");
+      } else {
+        return QueryBuilders.intersect(root).add("id", "{__NOMATCH__}");
+      }
+    }
+
+    // Extract entity IDs from the matches (format is "value#entityId")
+    Set<String> entityIds = matches.stream().map(match -> {
+      int hashIndex = match.lastIndexOf('#');
+      return hashIndex >= 0 ? match.substring(hashIndex + 1) : null;
+    }).filter(id -> id != null).collect(Collectors.toSet());
+
+    if (entityIds.isEmpty()) {
+      // No valid IDs found, return a query that matches nothing
+      if (root == null || root.toString().isEmpty()) {
+        return QueryBuilders.intersect().add("id", "{__NOMATCH__}");
+      } else {
+        return QueryBuilders.intersect(root).add("id", "{__NOMATCH__}");
+      }
+    }
+
+    // Build an ID-based query using the tag syntax: @id:{id1 | id2 | id3}
+    // Join the IDs with " | " separator as per RediSearch tag syntax
+    String idQuery = entityIds.stream().collect(Collectors.joining(" | "));
+
+    // Handle empty root node case - check if root is null, empty, or union (which produces empty string)
+    if (root == null || root.toString().isEmpty()) {
+      return QueryBuilders.intersect().add("id", "{" + idQuery + "}");
+    } else {
+      return QueryBuilders.intersect(root).add("id", "{" + idQuery + "}");
+    }
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicGreaterThanMarker.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicGreaterThanMarker.java
@@ -1,0 +1,36 @@
+package com.redis.om.spring.search.stream.predicates.lexicographic;
+
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+
+import redis.clients.jedis.search.querybuilder.Node;
+
+/**
+ * A marker predicate for lexicographic greater-than operations.
+ * This predicate doesn't apply the query itself but signals to the SearchStream
+ * that a lexicographic comparison is needed.
+ * 
+ * @param <E> the entity type being filtered
+ * @param <T> the field type (must be String or convertible to String)
+ * 
+ * @since 1.0
+ */
+public class LexicographicGreaterThanMarker<E, T> extends BaseAbstractPredicate<E, T> implements
+    LexicographicPredicate {
+  private final T value;
+
+  public LexicographicGreaterThanMarker(SearchFieldAccessor field, T value) {
+    super(field);
+    this.value = value;
+  }
+
+  public T getValue() {
+    return value;
+  }
+
+  @Override
+  public Node apply(Node root) {
+    // This is a marker predicate - actual processing happens in SearchStream
+    throw new UnsupportedOperationException("Lexicographic predicates must be processed by SearchStream");
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicGreaterThanPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicGreaterThanPredicate.java
@@ -1,0 +1,150 @@
+package com.redis.om.spring.search.stream.predicates.lexicographic;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+
+import redis.clients.jedis.search.querybuilder.Node;
+import redis.clients.jedis.search.querybuilder.QueryBuilders;
+
+/**
+ * A lexicographic comparison predicate that filters entities where a string field value
+ * is lexicographically greater than a specified value.
+ * 
+ * <p>This predicate works by querying the lexicographic sorted set maintained for
+ * fields marked with {@code lexicographic=true} in their {@code @Indexed} or
+ * {@code @Searchable} annotations. It uses Redis ZRANGEBYLEX to efficiently find
+ * matching entries.</p>
+ * 
+ * <p>Example usage in entity streams:</p>
+ * <pre>
+ * // Find products with names after "P" alphabetically
+ * entityStream.filter(Product$.NAME.gt("P"))
+ * 
+ * // Find users with IDs greater than "user100"
+ * entityStream.filter(User$.USER_ID.gt("user100"))
+ * </pre>
+ * 
+ * @param <E> the entity type being filtered
+ * @param <T> the field type (must be String or convertible to String)
+ * 
+ * @since 1.0
+ * @see BaseAbstractPredicate
+ * @see LexicographicLessThanPredicate
+ * @see LexicographicBetweenPredicate
+ */
+public class LexicographicGreaterThanPredicate<E, T> extends BaseAbstractPredicate<E, T> {
+  /** The threshold value for comparison */
+  private final T value;
+  private final RedisModulesOperations<String> rmo;
+  private final RediSearchIndexer indexer;
+
+  /**
+   * Creates a new LexicographicGreaterThanPredicate for the specified field and threshold.
+   * 
+   * @param field   the field accessor for the target string field
+   * @param value   the threshold value (field must be lexicographically greater than this)
+   * @param rmo     the Redis operations helper
+   * @param indexer the RediSearch indexer containing field metadata
+   */
+  public LexicographicGreaterThanPredicate(SearchFieldAccessor field, T value, RedisModulesOperations<String> rmo,
+      RediSearchIndexer indexer) {
+    super(field);
+    this.value = value;
+    this.rmo = rmo;
+    this.indexer = indexer;
+  }
+
+  /**
+   * Returns the threshold value for comparison.
+   * 
+   * @return the threshold value
+   */
+  public T getValue() {
+    return value;
+  }
+
+  /**
+   * Applies this lexicographic greater-than predicate to the given query node.
+   * 
+   * <p>This method queries the lexicographic sorted set to find entity IDs where
+   * the field value is lexicographically greater than the threshold. It then
+   * creates an ID-based query to match those specific entities.</p>
+   * 
+   * <p>If the value is empty or null, the predicate is ignored and the original
+   * root node is returned unchanged.</p>
+   * 
+   * @param root the base query node to apply this predicate to
+   * @return the modified query node with the lexicographic greater-than condition applied,
+   *         or the original root if the predicate cannot be applied
+   */
+  @Override
+  public Node apply(Node root) {
+    if (isEmpty(getValue())) {
+      return root;
+    }
+
+    // Get the entity class and field name
+    Class<?> entityClass = getSearchFieldAccessor().getDeclaringClass();
+    String fieldName = getSearchFieldAccessor().getField().getName();
+
+    // Get the entity prefix
+    String entityPrefix = indexer.getKeyspaceForEntityClass(entityClass);
+    if (entityPrefix == null) {
+      return root;
+    }
+
+    // Construct the sorted set key
+    String sortedSetKey = entityPrefix + fieldName + ":lex";
+
+    // Use ZRANGEBYLEX to find matching entries
+    // For greater than, we need to exclude exact matches with the same prefix
+    // Since our format is "value#id", we append a high character to ensure we skip all entries with this prefix
+    String gtParam = value.toString() + "\uffff"; // Unicode max character
+    Set<String> matches = rmo.template().opsForZSet().rangeByLex(sortedSetKey,
+        org.springframework.data.redis.connection.RedisZSetCommands.Range.range().gt(gtParam),
+        org.springframework.data.redis.connection.RedisZSetCommands.Limit.unlimited());
+
+    if (matches == null || matches.isEmpty()) {
+      // No matches, return a query that matches nothing by using an impossible ID
+      if (root == null || root.toString().isEmpty()) {
+        return QueryBuilders.intersect().add("id", "{__NOMATCH__}");
+      } else {
+        return QueryBuilders.intersect(root).add("id", "{__NOMATCH__}");
+      }
+    }
+
+    // Extract entity IDs from the matches (format is "value#entityId")
+    Set<String> entityIds = matches.stream().map(match -> {
+      int hashIndex = match.lastIndexOf('#');
+      return hashIndex >= 0 ? match.substring(hashIndex + 1) : null;
+    }).filter(id -> id != null).collect(Collectors.toSet());
+
+    if (entityIds.isEmpty()) {
+      // No valid IDs found, return a query that matches nothing
+      if (root == null || root.toString().isEmpty()) {
+        return QueryBuilders.intersect().add("id", "{__NOMATCH__}");
+      } else {
+        return QueryBuilders.intersect(root).add("id", "{__NOMATCH__}");
+      }
+    }
+
+    // Build an ID-based query using the tag syntax: @id:{id1 | id2 | id3}
+    // Join the IDs with " | " separator as per RediSearch tag syntax
+    String idQuery = entityIds.stream().collect(Collectors.joining(" | "));
+
+    // When root is empty (union node), we just return the ID query directly
+    // without intersecting with the empty root to avoid extra parentheses
+    if (root == null || root.toString().isEmpty()) {
+      return QueryBuilders.intersect().add("id", "{" + idQuery + "}");
+    } else {
+      return QueryBuilders.intersect(root).add("id", "{" + idQuery + "}");
+    }
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicLessThanMarker.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicLessThanMarker.java
@@ -1,0 +1,35 @@
+package com.redis.om.spring.search.stream.predicates.lexicographic;
+
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+
+import redis.clients.jedis.search.querybuilder.Node;
+
+/**
+ * A marker predicate for lexicographic less-than operations.
+ * This predicate doesn't apply the query itself but signals to the SearchStream
+ * that a lexicographic comparison is needed.
+ * 
+ * @param <E> the entity type being filtered
+ * @param <T> the field type (must be String or convertible to String)
+ * 
+ * @since 1.0
+ */
+public class LexicographicLessThanMarker<E, T> extends BaseAbstractPredicate<E, T> implements LexicographicPredicate {
+  private final T value;
+
+  public LexicographicLessThanMarker(SearchFieldAccessor field, T value) {
+    super(field);
+    this.value = value;
+  }
+
+  public T getValue() {
+    return value;
+  }
+
+  @Override
+  public Node apply(Node root) {
+    // This is a marker predicate - actual processing happens in SearchStream
+    throw new UnsupportedOperationException("Lexicographic predicates must be processed by SearchStream");
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicLessThanPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicLessThanPredicate.java
@@ -1,0 +1,149 @@
+package com.redis.om.spring.search.stream.predicates.lexicographic;
+
+import static org.apache.commons.lang3.ObjectUtils.isEmpty;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.metamodel.SearchFieldAccessor;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.search.stream.predicates.BaseAbstractPredicate;
+
+import redis.clients.jedis.search.querybuilder.Node;
+import redis.clients.jedis.search.querybuilder.QueryBuilders;
+
+/**
+ * A lexicographic comparison predicate that filters entities where a string field value
+ * is lexicographically less than a specified value.
+ * 
+ * <p>This predicate works by querying the lexicographic sorted set maintained for
+ * fields marked with {@code lexicographic=true} in their {@code @Indexed} or
+ * {@code @Searchable} annotations. It uses Redis ZRANGEBYLEX to efficiently find
+ * matching entries.</p>
+ * 
+ * <p>Example usage in entity streams:</p>
+ * <pre>
+ * // Find products with names before "M" alphabetically
+ * entityStream.filter(Product$.NAME.lt("M"))
+ * 
+ * // Find users with IDs less than "user500"
+ * entityStream.filter(User$.USER_ID.lt("user500"))
+ * </pre>
+ * 
+ * @param <E> the entity type being filtered
+ * @param <T> the field type (must be String or convertible to String)
+ * 
+ * @since 1.0
+ * @see BaseAbstractPredicate
+ * @see LexicographicGreaterThanPredicate
+ * @see LexicographicBetweenPredicate
+ */
+public class LexicographicLessThanPredicate<E, T> extends BaseAbstractPredicate<E, T> {
+  /** The threshold value for comparison */
+  private final T value;
+  private final RedisModulesOperations<String> rmo;
+  private final RediSearchIndexer indexer;
+
+  /**
+   * Creates a new LexicographicLessThanPredicate for the specified field and threshold.
+   * 
+   * @param field   the field accessor for the target string field
+   * @param value   the threshold value (field must be lexicographically less than this)
+   * @param rmo     the Redis operations helper
+   * @param indexer the RediSearch indexer containing field metadata
+   */
+  public LexicographicLessThanPredicate(SearchFieldAccessor field, T value, RedisModulesOperations<String> rmo,
+      RediSearchIndexer indexer) {
+    super(field);
+    this.value = value;
+    this.rmo = rmo;
+    this.indexer = indexer;
+  }
+
+  /**
+   * Returns the threshold value for comparison.
+   * 
+   * @return the threshold value
+   */
+  public T getValue() {
+    return value;
+  }
+
+  /**
+   * Applies this lexicographic less-than predicate to the given query node.
+   * 
+   * <p>This method queries the lexicographic sorted set to find entity IDs where
+   * the field value is lexicographically less than the threshold. It then
+   * creates an ID-based query to match those specific entities.</p>
+   * 
+   * <p>If the value is empty or null, the predicate is ignored and the original
+   * root node is returned unchanged.</p>
+   * 
+   * @param root the base query node to apply this predicate to
+   * @return the modified query node with the lexicographic less-than condition applied,
+   *         or the original root if the predicate cannot be applied
+   */
+  @Override
+  public Node apply(Node root) {
+    if (isEmpty(getValue())) {
+      return root;
+    }
+
+    // Get the entity class and field name
+    Class<?> entityClass = getSearchFieldAccessor().getDeclaringClass();
+    String fieldName = getSearchFieldAccessor().getField().getName();
+
+    // Get the entity prefix
+    String entityPrefix = indexer.getKeyspaceForEntityClass(entityClass);
+    if (entityPrefix == null) {
+      return root;
+    }
+
+    // Construct the sorted set key
+    String sortedSetKey = entityPrefix + fieldName + ":lex";
+
+    // Use ZRANGEBYLEX to find matching entries
+    // For less than, we need to ensure we don't include the value itself
+    // Since format is "value#id", we need to get everything before "value#" (excluded)
+    String ltParam = value.toString() + "#"; // Exclude exact matches with this prefix
+    Set<String> matches = rmo.template().opsForZSet().rangeByLex(sortedSetKey,
+        org.springframework.data.redis.connection.RedisZSetCommands.Range.range().lt(ltParam),
+        org.springframework.data.redis.connection.RedisZSetCommands.Limit.unlimited());
+
+    if (matches == null || matches.isEmpty()) {
+      // No matches, return a query that matches nothing by using an impossible ID
+      if (root == null || root.toString().isEmpty()) {
+        return QueryBuilders.intersect().add("id", "{__NOMATCH__}");
+      } else {
+        return QueryBuilders.intersect(root).add("id", "{__NOMATCH__}");
+      }
+    }
+
+    // Extract entity IDs from the matches (format is "value#entityId")
+    Set<String> entityIds = matches.stream().map(match -> {
+      int hashIndex = match.lastIndexOf('#');
+      return hashIndex >= 0 ? match.substring(hashIndex + 1) : null;
+    }).filter(id -> id != null).collect(Collectors.toSet());
+
+    if (entityIds.isEmpty()) {
+      // No valid IDs found, return a query that matches nothing
+      if (root == null || root.toString().isEmpty()) {
+        return QueryBuilders.intersect().add("id", "{__NOMATCH__}");
+      } else {
+        return QueryBuilders.intersect(root).add("id", "{__NOMATCH__}");
+      }
+    }
+
+    // Build an ID-based query using the tag syntax: @id:{id1 | id2 | id3}
+    // Join the IDs with " | " separator as per RediSearch tag syntax
+    String idQuery = entityIds.stream().collect(Collectors.joining(" | "));
+
+    // Handle empty root node case - check if root is null, empty, or union (which produces empty string)
+    if (root == null || root.toString().isEmpty()) {
+      return QueryBuilders.intersect().add("id", "{" + idQuery + "}");
+    } else {
+      return QueryBuilders.intersect(root).add("id", "{" + idQuery + "}");
+    }
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicPredicate.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/predicates/lexicographic/LexicographicPredicate.java
@@ -1,0 +1,11 @@
+package com.redis.om.spring.search.stream.predicates.lexicographic;
+
+/**
+ * Marker interface for predicates that require lexicographic index support.
+ * These predicates need special handling in the SearchStream to access
+ * the lexicographic sorted sets.
+ * 
+ * @since 1.0
+ */
+public interface LexicographicPredicate {
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/LexicographicDebugTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/LexicographicDebugTest.java
@@ -1,0 +1,81 @@
+package com.redis.om.spring.annotations;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.LexicographicDoc;
+import com.redis.om.spring.fixtures.document.repository.LexicographicDocRepository;
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Debug test for lexicographic feature
+ */
+class LexicographicDebugTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  LexicographicDocRepository repository;
+
+  @Autowired
+  RediSearchIndexer indexer;
+
+  @Autowired
+  RedisModulesOperations<String> modulesOperations;
+
+  @Autowired
+  RedisTemplate<String, String> redisTemplate;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+    
+    // Force index recreation
+    indexer.dropAndRecreateIndexFor(LexicographicDoc.class);
+    
+    // Create test data
+    LexicographicDoc doc1 = LexicographicDoc.of("product001", "Product Alpha", "Electronics", "Active");
+    doc1.setId("1");
+    LexicographicDoc doc2 = LexicographicDoc.of("product002", "Product Beta", "Books", "Active");
+    doc2.setId("2");
+    LexicographicDoc doc3 = LexicographicDoc.of("product003", "Product Gamma", "Clothing", "Inactive");
+    doc3.setId("3");
+    
+    repository.saveAll(Arrays.asList(doc1, doc2, doc3));
+    
+    // Debug: Check sorted set
+    String entityPrefix = indexer.getKeyspaceForEntityClass(LexicographicDoc.class);
+    String skuLexKey = entityPrefix + "sku:lex";
+    Set<String> members = redisTemplate.opsForZSet().range(skuLexKey, 0, -1);
+    System.out.println("Sorted set members: " + members);
+  }
+
+  @Test
+  void debugRepositoryQuery() {
+    System.out.println("\n=== DEBUG REPOSITORY QUERY ===");
+    
+    // Enable debug logging
+    ch.qos.logback.classic.Logger rootLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+    rootLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+    
+    ch.qos.logback.classic.Logger queryLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger("com.redis.om.spring.repository.query");
+    queryLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+    
+    // Try the query
+    List<LexicographicDoc> results = repository.findBySkuGreaterThan("product001");
+    
+    System.out.println("Query results size: " + results.size());
+    for (LexicographicDoc doc : results) {
+      System.out.println("  Result: " + doc.getSku());
+    }
+    
+    assertThat(results).hasSize(2);
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/LexicographicIndexTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/LexicographicIndexTest.java
@@ -1,0 +1,349 @@
+package com.redis.om.spring.annotations;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.LexicographicDoc;
+import com.redis.om.spring.fixtures.document.model.LexicographicDoc$;
+import com.redis.om.spring.fixtures.document.repository.LexicographicDocRepository;
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.search.stream.EntityStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import redis.clients.jedis.search.Schema;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for lexicographic indexing feature on @Indexed and @Searchable annotations.
+ * This feature enables sorted set backing for efficient string range queries.
+ */
+class LexicographicIndexTest extends AbstractBaseDocumentTest {
+  private static final Logger logger = LoggerFactory.getLogger(LexicographicIndexTest.class);
+
+  @Autowired
+  LexicographicDocRepository repository;
+
+  @Autowired
+  RediSearchIndexer indexer;
+
+  @Autowired
+  RedisModulesOperations<String> modulesOperations;
+
+  @Autowired
+  RedisTemplate<String, String> redisTemplate;
+
+  @Autowired
+  EntityStream entityStream;
+
+  private String entityPrefix;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+    
+    // Force index recreation to ensure sorted sets are created
+    indexer.dropAndRecreateIndexFor(LexicographicDoc.class);
+    
+    entityPrefix = indexer.getKeyspaceForEntityClass(LexicographicDoc.class);
+    assertThat(entityPrefix).isNotNull().isNotEmpty();
+
+    // Create test data with explicit IDs
+    LexicographicDoc doc1 = LexicographicDoc.of("product001", "Product Alpha", "Electronics", "Active");
+    doc1.setId("1");
+    LexicographicDoc doc2 = LexicographicDoc.of("product002", "Product Beta", "Books", "Active");
+    doc2.setId("2");
+    LexicographicDoc doc3 = LexicographicDoc.of("product003", "Product Gamma", "Clothing", "Inactive");
+    doc3.setId("3");
+    LexicographicDoc doc4 = LexicographicDoc.of("product004", "Product Delta", "Electronics", "Active");
+    doc4.setId("4");
+    LexicographicDoc doc5 = LexicographicDoc.of("product005", "Product Epsilon", "Food", "Pending");
+    doc5.setId("5");
+    
+    repository.saveAll(Arrays.asList(doc1, doc2, doc3, doc4, doc5));
+  }
+
+  @Test
+  void testIndexedAnnotationHasLexicographicParameter() throws NoSuchFieldException {
+    // Test that @Indexed annotation has lexicographic parameter
+    Field skuField = LexicographicDoc.class.getDeclaredField("sku");
+    Indexed indexed = skuField.getAnnotation(Indexed.class);
+    
+    assertNotNull(indexed, "@Indexed annotation should be present on sku field");
+    assertTrue(indexed.lexicographic(), "lexicographic parameter should be true");
+  }
+
+  @Test
+  void testSearchableAnnotationHasLexicographicParameter() throws NoSuchFieldException {
+    // Test that @Searchable annotation has lexicographic parameter
+    Field nameField = LexicographicDoc.class.getDeclaredField("name");
+    Searchable searchable = nameField.getAnnotation(Searchable.class);
+    
+    assertNotNull(searchable, "@Searchable annotation should be present on name field");
+    assertTrue(searchable.lexicographic(), "lexicographic parameter should be true");
+  }
+
+  @Test
+  void testSortedSetCreatedForLexicographicFields() {
+    // Verify that sorted sets are created for fields with lexicographic=true
+    String skuLexKey = entityPrefix + "sku:lex";
+    String nameLexKey = entityPrefix + "name:lex";
+    String categoryLexKey = entityPrefix + "category:lex";
+    String statusLexKey = entityPrefix + "status:lex"; // Should not exist
+
+    assertTrue(redisTemplate.hasKey(skuLexKey), "Sorted set for sku field should exist");
+    assertTrue(redisTemplate.hasKey(nameLexKey), "Sorted set for name field should exist");
+    assertTrue(redisTemplate.hasKey(categoryLexKey), "Sorted set for category field should exist");
+    assertFalse(redisTemplate.hasKey(statusLexKey), "Sorted set for status field should not exist (lexicographic=false)");
+  }
+
+  @Test
+  void testSortedSetContainsCorrectEntries() {
+    String skuLexKey = entityPrefix + "sku:lex";
+    logger.debug("Checking sorted set key: '{}'", skuLexKey);
+    
+    // Check sorted set members
+    Set<String> members = redisTemplate.opsForZSet().range(skuLexKey, 0, -1);
+    assertNotNull(members);
+    logger.debug("Sorted set members: {}", members);
+    
+    // After the saveAll in setup, we should have 5 entries
+    assertEquals(5, members.size(), "Should have 5 entries in sorted set");
+    
+    // Verify member format (value#id)
+    assertTrue(members.stream().anyMatch(m -> m.startsWith("product001#")), 
+      "Should contain entry for product001");
+    assertTrue(members.stream().anyMatch(m -> m.startsWith("product002#")), 
+      "Should contain entry for product002");
+    assertTrue(members.stream().anyMatch(m -> m.startsWith("product003#")), 
+      "Should contain entry for product003");
+    assertTrue(members.stream().anyMatch(m -> m.startsWith("product004#")), 
+      "Should contain entry for product004");
+    assertTrue(members.stream().anyMatch(m -> m.startsWith("product005#")), 
+      "Should contain entry for product005");
+    
+    // Verify lexicographic ordering
+    // Get entries in sorted set order (should already be lexicographic)
+    List<String> entriesInOrder = new ArrayList<>(members);
+    List<String> entriesSorted = entriesInOrder.stream().sorted().collect(Collectors.toList());
+    assertEquals(entriesSorted, entriesInOrder, 
+      "Members should be in lexicographic order");
+  }
+
+  @Test
+  void testRepositoryMethodFindBySkuGreaterThan() {
+    List<LexicographicDoc> results = repository.findBySkuGreaterThan("product002");
+    
+    assertThat(results).hasSize(3);
+    assertThat(results.stream().map(LexicographicDoc::getSku))
+      .containsExactlyInAnyOrder("product003", "product004", "product005");
+  }
+
+  @Test
+  void testRepositoryMethodFindByNameLessThan() {
+    List<LexicographicDoc> results = repository.findByNameLessThan("Product Delta");
+    
+    assertThat(results).hasSize(2);
+    assertThat(results.stream().map(LexicographicDoc::getName))
+      .containsExactlyInAnyOrder("Product Alpha", "Product Beta");
+  }
+
+  @Test
+  void testRepositoryMethodFindBySkuBetween() {
+    List<LexicographicDoc> results = repository.findBySkuBetween("product002", "product004");
+    
+    assertThat(results).hasSize(3);
+    assertThat(results.stream().map(LexicographicDoc::getSku))
+      .containsExactlyInAnyOrder("product002", "product003", "product004");
+  }
+
+  @Test
+  void testEntityStreamGtMethodOnTextTagField() {
+    var stream = entityStream.of(LexicographicDoc.class);
+    logger.debug("Initial backing query: '{}'", stream.backingQuery());
+    
+    logger.debug("SKU field type: {}", LexicographicDoc$.SKU.getClass().getName());
+    var predicate = LexicographicDoc$.SKU.gt("product003");
+    logger.debug("Predicate class: {}", predicate.getClass().getName());
+    logger.debug("Predicate simple name: {}", predicate.getClass().getSimpleName());
+    logger.debug("Is LexicographicPredicate? {}", (predicate instanceof com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicPredicate));
+    logger.debug("Is LexicographicGreaterThanMarker? {}", (predicate instanceof com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicGreaterThanMarker));
+    
+    var filteredStream = stream.filter(predicate);
+    logger.debug("After filter backing query: '{}'", filteredStream.backingQuery());
+    
+    List<LexicographicDoc> results = filteredStream.collect(Collectors.toList());
+    logger.debug("Results count: {}", results.size());
+    results.forEach(r -> logger.debug("Result: {} (id={})", r.getSku(), r.getId()));
+    
+    assertThat(results).hasSize(2);
+    assertThat(results.stream().map(LexicographicDoc::getSku))
+      .containsExactlyInAnyOrder("product004", "product005");
+  }
+
+  @Test
+  void testEntityStreamLtMethodOnTextField() {
+    List<LexicographicDoc> results = entityStream
+      .of(LexicographicDoc.class)
+      .filter(LexicographicDoc$.NAME.lt("Product Gamma"))
+      .collect(Collectors.toList());
+    
+    assertThat(results).hasSize(4);
+    assertThat(results.stream().map(LexicographicDoc::getName))
+      .containsExactlyInAnyOrder("Product Alpha", "Product Beta", "Product Delta", "Product Epsilon");
+  }
+
+  @Test
+  void testEntityStreamBetweenMethod() {
+    List<LexicographicDoc> results = entityStream
+      .of(LexicographicDoc.class)
+      .filter(LexicographicDoc$.CATEGORY.between("Books", "Electronics"))
+      .collect(Collectors.toList());
+    
+    assertThat(results).hasSize(4); // Two Electronics entries (id=1 and id=4), plus Books and Clothing
+    assertThat(results.stream().map(LexicographicDoc::getCategory))
+      .containsExactlyInAnyOrder("Electronics", "Books", "Clothing", "Electronics");
+  }
+
+  @Test
+  void testUpdateMaintainsSortedSet() {
+    // First, check what's in the sorted set before updating
+    String skuLexKey = entityPrefix + "sku:lex";
+    Set<String> beforeMembers = redisTemplate.opsForZSet().range(skuLexKey, 0, -1);
+    logger.debug("Before update: {}", beforeMembers);
+    
+    // Update a document
+    LexicographicDoc doc = repository.findById("1").orElseThrow();
+    String oldSku = doc.getSku();
+    logger.debug("Found doc with SKU: {}", oldSku);
+    doc.setSku("product000"); // Change to come before all others
+    repository.save(doc);
+    
+    // Verify sorted set was updated
+    Set<String> afterMembers = redisTemplate.opsForZSet().range(skuLexKey, 0, -1);
+    logger.debug("After update: {}", afterMembers);
+    
+    // Old entry should be removed
+    assertFalse(afterMembers.stream().anyMatch(m -> m.startsWith(oldSku + "#")), 
+      "Old SKU entry should be removed");
+    
+    // New entry should exist
+    assertTrue(afterMembers.stream().anyMatch(m -> m.startsWith("product000#")), 
+      "New SKU entry should exist");
+    
+    // Should still have 5 entries after update
+    assertEquals(5, afterMembers.size(), "Should still have 5 entries after update");
+  }
+
+  @Test
+  void testDeleteRemovesFromSortedSet() {
+    // First, check what's in the sorted set before deleting
+    String skuLexKey = entityPrefix + "sku:lex";
+    Set<String> beforeMembers = redisTemplate.opsForZSet().range(skuLexKey, 0, -1);
+    logger.debug("Before delete: {}", beforeMembers);
+    
+    // Delete a document
+    repository.deleteById("3");
+    
+    // Verify sorted set was updated
+    Set<String> afterMembers = redisTemplate.opsForZSet().range(skuLexKey, 0, -1);
+    logger.debug("After delete: {}", afterMembers);
+    
+    // Should have 4 entries now  
+    assertEquals(4, afterMembers.size(), "Should have 4 entries after delete");
+    
+    // Deleted entry should not exist
+    assertFalse(afterMembers.stream().anyMatch(m -> m.contains("#3")), 
+      "Deleted document entry should not exist");
+  }
+
+  // Tests for @Searchable(lexicographic=true) field
+  @Test
+  void testSearchableLexicographicGreaterThan() {
+    // Test repository method for name field (TEXT field with lexicographic=true)
+    List<LexicographicDoc> results = repository.findByNameGreaterThan("Product Beta");
+    
+    assertThat(results).hasSize(3);
+    assertThat(results.stream().map(LexicographicDoc::getName))
+      .containsExactlyInAnyOrder("Product Gamma", "Product Delta", "Product Epsilon");
+  }
+
+  @Test
+  void testSearchableLexicographicLessThan() {
+    // Test that findByNameLessThan works correctly
+    List<LexicographicDoc> results = repository.findByNameLessThan("Product Delta");
+    
+    assertThat(results).hasSize(2);
+    assertThat(results.stream().map(LexicographicDoc::getName))
+      .containsExactlyInAnyOrder("Product Alpha", "Product Beta");
+  }
+
+  @Test
+  void testSearchableLexicographicBetween() {
+    // Test repository method for name field between range
+    List<LexicographicDoc> results = repository.findByNameBetween("Product Beta", "Product Delta");
+    
+    assertThat(results).hasSize(2);
+    assertThat(results.stream().map(LexicographicDoc::getName))
+      .containsExactlyInAnyOrder("Product Beta", "Product Delta");
+  }
+
+  @Test
+  void testEntityStreamWithSearchableLexicographic() {
+    // Test EntityStream with TextField gt method
+    List<LexicographicDoc> results = entityStream
+      .of(LexicographicDoc.class)
+      .filter(LexicographicDoc$.NAME.gt("Product Beta"))
+      .collect(Collectors.toList());
+    
+    assertThat(results).hasSize(3);
+    assertThat(results.stream().map(LexicographicDoc::getName))
+      .containsExactlyInAnyOrder("Product Gamma", "Product Delta", "Product Epsilon");
+  }
+
+  @Test
+  void testEntityStreamSearchableLexicographicBetween() {
+    // Test EntityStream with TextField between method
+    List<LexicographicDoc> results = entityStream
+      .of(LexicographicDoc.class)
+      .filter(LexicographicDoc$.NAME.between("Product Alpha", "Product Gamma"))
+      .sorted(LexicographicDoc$.NAME)
+      .collect(Collectors.toList());
+    
+    assertThat(results).hasSize(5);
+    assertThat(results.stream().map(LexicographicDoc::getName))
+      .containsExactly("Product Alpha", "Product Beta", "Product Delta", "Product Epsilon", "Product Gamma");
+  }
+
+  @Test
+  void testSearchableLexicographicSortedSetCreated() {
+    // Verify that a sorted set is created for the name field
+    String nameLexKey = entityPrefix + "name:lex";
+    
+    // Check that the sorted set exists
+    Long size = redisTemplate.opsForZSet().size(nameLexKey);
+    assertNotNull(size);
+    assertEquals(5L, size, "Should have 5 entries in name lexicographic sorted set");
+    
+    // Verify the entries are in correct order
+    Set<String> members = redisTemplate.opsForZSet().range(nameLexKey, 0, -1);
+    assertNotNull(members);
+    assertEquals(5, members.size());
+    
+    // Convert to list to check order
+    List<String> orderedMembers = new ArrayList<>(members);
+    assertTrue(orderedMembers.get(0).startsWith("Product Alpha#"));
+    assertTrue(orderedMembers.get(1).startsWith("Product Beta#"));
+    assertTrue(orderedMembers.get(2).startsWith("Product Delta#"));
+    assertTrue(orderedMembers.get(3).startsWith("Product Epsilon#"));
+    assertTrue(orderedMembers.get(4).startsWith("Product Gamma#"));
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/LexicographicLessThanDebugTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/LexicographicLessThanDebugTest.java
@@ -1,0 +1,82 @@
+package com.redis.om.spring.annotations;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.LexicographicDoc;
+import com.redis.om.spring.fixtures.document.repository.LexicographicDocRepository;
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Debug test for lexicographic LessThan queries
+ */
+class LexicographicLessThanDebugTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  LexicographicDocRepository repository;
+
+  @Autowired
+  RediSearchIndexer indexer;
+
+  @Autowired
+  RedisTemplate<String, String> redisTemplate;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+    
+    // Force index recreation
+    indexer.dropAndRecreateIndexFor(LexicographicDoc.class);
+    
+    // Create test data
+    LexicographicDoc doc1 = LexicographicDoc.of("product001", "Product Alpha", "Electronics", "Active");
+    doc1.setId("1");
+    LexicographicDoc doc2 = LexicographicDoc.of("product002", "Product Beta", "Books", "Active");
+    doc2.setId("2");
+    LexicographicDoc doc3 = LexicographicDoc.of("product003", "Product Gamma", "Clothing", "Inactive");
+    doc3.setId("3");
+    LexicographicDoc doc4 = LexicographicDoc.of("product004", "Product Delta", "Electronics", "Active");
+    doc4.setId("4");
+    LexicographicDoc doc5 = LexicographicDoc.of("product005", "Product Epsilon", "Food", "Pending");
+    doc5.setId("5");
+    
+    repository.saveAll(Arrays.asList(doc1, doc2, doc3, doc4, doc5));
+    
+    // Debug: Check sorted set for name field
+    String entityPrefix = indexer.getKeyspaceForEntityClass(LexicographicDoc.class);
+    String nameLexKey = entityPrefix + "name:lex";
+    Set<String> members = redisTemplate.opsForZSet().range(nameLexKey, 0, -1);
+    System.out.println("Name sorted set members: " + members);
+    
+    // Test direct ZRANGEBYLEX
+    Set<String> directQuery = redisTemplate.opsForZSet().rangeByLex(nameLexKey,
+        org.springframework.data.redis.connection.RedisZSetCommands.Range.range().lt("Product Delta#"));
+    System.out.println("Direct ZRANGEBYLEX LT 'Product Delta#': " + directQuery);
+  }
+
+  @Test
+  void testLessThanQuery() {
+    System.out.println("\n=== TEST LESS THAN QUERY ===");
+    
+    List<LexicographicDoc> results = repository.findByNameLessThan("Product Delta");
+    
+    System.out.println("Results size: " + results.size());
+    for (LexicographicDoc doc : results) {
+      System.out.println("  Result: " + doc.getName() + " (id=" + doc.getId() + ")");
+    }
+    
+    // Check lexicographic ordering manually
+    String[] names = {"Product Alpha", "Product Beta", "Product Gamma", "Product Delta", "Product Epsilon"};
+    System.out.println("\nLexicographic comparison with 'Product Delta':");
+    for (String name : names) {
+      int comparison = name.compareTo("Product Delta");
+      System.out.println("  '" + name + "'.compareTo('Product Delta') = " + comparison + " (" + (comparison < 0 ? "LESS" : comparison > 0 ? "GREATER" : "EQUAL") + ")");
+    }
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/LexicographicMinimalTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/LexicographicMinimalTest.java
@@ -1,0 +1,68 @@
+package com.redis.om.spring.annotations;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.LexicographicDoc;
+import com.redis.om.spring.fixtures.document.repository.LexicographicDocRepository;
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.repository.query.RediSearchQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Minimal test for lexicographic queries with full debug logging
+ */
+class LexicographicMinimalTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  LexicographicDocRepository repository;
+
+  @Autowired
+  RediSearchIndexer indexer;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+    
+    // Enable debug logging for RediSearchQuery and LexicographicQueryExecutor
+    ch.qos.logback.classic.Logger queryLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(RediSearchQuery.class);
+    queryLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+    
+    ch.qos.logback.classic.Logger lexLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger("com.redis.om.spring.repository.query.lexicographic");
+    lexLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+    
+    // Force index recreation
+    indexer.dropAndRecreateIndexFor(LexicographicDoc.class);
+    
+    // Create test data
+    LexicographicDoc doc1 = LexicographicDoc.of("product001", "Product Alpha", "Electronics", "Active");
+    doc1.setId("1");
+    LexicographicDoc doc2 = LexicographicDoc.of("product002", "Product Beta", "Books", "Active");
+    doc2.setId("2");
+    LexicographicDoc doc3 = LexicographicDoc.of("product003", "Product Gamma", "Clothing", "Inactive");
+    doc3.setId("3");
+    
+    repository.saveAll(Arrays.asList(doc1, doc2, doc3));
+  }
+
+  @Test
+  void testFindBySkuGreaterThan() {
+    System.out.println("\n=== TEST FIND BY SKU GREATER THAN ===");
+    
+    List<LexicographicDoc> results = repository.findBySkuGreaterThan("product001");
+    
+    System.out.println("Results size: " + results.size());
+    for (LexicographicDoc doc : results) {
+      System.out.println("  Result: " + doc.getSku() + " - " + doc.getName());
+    }
+    
+    assertThat(results).hasSize(2);
+    assertThat(results.stream().map(LexicographicDoc::getSku))
+      .containsExactlyInAnyOrder("product002", "product003");
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/LexicographicQueryDebugTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/LexicographicQueryDebugTest.java
@@ -1,0 +1,118 @@
+package com.redis.om.spring.annotations;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.LexicographicDoc;
+import com.redis.om.spring.fixtures.document.repository.LexicographicDocRepository;
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.repository.query.RediSearchQuery;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Debug test for lexicographic query processing
+ */
+class LexicographicQueryDebugTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  LexicographicDocRepository repository;
+
+  @Autowired
+  RediSearchIndexer indexer;
+
+  @Autowired
+  RedisModulesOperations<String> modulesOperations;
+
+  @Autowired
+  RedisTemplate<String, String> redisTemplate;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+    
+    // Enable debug logging
+    ch.qos.logback.classic.Logger rootLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME);
+    rootLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+    
+    ch.qos.logback.classic.Logger queryLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(RediSearchQuery.class);
+    queryLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+    
+    ch.qos.logback.classic.Logger indexerLogger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(RediSearchIndexer.class);
+    indexerLogger.setLevel(ch.qos.logback.classic.Level.DEBUG);
+    
+    // Force index recreation
+    indexer.dropAndRecreateIndexFor(LexicographicDoc.class);
+    
+    // Create test data
+    LexicographicDoc doc1 = LexicographicDoc.of("product001", "Product Alpha", "Electronics", "Active");
+    doc1.setId("1");
+    LexicographicDoc doc2 = LexicographicDoc.of("product002", "Product Beta", "Books", "Active");
+    doc2.setId("2");
+    LexicographicDoc doc3 = LexicographicDoc.of("product003", "Product Gamma", "Clothing", "Inactive");
+    doc3.setId("3");
+    LexicographicDoc doc4 = LexicographicDoc.of("product004", "Product Delta", "Electronics", "Active");
+    doc4.setId("4");
+    LexicographicDoc doc5 = LexicographicDoc.of("product005", "Product Epsilon", "Books", "Inactive");
+    doc5.setId("5");
+    
+    repository.saveAll(Arrays.asList(doc1, doc2, doc3, doc4, doc5));
+    
+    // Debug: Check sorted set
+    String entityPrefix = indexer.getKeyspaceForEntityClass(LexicographicDoc.class);
+    String skuLexKey = entityPrefix + "sku:lex";
+    Set<String> members = redisTemplate.opsForZSet().range(skuLexKey, 0, -1);
+    System.out.println("Sorted set key: " + skuLexKey);
+    System.out.println("Sorted set members: " + members);
+    
+    // Check if documents exist
+    long count = repository.count();
+    System.out.println("Total documents: " + count);
+    
+    // Test direct sorted set query
+    Set<String> directQuery = redisTemplate.opsForZSet().rangeByLex(skuLexKey,
+        org.springframework.data.redis.connection.RedisZSetCommands.Range.range().gt("product002"));
+    System.out.println("Direct ZRANGEBYLEX result: " + directQuery);
+  }
+
+  @Test
+  void debugRepositoryQuery() {
+    System.out.println("\n=== DEBUG REPOSITORY QUERY ===");
+    
+    // Try the query
+    List<LexicographicDoc> results = repository.findBySkuGreaterThan("product002");
+    
+    System.out.println("Query results size: " + results.size());
+    for (LexicographicDoc doc : results) {
+      System.out.println("  Result: " + doc.getSku() + " - " + doc.getName());
+    }
+    
+    assertThat(results).hasSize(3);
+    assertThat(results.stream().map(LexicographicDoc::getSku))
+      .containsExactlyInAnyOrder("product003", "product004", "product005");
+  }
+  
+  @Test
+  void debugFindAll() {
+    System.out.println("\n=== DEBUG FIND ALL ===");
+    
+    // Try simple find all
+    Iterable<LexicographicDoc> results = repository.findAll();
+    
+    int count = 0;
+    for (LexicographicDoc doc : results) {
+      System.out.println("  Result: " + doc.getSku() + " - " + doc.getName());
+      count++;
+    }
+    
+    System.out.println("Find all results size: " + count);
+    assertThat(count).isEqualTo(5);
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/LexicographicDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/LexicographicDoc.java
@@ -1,0 +1,39 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+
+/**
+ * Test entity for lexicographic indexing feature.
+ * Demonstrates the use of lexicographic=true parameter on both
+ * @Indexed and @Searchable annotations to enable sorted set backing
+ * for efficient string range queries.
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(force = true)
+@Document
+public class LexicographicDoc {
+  @Id
+  private String id;
+  
+  @NonNull
+  @Indexed(lexicographic = true)
+  private String sku;
+  
+  @NonNull
+  @Searchable(lexicographic = true)
+  private String name;
+  
+  @NonNull
+  @Indexed(lexicographic = true)
+  private String category;
+  
+  @NonNull
+  @Indexed // lexicographic = false by default
+  private String status;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/StringComparisonTestDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/StringComparisonTestDoc.java
@@ -1,0 +1,41 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+import com.redis.om.spring.annotations.TextIndexed;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.annotation.Id;
+
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
+@Document
+public class StringComparisonTestDoc {
+  @Id
+  private String id;
+
+  @NonNull
+  @Indexed(lexicographic = true)
+  private String indexedStringField;
+
+  @NonNull
+  @Searchable
+  private String searchableStringField;
+
+  @NonNull
+  @TextIndexed
+  private String textIndexedStringField;
+
+  @NonNull
+  private String regularStringField;
+
+  @NonNull
+  @Indexed(lexicographic = true)
+  private String comId;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/LexicographicDocRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/LexicographicDocRepository.java
@@ -1,0 +1,30 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import com.redis.om.spring.fixtures.document.model.LexicographicDoc;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+import java.util.List;
+
+public interface LexicographicDocRepository extends RedisDocumentRepository<LexicographicDoc, String> {
+  
+  // SKU field queries (TAG field with lexicographic=true)
+  List<LexicographicDoc> findBySkuGreaterThan(String sku);
+  List<LexicographicDoc> findBySkuLessThan(String sku);
+  List<LexicographicDoc> findBySkuGreaterThanEqual(String sku);
+  List<LexicographicDoc> findBySkuLessThanEqual(String sku);
+  List<LexicographicDoc> findBySkuBetween(String min, String max);
+  
+  // Name field queries (TEXT field with lexicographic=true)
+  List<LexicographicDoc> findByNameGreaterThan(String name);
+  List<LexicographicDoc> findByNameLessThan(String name);
+  List<LexicographicDoc> findByNameBetween(String min, String max);
+  
+  // Category field queries (TAG field with lexicographic=true)
+  List<LexicographicDoc> findByCategoryGreaterThan(String category);
+  List<LexicographicDoc> findByCategoryLessThan(String category);
+  List<LexicographicDoc> findByCategoryBetween(String min, String max);
+  
+  // Status field queries (TAG field with lexicographic=false)
+  // These should work as normal TAG queries
+  List<LexicographicDoc> findByStatus(String status);
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/StringComparisonTestDocRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/StringComparisonTestDocRepository.java
@@ -1,0 +1,28 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import com.redis.om.spring.fixtures.document.model.StringComparisonTestDoc;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface StringComparisonTestDocRepository extends RedisDocumentRepository<StringComparisonTestDoc, String> {
+  
+  List<StringComparisonTestDoc> findByIndexedStringFieldGreaterThan(String value);
+  
+  List<StringComparisonTestDoc> findByIndexedStringFieldLessThan(String value);
+  
+  List<StringComparisonTestDoc> findByIndexedStringFieldGreaterThanEqual(String value);
+  
+  List<StringComparisonTestDoc> findByIndexedStringFieldLessThanEqual(String value);
+  
+  List<StringComparisonTestDoc> findByComIdGreaterThan(String comId);
+  
+  List<StringComparisonTestDoc> findByComIdLessThan(String comId);
+  
+  List<StringComparisonTestDoc> findByComIdBetween(String start, String end);
+  
+  List<StringComparisonTestDoc> findBySearchableStringFieldGreaterThan(String value);
+  
+  List<StringComparisonTestDoc> findByTextIndexedStringFieldGreaterThan(String value);
+}

--- a/tests/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
+++ b/tests/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
@@ -1,23 +1,21 @@
 package com.redis.om.spring.metamodel;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.Collectors;
-
-import javax.tools.JavaFileObject;
-
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import com.karuslabs.elementary.Results;
 import com.karuslabs.elementary.junit.JavacExtension;
 import com.karuslabs.elementary.junit.annotations.Classpath;
 import com.karuslabs.elementary.junit.annotations.Options;
 import com.karuslabs.elementary.junit.annotations.Processors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import javax.tools.JavaFileObject;
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @SuppressWarnings(
   "SpellCheckingInspection"
@@ -558,5 +556,42 @@ class MetamodelGeneratorTest {
         //
         () -> assertThat(fileContents).contains(
             "_KEY = new MetamodelField<ValidDocumentNumericIndexed, String>(\"__key\", String.class, true);"));
+  }
+
+  @Test
+  void testLexicographicPredicateGeneration() {
+    // Test that the generated metamodel fields produce correct lexicographic predicates
+    var gtPredicate = com.redis.om.spring.fixtures.document.model.LexicographicDoc$.SKU.gt("product003");
+    assertThat(gtPredicate).isInstanceOf(
+        com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicGreaterThanMarker.class);
+    assertThat(
+        ((com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicGreaterThanMarker<?, ?>) gtPredicate).getValue()).isEqualTo(
+        "product003");
+
+    var ltPredicate = com.redis.om.spring.fixtures.document.model.LexicographicDoc$.SKU.lt("product003");
+    assertThat(ltPredicate).isInstanceOf(
+        com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicLessThanMarker.class);
+    assertThat(
+        ((com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicLessThanMarker<?, ?>) ltPredicate).getValue()).isEqualTo(
+        "product003");
+
+    var betweenPredicate = com.redis.om.spring.fixtures.document.model.LexicographicDoc$.SKU.between("product001",
+        "product005");
+    assertThat(betweenPredicate).isInstanceOf(
+        com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicBetweenMarker.class);
+    assertThat(
+        ((com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicBetweenMarker<?, ?>) betweenPredicate).getMin()).isEqualTo(
+        "product001");
+    assertThat(
+        ((com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicBetweenMarker<?, ?>) betweenPredicate).getMax()).isEqualTo(
+        "product005");
+
+    // Test that TextField also generates correct lexicographic predicates
+    var namePredicate = com.redis.om.spring.fixtures.document.model.LexicographicDoc$.NAME.lt("Product Gamma");
+    assertThat(namePredicate).isInstanceOf(
+        com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicLessThanMarker.class);
+    assertThat(
+        ((com.redis.om.spring.search.stream.predicates.lexicographic.LexicographicLessThanMarker<?, ?>) namePredicate).getValue()).isEqualTo(
+        "Product Gamma");
   }
 }

--- a/tests/src/test/java/com/redis/om/spring/repository/StringComparisonTest.java
+++ b/tests/src/test/java/com/redis/om/spring/repository/StringComparisonTest.java
@@ -1,0 +1,133 @@
+package com.redis.om.spring.repository;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.StringComparisonTestDoc;
+import com.redis.om.spring.fixtures.document.model.StringComparisonTestDoc$;
+import com.redis.om.spring.fixtures.document.repository.StringComparisonTestDocRepository;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.search.stream.EntityStream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.ExampleMatcher;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests to demonstrate the missing feature for string comparison operations
+ * as described in issue #526: https://github.com/redis/redis-om-spring/issues/526
+ *
+ * The issue requests support for TextTagField and TextField GreaterThan, LessThan
+ * or CompareTo operations for string fields in Redis OM Spring.
+ */
+class StringComparisonTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  StringComparisonTestDocRepository repository;
+
+  @Autowired
+  RedisModulesOperations<String> modulesOperations;
+
+  @Autowired
+  EntityStream entityStream;
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+
+    // Create test data with string values that can be compared lexicographically
+    repository.saveAll(Arrays.asList(
+      StringComparisonTestDoc.of("AAA", "text_aaa", "text_aaa", "regular_001", "100000001"),
+      StringComparisonTestDoc.of("BBB", "text_bbb", "text_bbb", "regular_002", "100000002"),
+      StringComparisonTestDoc.of("CCC", "text_ccc", "text_ccc", "regular_003", "100000003"),
+      StringComparisonTestDoc.of("DDD", "text_ddd", "text_ddd", "regular_004", "100000004"),
+      StringComparisonTestDoc.of("EEE", "text_eee", "text_eee", "regular_005", "100000005")
+    ));
+  }
+
+  @Test
+  void testRepositoryMethodFindByIndexedStringFieldGreaterThan() {
+    // Test if findByFieldGreaterThan works for @Indexed string fields
+    List<StringComparisonTestDoc> results = repository.findByIndexedStringFieldGreaterThan("BBB");
+
+    // Expected behavior: Should return docs with values > "BBB" (i.e., "CCC", "DDD", "EEE")
+    // The feature is now properly supported with lexicographic=true
+    assertThat(results).hasSize(3);
+    assertThat(results.stream().map(StringComparisonTestDoc::getIndexedStringField))
+      .containsExactlyInAnyOrder("CCC", "DDD", "EEE");
+  }
+
+  @Test
+  void testRepositoryMethodFindByComIdGreaterThan() {
+    // Test the specific use case from the issue - comparing comId strings
+    List<StringComparisonTestDoc> results = repository.findByComIdGreaterThan("100000003");
+
+    // Expected behavior: Should return docs with comId > "100000003" (i.e., "100000004", "100000005")
+    // The feature is now properly supported with lexicographic=true
+    assertThat(results).hasSize(2);
+    assertThat(results.stream().map(StringComparisonTestDoc::getComId))
+      .containsExactlyInAnyOrder("100000004", "100000005");
+  }
+
+  @Test
+  void testEntityStreamWithGtOperationOnStringField() {
+    // This test demonstrates that gt() is supported for string fields in EntityStream
+    // when the field is marked with lexicographic=true
+
+    // This is what the user wants to do (from issue #526):
+    List<StringComparisonTestDoc> results = entityStream
+      .of(StringComparisonTestDoc.class)
+      .filter(StringComparisonTestDoc$.COM_ID.gt("100000003"))
+      .collect(Collectors.toList());
+
+    // The feature is now implemented for fields with lexicographic=true
+    assertThat(results).hasSize(2);
+    assertThat(results.stream().map(StringComparisonTestDoc::getComId))
+      .containsExactlyInAnyOrder("100000004", "100000005");
+  }
+
+  @Test
+  void testEntityStreamWithLtOperationOnStringField() {
+    // This test demonstrates that lt() is supported for string fields in EntityStream
+    // when the field is marked with lexicographic=true
+
+    // This is what the user wants to do:
+    List<StringComparisonTestDoc> results = entityStream
+      .of(StringComparisonTestDoc.class)
+      .filter(StringComparisonTestDoc$.COM_ID.lt("100000003"))
+      .collect(Collectors.toList());
+
+    assertThat(results).hasSize(2);
+    assertThat(results.stream().map(StringComparisonTestDoc::getComId))
+      .containsExactlyInAnyOrder("100000001", "100000002");
+  }
+
+  @Test
+  void testQueryByExampleWithStringComparison() {
+    // Test Query By Example with string comparison
+    StringComparisonTestDoc probe = new StringComparisonTestDoc();
+    probe.setComId("100000003");
+
+    // ExampleMatcher only supports exact, contains, startsWith, endsWith, and regex
+    // It does NOT support greater than or less than comparisons
+    ExampleMatcher matcher = ExampleMatcher.matching()
+      .withMatcher("comId", ExampleMatcher.GenericPropertyMatchers.exact());
+
+    Example<StringComparisonTestDoc> example = Example.of(probe, matcher);
+    List<StringComparisonTestDoc> results = (List<StringComparisonTestDoc>) repository.findAll(example);
+
+    // This will only find exact matches, not greater/less than
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getComId()).isEqualTo("100000003");
+
+    // There's no way to create an ExampleMatcher for > or < comparisons
+    // Note: ExampleMatcher does not support comparison operations (>, <, >=, <=) for strings
+  }
+
+
+}


### PR DESCRIPTION
Implements lexicographic string comparison operations (>, <, >=, <=, between) for string fields
in Redis OM Spring. This feature enables efficient range queries on string data using Redis
sorted sets with ZRANGEBYLEX commands.

Key changes:
- Add lexicographic parameter to [@Indexed](https://github.com/Indexed) and [@Searchable](https://github.com/Searchable) annotations
- Implement sorted set indexing for fields marked with lexicographic=true
- Add gt(), lt(), and between() methods to TextTagField and TextField metamodel classes
- Support repository query methods like findByFieldGreaterThan for lexicographic fields
- Integrate lexicographic predicates with EntityStream API
- Create LexicographicQueryExecutor to handle repository method queries
- Implement marker/implementation predicate pattern for clean separation of concerns

The feature maintains backward compatibility and only activates when explicitly enabled
via the lexicographic parameter. All string comparison operations are performed using
Redis sorted sets for optimal performance.

Usage:
```java
@Indexed(lexicographic = true)
private String comId;

// Repository method
List<Entity> findByComIdGreaterThan(String value);

// EntityStream API
entityStream.of(Entity.class)
  .filter(Entity$.COM_ID.gt("100000"))
  .collect(Collectors.toList());
```