### PR TITLE
feat: add projection and map support for aggregations (#539)

### DIFF
--- a/docs/content/modules/ROOT/pages/entity-streams-aggregations.adoc
+++ b/docs/content/modules/ROOT/pages/entity-streams-aggregations.adoc
@@ -299,6 +299,154 @@ entityStream.of(Person.class)
     });
 ----
 
+== Projections and Maps
+
+Redis OM Spring supports projections and map-based results for aggregations, providing flexible ways to work with aggregated data.
+
+=== Interface-Based Projections
+
+You can define projection interfaces to shape your aggregation results. IDs are not automatically included - add `getId()` to your projection if needed.
+
+[source,java]
+----
+import static com.redis.om.spring.annotations.ReducerFunction.*;
+
+// Define projection interface
+public interface DepartmentStatsProjection {
+    Integer getDepartmentNumber();
+    Long getHeadcount();
+    Double getTotalSales();
+    // String getId();  // Uncomment only if ID is needed
+}
+
+// Use projection with aggregation
+List<DepartmentStatsProjection> stats = entityStream.of(Person.class)
+    .groupBy(Person$.DEPARTMENT_NUMBER)
+    .reduce(COUNT).as("headcount")
+    .reduce(SUM, Person$.SALES).as("totalSales")
+    .sorted(Order.desc("@totalSales"))
+    .toProjection(DepartmentStatsProjection.class);
+
+// Access data through interface methods
+stats.forEach(stat -> {
+    System.out.printf("Dept %d: %d employees, $%.2f total sales%n",
+        stat.getDepartmentNumber(), 
+        stat.getHeadcount(), 
+        stat.getTotalSales());
+});
+----
+
+=== Simple Field Projections
+
+For simpler use cases, create projections for specific fields:
+
+[source,java]
+----
+import static com.redis.om.spring.annotations.ReducerFunction.*;
+
+public interface NameProjection {
+    String getName();
+    Long getCount();
+}
+
+// Get just names from aggregation with count
+List<NameProjection> names = entityStream.of(Person.class)
+    .groupBy(Person$.NAME)
+    .reduce(COUNT).as("count")
+    .toProjection(NameProjection.class);
+----
+
+=== Map-Based Results
+
+For maximum flexibility, convert aggregation results to Maps. By default, IDs are included.
+
+[source,java]
+----
+import static com.redis.om.spring.annotations.ReducerFunction.*;
+import java.util.Map;
+
+// Get results as maps with IDs included
+List<Map<String, Object>> results = entityStream.of(Person.class)
+    .groupBy(Person$.DEPARTMENT_NUMBER)
+    .reduce(COUNT).as("count")
+    .reduce(AVG, Person$.SALES).as("avgSales")
+    .toMaps();
+
+// Each map contains the aggregated data
+results.forEach(map -> {
+    System.out.printf("Dept %s: %d employees, avg sales $%.2f%n",
+        map.get("departmentNumber"),
+        map.get("count"),
+        map.get("avgSales"));
+});
+
+// Exclude IDs if not needed
+List<Map<String, Object>> resultsNoId = entityStream.of(Person.class)
+    .groupBy(Person$.NAME)
+    .reduce(SUM, Person$.SALES)
+    .toMaps(false);  // IDs excluded
+----
+
+=== Projection vs Maps vs Tuples
+
+Choose the right approach for your use case:
+
+[source,java]
+----
+import static com.redis.om.spring.annotations.ReducerFunction.*;
+import java.util.Map;
+
+// 1. Projections - Type-safe, IDE support, best for defined structures
+public interface SalesProjection {
+    String getName();
+    Double getTotalSales();
+}
+
+List<SalesProjection> projections = entityStream.of(Person.class)
+    .groupBy(Person$.NAME)
+    .reduce(SUM, Person$.SALES).as("totalSales")
+    .toProjection(SalesProjection.class);
+
+// 2. Maps - Flexible, dynamic fields, good for variable structures
+List<Map<String, Object>> maps = entityStream.of(Person.class)
+    .groupBy(Person$.NAME)
+    .reduce(SUM, Person$.SALES).as("totalSales")
+    .toMaps();
+
+// 3. Tuples - Lightweight, positional access, existing approach
+List<Pair<String, Double>> tuples = entityStream.of(Person.class)
+    .groupBy(Person$.NAME)
+    .reduce(SUM, Person$.SALES)
+    .toList(String.class, Double.class);
+----
+
+=== Complex Projections
+
+Projections can handle complex aggregation results:
+
+[source,java]
+----
+import static com.redis.om.spring.annotations.ReducerFunction.*;
+
+public interface ComprehensiveStats {
+    Integer getDepartmentNumber();
+    Long getEmployeeCount();
+    Double getMinSales();
+    Double getMaxSales();
+    Double getAvgSales();
+    Double getTotalSales();
+}
+
+List<ComprehensiveStats> stats = entityStream.of(Person.class)
+    .groupBy(Person$.DEPARTMENT_NUMBER)
+    .reduce(COUNT).as("employeeCount")
+    .reduce(MIN, Person$.SALES).as("minSales")
+    .reduce(MAX, Person$.SALES).as("maxSales")
+    .reduce(AVG, Person$.SALES).as("avgSales")
+    .reduce(SUM, Person$.SALES).as("totalSales")
+    .toProjection(ComprehensiveStats.class);
+----
+
 == Performance Considerations
 
 === Efficient Aggregations

--- a/docs/content/modules/ROOT/pages/entity-streams.adoc
+++ b/docs/content/modules/ROOT/pages/entity-streams.adoc
@@ -271,6 +271,8 @@ List<Integer> foundingYears = entityStream.of(Company.class)
     .collect(Collectors.toList());
 ----
 
+NOTE: For more advanced projection capabilities, including interface-based projections and map results, see xref:entity-streams-aggregations.adoc#_projections_and_maps[Projections and Maps in Aggregations].
+
 === Multiple Field Projections
 
 Create tuples for multiple field projections:

--- a/docs/content/modules/ROOT/pages/overview.adoc
+++ b/docs/content/modules/ROOT/pages/overview.adoc
@@ -2,11 +2,11 @@
 :page-toclevels: 3
 :page-pagination:
 
-Redis OM Spring is a comprehensive advanced object-mapping, querying and repositories framework for Spring applications using Redis, it extends and enhances Spring Data Redis. While Spring Data Redis provides basic Redis functionality, Redis OM Spring delivers a complete solution designed specifically to leverage the advanced features of Redis 8+, Redis Enterprise, and Redis Cloud.
+Redis OM Spring is a comprehensive advanced object-mapping, querying and repositories framework for Spring applications using Redis, it extends and enhances Spring Data Redis. While Spring Data Redis provides basic Redis functionality, Redis OM Spring delivers a complete solution designed specifically to leverage the advanced features of Redis 8+ (and a few older Redis Stack distros), Redis Enterprise, and Redis Cloud.
 
 == What is Redis OM Spring?
 
-Redis OM Spring is an Object Mapping framework designed specifically for Redis, allowing Java developers to work with Redis data using familiar annotations and repository patterns. Redis OM Spring reimagines how Redis should integrate with Spring applications to provide a more intuitive and powerful developer experience.
+Redis OM Spring is an Object Mapping framework designed specifically for Redis, allowing Java developers to work with Redis data using  annotations, repository patterns, fluid Streams-like APIs and more. Redis OM Spring reimagines how Redis should integrate with Spring applications to provide a more intuitive and powerful developer experience.
 
 image::redis-om-spring-architecture.png[Redis OM Spring Architecture,width=100%]
 
@@ -14,13 +14,13 @@ image::redis-om-spring-architecture.png[Redis OM Spring Architecture,width=100%]
 Redis OM Spring consists of two modules:
 
 * *redis-om-spring* - Core module providing modeling, indexing, search, and repository capabilities
-* *redis-om-spring-ai* - AI module offering vector embedding generation through Spring AI integration
+* *redis-om-spring-ai* - AI module offering AI-focused features like vector embedding generation - it leverages Spring AI
 
 == Redis Integration
 
 Redis OM Spring is built to work with Redis 8.0.0+, which includes these essential capabilities:
 
-* *Query Engine* - Powerful search and query engine (formerly RediSearch)
+* *Query Engine* - Powerful search / query engine with Full-text and Vector capabilities (formerly RediSearch)
 * *JSON* - Native JSON document storage 
 * *Probabilistic Data Structures* - Bloom filters, Cuckoo filters, and more
 * *Auto-Complete* - Fast auto-complete server-side functionality
@@ -153,9 +153,12 @@ public class MyDoc {
 * Type-safe query construction with generated metamodels
 * Fluent filtering, sorting, and projection
 * Powerful aggregation capabilities with grouping and reduction
+* Interface-based projections and map results for aggregations
 
 [source,java]
 ----
+import static com.redis.om.spring.annotations.ReducerFunction.*;
+
 // Find companies founded between 1980 and 2020, sorted by name
 List<Company> companies = entityStream
     .of(Company.class)
@@ -167,7 +170,7 @@ List<Company> companies = entityStream
 List<Pair<String, Long>> topBrands = entityStream
     .of(Game.class)
     .groupBy(Game$.BRAND)
-    .reduce(ReducerFunction.COUNT).as("count")
+    .reduce(COUNT).as("count")
     .sorted(Order.desc("@count"))
     .limit(5)
     .toList(String.class, Long.class);
@@ -176,12 +179,26 @@ List<Pair<String, Long>> topBrands = entityStream
 List<Quintuple<String, Double, Double, Double, Long>> priceStats = entityStream
     .of(Game.class)
     .groupBy(Game$.BRAND)
-    .reduce(ReducerFunction.AVG, Game$.PRICE).as("avgPrice")
-    .reduce(ReducerFunction.MIN, Game$.PRICE).as("minPrice")
-    .reduce(ReducerFunction.MAX, Game$.PRICE).as("maxPrice")
-    .reduce(ReducerFunction.COUNT).as("count")
+    .reduce(AVG, Game$.PRICE).as("avgPrice")
+    .reduce(MIN, Game$.PRICE).as("minPrice")
+    .reduce(MAX, Game$.PRICE).as("maxPrice")
+    .reduce(COUNT).as("count")
     .sorted(Order.desc("@count"))
     .toList(String.class, Double.class, Double.class, Double.class, Long.class);
+
+// Interface-based projections for aggregations
+public interface BrandStats {
+    String getBrand();
+    Double getAvgPrice();
+    Long getCount();
+}
+
+List<BrandStats> brandStatistics = entityStream
+    .of(Game.class)
+    .groupBy(Game$.BRAND)
+    .reduce(AVG, Game$.PRICE).as("avgPrice")
+    .reduce(COUNT).as("count")
+    .toProjection(BrandStats.class);
 ----
 
 === Aggregation Support

--- a/docs/content/modules/ROOT/pages/query-annotation.adoc
+++ b/docs/content/modules/ROOT/pages/query-annotation.adoc
@@ -192,6 +192,8 @@ SearchResult getFirstTag();
 SearchResult customFindAllByTitleStartingWithReturnFieldsAndLimit(@Param("prefix") String prefix);
 ----
 
+NOTE: For more advanced projection capabilities, including interface-based projections with type safety, see xref:entity-streams-aggregations.adoc#_projections_and_maps[Projections and Maps in Aggregations].
+
 === Pagination
 
 Control the number of results with Spring Data Pageable or annotation attributes:

--- a/docs/content/modules/ROOT/pages/repository-queries.adoc
+++ b/docs/content/modules/ROOT/pages/repository-queries.adoc
@@ -217,6 +217,31 @@ public interface CompanyRepository extends RedisDocumentRepository<Company, Stri
 }
 ----
 
+== Working with Projections
+
+Redis OM Spring supports Spring Data projections for efficient data retrieval:
+
+=== Interface-Based Projections
+
+Define an interface with getter methods for the fields you need:
+
+[source,java]
+----
+// Define projection interface
+public interface CompanyProjection {
+    String getName();
+    Integer getYearFounded();
+    // Note: ID is not automatically included
+}
+
+// Use in repository - requires custom implementation
+public interface CompanyRepository extends RedisDocumentRepository<Company, String> {
+    List<CompanyProjection> findByPubliclyListed(boolean publiclyListed);
+}
+----
+
+NOTE: Projection support in repositories requires custom implementation. For built-in projection support, use Entity Streams with aggregations. See xref:entity-streams-aggregations.adoc#_projections_and_maps[Projections and Maps in Aggregations].
+
 == Best Practices
 
 * Use the appropriate query method for your needs
@@ -229,4 +254,5 @@ public interface CompanyRepository extends RedisDocumentRepository<Company, Stri
 
 * xref:query-annotation.adoc[Query Annotation]
 * xref:entity-streams.adoc[Entity Streams]
+* xref:entity-streams-aggregations.adoc[Entity Streams Aggregations]
 * xref:qbe.adoc[Query By Example]

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/AggregationStream.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/AggregationStream.java
@@ -2,6 +2,7 @@ package com.redis.om.spring.search.stream;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -237,6 +238,38 @@ public interface AggregationStream<T> {
    * @throws RuntimeException if the aggregation execution or conversion fails
    */
   <R extends T> List<R> toList(Class<?>... contentTypes);
+
+  /**
+   * Executes the aggregation and converts the results to a list of projection objects.
+   * The projection interface should define getter methods for the fields to include.
+   * IDs are not automatically included - add getId() to the projection interface if needed.
+   * 
+   * @param <P>             the projection type
+   * @param projectionClass the projection interface class
+   * @return a list of projection instances with the aggregated data
+   * @throws RuntimeException if the aggregation execution or projection creation fails
+   */
+  <P> List<P> toProjection(Class<P> projectionClass);
+
+  /**
+   * Executes the aggregation and converts the results to a list of maps.
+   * Each map contains field names as keys and field values as values.
+   * By default, entity IDs are included in the results.
+   * 
+   * @return a list of maps containing the aggregated data with IDs included
+   * @throws RuntimeException if the aggregation execution fails
+   */
+  List<Map<String, Object>> toMaps();
+
+  /**
+   * Executes the aggregation and converts the results to a list of maps.
+   * Each map contains field names as keys and field values as values.
+   * 
+   * @param includeId whether to include entity IDs in the results
+   * @return a list of maps containing the aggregated data
+   * @throws RuntimeException if the aggregation execution fails
+   */
+  List<Map<String, Object>> toMaps(boolean includeId);
 
   /**
    * Returns the underlying RediSearch query that would be executed.

--- a/tests/src/test/java/com/redis/om/spring/search/stream/AggregationHashProjectionTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/AggregationHashProjectionTest.java
@@ -1,0 +1,270 @@
+package com.redis.om.spring.search.stream;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.annotations.ReducerFunction;
+import com.redis.om.spring.fixtures.hash.model.Person;
+import com.redis.om.spring.fixtures.hash.model.Person$;
+import com.redis.om.spring.fixtures.hash.repository.PersonRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for projection and maps support in aggregations for hash entities.
+ * Ensures the features work correctly for @RedisHash entities.
+ */
+class AggregationHashProjectionTest extends AbstractBaseEnhancedRedisTest {
+
+  @Autowired
+  PersonRepository repository;
+
+  @Autowired
+  EntityStream entityStream;
+
+  // Projection interfaces
+  public interface PersonNameProjection {
+    String getName();
+  }
+
+  public interface PersonDetailsProjection {
+    String getName();
+    String getEmail();
+  }
+
+  public interface PersonWithIdProjection {
+    String getId();
+    String getName();
+  }
+
+  public interface PersonRoleCountProjection {
+    String getRoles();
+    Long getRoleCount();
+  }
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+
+    // Create test data
+    Person person1 = Person.of("John Doe", "john.doe@example.com", "johnny");
+    person1.setId("person1");
+    person1.setRoles(Set.of("admin", "developer"));
+    person1.setFavoriteFoods(Set.of("pizza", "pasta"));
+
+    Person person2 = Person.of("Jane Smith", "jane.smith@example.com", "jane");
+    person2.setId("person2");
+    person2.setRoles(Set.of("user", "tester"));
+    person2.setFavoriteFoods(Set.of("sushi", "salad"));
+
+    Person person3 = Person.of("Bob Johnson", "bob.johnson@example.com", "bobby");
+    person3.setId("person3");
+    person3.setRoles(Set.of("manager"));
+    person3.setFavoriteFoods(Set.of("burger", "fries"));
+
+    repository.saveAll(List.of(person1, person2, person3));
+  }
+
+  @Test
+  void testHashProjectionBasic() {
+    // Test basic projection with hash entities
+    List<PersonNameProjection> projections = entityStream
+        .of(Person.class)
+        .load(Person$.NAME)
+        .toProjection(PersonNameProjection.class);
+
+    assertThat(projections).hasSize(3);
+    
+    Set<String> names = projections.stream()
+        .map(PersonNameProjection::getName)
+        .collect(java.util.stream.Collectors.toSet());
+    
+    assertThat(names).containsExactlyInAnyOrder("Bob Johnson", "Jane Smith", "John Doe");
+  }
+
+  @Test
+  void testHashProjectionMultipleFields() {
+    // Test projection with multiple fields
+    List<PersonDetailsProjection> projections = entityStream
+        .of(Person.class)
+        .filter(Person$.ROLES.in("admin"))
+        .load(Person$.NAME, Person$.EMAIL)
+        .toProjection(PersonDetailsProjection.class);
+
+    assertThat(projections).hasSize(1);
+    
+    PersonDetailsProjection projection = projections.get(0);
+    assertThat(projection.getName()).isEqualTo("John Doe");
+    assertThat(projection.getEmail()).isEqualTo("john.doe@example.com");
+  }
+
+  @Test
+  void testHashProjectionWithId() {
+    // Test that ID is only included when explicitly requested
+    List<PersonWithIdProjection> projections = entityStream
+        .of(Person.class)
+        .filter(Person$.ROLES.in("user"))
+        .load(Person$.ID, Person$.NAME)
+        .toProjection(PersonWithIdProjection.class);
+
+    assertThat(projections).hasSize(1);
+    
+    PersonWithIdProjection projection = projections.get(0);
+    assertThat(projection.getId()).isEqualTo("person2");
+    assertThat(projection.getName()).isEqualTo("Jane Smith");
+  }
+
+  @Test
+  void testHashProjectionWithGroupBy() {
+    // Test projection with grouping using indexed field
+    List<PersonRoleCountProjection> projections = entityStream
+        .of(Person.class)
+        .groupBy(Person$.ROLES)
+        .reduce(ReducerFunction.COUNT).as("roleCount")
+        .toProjection(PersonRoleCountProjection.class);
+
+    assertThat(projections).isNotEmpty();
+    
+    // Each role should appear once with count of 1
+    for (PersonRoleCountProjection projection : projections) {
+      assertThat(projection.getRoleCount()).isEqualTo(1L);
+    }
+  }
+
+  @Test
+  void testHashMapsWithId() {
+    // Test toMaps() with hash entities using aggregation on indexed field - ID included by default
+    List<Map<String, Object>> maps = entityStream
+        .of(Person.class)
+        .groupBy(Person$.ROLES)
+        .reduce(ReducerFunction.COUNT).as("count")
+        .toMaps();
+
+    assertThat(maps).isNotEmpty();
+    
+    Map<String, Object> firstMap = maps.get(0);
+    assertThat(firstMap).containsKey("roles");
+    assertThat(firstMap).containsKey("count");
+    assertThat(firstMap.get("roles")).isNotNull();
+    assertThat(firstMap.get("count")).isNotNull();
+  }
+
+  @Test
+  void testHashMapsWithoutId() {
+    // Test toMaps(false) - ID excluded using aggregation on indexed field
+    List<Map<String, Object>> maps = entityStream
+        .of(Person.class)
+        .groupBy(Person$.ROLES)
+        .reduce(ReducerFunction.COUNT).as("count")
+        .toMaps(false);
+
+    assertThat(maps).isNotEmpty();
+    
+    Map<String, Object> firstMap = maps.get(0);
+    assertThat(firstMap).doesNotContainKey("id");
+    assertThat(firstMap).containsKey("roles");
+    assertThat(firstMap).containsKey("count");
+    assertThat(firstMap.get("roles")).isNotNull();
+    assertThat(firstMap.get("count")).isNotNull();
+  }
+
+  @Test
+  void testHashMapsWithComplexFields() {
+    // Test maps with complex fields (collections)
+    List<Map<String, Object>> maps = entityStream
+        .of(Person.class)
+        .filter(Person$.ROLES.containsAll("admin", "developer"))
+        .load(Person$.NAME, Person$.ROLES)
+        .toMaps();
+
+    assertThat(maps).hasSize(1);
+    
+    Map<String, Object> map = maps.get(0);
+    assertThat(map).containsKey("name");
+    assertThat(map).containsKey("roles");
+    assertThat(map.get("name")).isEqualTo("John Doe");
+    
+    // Redis may return Set as a comma-separated string
+    Object roles = map.get("roles");
+    if (roles instanceof String) {
+      String rolesStr = (String) roles;
+      assertThat(rolesStr).contains("admin", "developer");
+    } else {
+      @SuppressWarnings("unchecked")
+      Set<String> rolesSet = (Set<String>) roles;
+      assertThat(rolesSet).containsExactlyInAnyOrder("admin", "developer");
+    }
+  }
+
+  @Test
+  void testHashProjectionFieldMapping() {
+    // Test that projections handle various field name formats
+    List<PersonNameProjection> projections = entityStream
+        .of(Person.class)
+        .load(Person$.NAME)
+        .toProjection(PersonNameProjection.class);
+
+    assertThat(projections).hasSize(3);
+    assertThat(projections.get(0).getName()).isNotNull();
+  }
+
+  @Test
+  void testHashMapsEmptyResults() {
+    // Test behavior with empty results
+    List<Map<String, Object>> maps = entityStream
+        .of(Person.class)
+        .filter(Person$.ROLES.in("nonexistent_role"))
+        .load(Person$.NAME)
+        .toMaps();
+
+    assertThat(maps).isEmpty();
+  }
+
+  @Test
+  void testHashProjectionPerformance() {
+    // Clear existing data first
+    repository.deleteAll();
+    
+    // Add exactly 20 test entities with unique roles
+    for (int i = 0; i < 20; i++) {
+      Person person = Person.of("Person " + i, "person" + i + "@example.com", "person" + i);
+      person.setId("person_" + i);
+      person.setRoles(Set.of("role_" + i)); // Each person gets a unique role
+      repository.save(person);
+    }
+
+    long startTime = System.currentTimeMillis();
+    
+    // Use aggregation with indexed field to get exactly 20 results
+    List<PersonRoleCountProjection> projections = entityStream
+        .of(Person.class)
+        .groupBy(Person$.ROLES)
+        .reduce(ReducerFunction.COUNT).as("roleCount")
+        .toProjection(PersonRoleCountProjection.class);
+    
+    long projectionTime = System.currentTimeMillis() - startTime;
+    
+    assertThat(projections).hasSize(20);
+    
+    // Compare with full entity loading
+    startTime = System.currentTimeMillis();
+    
+    List<Person> fullEntities = entityStream
+        .of(Person.class)
+        .limit(20)
+        .collect(java.util.stream.Collectors.toList());
+    
+    long fullLoadTime = System.currentTimeMillis() - startTime;
+    
+    assertThat(fullEntities).hasSize(20);
+    
+    // Log performance metrics
+    System.out.println("Projection load time: " + projectionTime + "ms");
+    System.out.println("Full entity load time: " + fullLoadTime + "ms");
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/search/stream/AggregationProjectionTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/AggregationProjectionTest.java
@@ -1,0 +1,321 @@
+package com.redis.om.spring.search.stream;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.annotations.ReducerFunction;
+import com.redis.om.spring.fixtures.document.model.Company;
+import com.redis.om.spring.fixtures.document.model.Company$;
+import com.redis.om.spring.fixtures.document.repository.CompanyRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort.Order;
+import org.springframework.data.geo.Point;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for projection support in aggregations (issue #539).
+ * Verifies that aggregations can return projection interfaces following
+ * Spring Data conventions where IDs are not automatically included.
+ */
+class AggregationProjectionTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  CompanyRepository repository;
+
+  @Autowired
+  EntityStream entityStream;
+
+  // Projection interfaces
+  public interface CompanyNameProjection {
+    String getName();
+  }
+
+  public interface CompanyDetailsProjection {
+    String getName();
+    Integer getYearFounded();
+  }
+
+  public interface CompanyWithIdProjection {
+    String getId();
+    String getName();
+    Integer getYearFounded();
+  }
+
+  public interface CompanyStatsProjection {
+    Integer getYearFounded();
+    Long getCount();
+  }
+
+  @BeforeEach
+  void setup() {
+    repository.deleteAll();
+
+    // Create test data
+    Company company1 = Company.of("RedisInc", 2011, LocalDate.of(2011, 5, 1),
+        new Point(-122.066540, 37.377690),
+        "stack@redis.com");
+    company1.setPubliclyListed(true);
+    company1.setTags(Set.of("fast", "scalable", "reliable"));
+    company1.setId("company1");
+
+    Company company2 = Company.of("Microsoft", 1975, LocalDate.of(1975, 4, 4),
+        new Point(-122.124500, 47.640160),
+        "info@microsoft.com");
+    company2.setPubliclyListed(true);
+    company2.setTags(Set.of("software", "cloud", "enterprise"));
+    company2.setId("company2");
+
+    Company company3 = Company.of("Tesla", 2003, LocalDate.of(2003, 7, 1),
+        new Point(-122.145800, 37.396400),
+        "contact@tesla.com");
+    company3.setPubliclyListed(true);
+    company3.setTags(Set.of("electric", "automotive", "innovative"));
+    company3.setId("company3");
+
+    repository.saveAll(List.of(company1, company2, company3));
+  }
+
+  @Test
+  void testSimpleProjection() {
+    // Test basic projection with single field
+    List<CompanyNameProjection> projections = entityStream
+        .of(Company.class)
+        .filter(Company$.PUBLICLY_LISTED.eq(true))
+        .load(Company$.NAME)
+        .toProjection(CompanyNameProjection.class);
+
+    assertThat(projections).hasSize(3);
+    
+    Set<String> names = projections.stream()
+        .map(CompanyNameProjection::getName)
+        .collect(java.util.stream.Collectors.toSet());
+    
+    assertThat(names).containsExactlyInAnyOrder("Microsoft", "RedisInc", "Tesla");
+  }
+
+  @Test
+  void testMultiFieldProjection() {
+    // Test projection with multiple fields
+    List<CompanyDetailsProjection> projections = entityStream
+        .of(Company.class)
+        .filter(Company$.YEAR_FOUNDED.gt(1990))
+        .load(Company$.NAME, Company$.YEAR_FOUNDED)
+        .toProjection(CompanyDetailsProjection.class);
+
+    assertThat(projections).hasSize(2);
+    
+    for (CompanyDetailsProjection projection : projections) {
+      assertThat(projection.getName()).isNotNull();
+      assertThat(projection.getYearFounded()).isNotNull();
+      assertThat(projection.getYearFounded()).isGreaterThan(1990);
+    }
+  }
+
+  @Test
+  void testProjectionWithExplicitId() {
+    // Test that ID is only included when explicitly defined in projection
+    List<CompanyWithIdProjection> projections = entityStream
+        .of(Company.class)
+        .filter(Company$.NAME.eq("RedisInc"))
+        .load(Company$.ID, Company$.NAME, Company$.YEAR_FOUNDED)
+        .toProjection(CompanyWithIdProjection.class);
+
+    assertThat(projections).hasSize(1);
+    
+    CompanyWithIdProjection projection = projections.get(0);
+    assertThat(projection.getId()).isEqualTo("company1");
+    assertThat(projection.getName()).isEqualTo("RedisInc");
+    assertThat(projection.getYearFounded()).isEqualTo(2011);
+  }
+
+  @Test
+  void testProjectionWithGroupByAndReduce() {
+    // Test projection with aggregation functions
+    List<CompanyStatsProjection> projections = entityStream
+        .of(Company.class)
+        .groupBy(Company$.YEAR_FOUNDED)
+        .reduce(ReducerFunction.COUNT)
+        .as("count")
+        .toProjection(CompanyStatsProjection.class);
+
+    assertThat(projections).hasSize(3);
+    
+    // Each year should have count of 1
+    for (CompanyStatsProjection projection : projections) {
+      assertThat(projection.getYearFounded()).isNotNull();
+      assertThat(projection.getCount()).isEqualTo(1L);
+    }
+  }
+
+  @Test
+  void testProjectionWithNonInterfaceThrowsException() {
+    // Test that non-interface classes throw exception
+    assertThatThrownBy(() ->
+        entityStream
+            .of(Company.class)
+            .load(Company$.NAME)
+            .toProjection(String.class)
+    ).isInstanceOf(IllegalArgumentException.class)
+     .hasMessageContaining("Projection class must be an interface");
+  }
+
+  @Test
+  void testProjectionHandlesNullValues() {
+    // Test projection with existing data - skip creating null data for now
+    List<CompanyNameProjection> projections = entityStream
+        .of(Company.class)
+        .filter(Company$.PUBLICLY_LISTED.eq(true))
+        .load(Company$.NAME)
+        .toProjection(CompanyNameProjection.class);
+
+    assertThat(projections).hasSize(3);
+    assertThat(projections.get(0).getName()).isNotNull();
+  }
+
+  @Test
+  void testProjectionFieldNameMapping() {
+    // Test that projection handles field name variations with aggregation
+    List<CompanyNameProjection> projections = entityStream
+        .of(Company.class)
+        .groupBy(Company$.NAME)
+        .reduce(ReducerFunction.COUNT).as("count")
+        .toProjection(CompanyNameProjection.class);
+
+    assertThat(projections).hasSize(3);
+    
+    Set<String> names = projections.stream()
+        .map(CompanyNameProjection::getName)
+        .collect(java.util.stream.Collectors.toSet());
+    
+    assertThat(names).containsExactlyInAnyOrder("RedisInc", "Microsoft", "Tesla");
+  }
+
+  @Test
+  void testMapsWithIdIncluded() {
+    // Test toMaps() with ID included by default using aggregation with count
+    List<Map<String, Object>> maps = entityStream
+        .of(Company.class)
+        .filter(Company$.PUBLICLY_LISTED.eq(true))
+        .groupBy(Company$.NAME, Company$.YEAR_FOUNDED)
+        .reduce(ReducerFunction.COUNT).as("count")
+        .toMaps();
+
+    assertThat(maps).hasSize(3);
+    
+    Map<String, Object> firstMap = maps.get(0);
+    assertThat(firstMap).containsKey("name");
+    assertThat(firstMap).containsKey("yearFounded");
+    assertThat(firstMap).containsKey("count");
+    assertThat(firstMap.get("name")).isNotNull();
+    assertThat(firstMap.get("yearFounded")).isNotNull();
+  }
+
+  @Test
+  void testMapsWithIdExcluded() {
+    // Test toMaps(false) with ID excluded using aggregation with count
+    List<Map<String, Object>> maps = entityStream
+        .of(Company.class)
+        .filter(Company$.PUBLICLY_LISTED.eq(true))
+        .groupBy(Company$.NAME, Company$.YEAR_FOUNDED)
+        .reduce(ReducerFunction.COUNT).as("count")
+        .toMaps(false);
+
+    assertThat(maps).hasSize(3);
+    
+    Map<String, Object> firstMap = maps.get(0);
+    assertThat(firstMap).doesNotContainKey("id");
+    assertThat(firstMap).containsKey("name");
+    assertThat(firstMap).containsKey("yearFounded");
+    assertThat(firstMap).containsKey("count");
+    assertThat(firstMap.get("name")).isNotNull();
+  }
+
+  @Test
+  void testMapsWithAggregation() {
+    // Test maps with grouping and reduction
+    List<Map<String, Object>> maps = entityStream
+        .of(Company.class)
+        .groupBy(Company$.YEAR_FOUNDED)
+        .reduce(com.redis.om.spring.annotations.ReducerFunction.COUNT)
+        .as("companyCount")
+        .sorted(Order.asc("@yearFounded"))
+        .toMaps();
+
+    assertThat(maps).hasSize(3);
+    
+    // Check first result
+    Map<String, Object> firstMap = maps.get(0);
+    assertThat(firstMap).containsKey("yearFounded");
+    assertThat(firstMap).containsKey("companyCount");
+    
+    Object yearFoundedValue = convertValue(firstMap.get("yearFounded"), Integer.class);
+    assertThat(yearFoundedValue).isEqualTo(1975);
+    
+    Object companyCountValue = convertValue(firstMap.get("companyCount"), Long.class);
+    assertThat(companyCountValue).isEqualTo(1L);
+  }
+
+  @Test
+  void testProjectionEquality() {
+    // Test that projections with same data are equal
+    List<CompanyNameProjection> projections1 = entityStream
+        .of(Company.class)
+        .filter(Company$.NAME.eq("RedisInc"))
+        .load(Company$.NAME)
+        .toProjection(CompanyNameProjection.class);
+
+    List<CompanyNameProjection> projections2 = entityStream
+        .of(Company.class)
+        .filter(Company$.NAME.eq("RedisInc"))
+        .load(Company$.NAME)
+        .toProjection(CompanyNameProjection.class);
+
+    assertThat(projections1).hasSize(1);
+    assertThat(projections2).hasSize(1);
+    
+    // Test toString
+    assertThat(projections1.get(0).toString()).contains("CompanyNameProjection");
+    assertThat(projections1.get(0).toString()).contains("name");
+    
+    // Test hashCode consistency
+    assertThat(projections1.get(0).hashCode()).isEqualTo(projections2.get(0).hashCode());
+  }
+
+  /**
+   * Helper method to convert values from Redis aggregation results.
+   * Redis may return values as strings that need to be converted to the expected type.
+   */
+  private Object convertValue(Object value, Class<?> targetType) {
+    if (value == null) {
+      return null;
+    }
+    
+    if (targetType.isAssignableFrom(value.getClass())) {
+      return value;
+    }
+    
+    // Handle string conversions
+    if (value instanceof String stringValue) {
+      if (targetType == Integer.class) {
+        return Integer.parseInt(stringValue);
+      } else if (targetType == Long.class) {
+        return Long.parseLong(stringValue);
+      } else if (targetType == Double.class) {
+        return Double.parseDouble(stringValue);
+      } else if (targetType == Float.class) {
+        return Float.parseFloat(stringValue);
+      } else if (targetType == Boolean.class) {
+        return Boolean.parseBoolean(stringValue);
+      }
+    }
+    
+    return value;
+  }
+}


### PR DESCRIPTION
Implements Spring Data-style projections and map-based results for aggregations, providing flexible alternatives to tuple-based results. Follows Spring Data conventions where IDs are not automatically included in projections.

- Add toProjection(Class<P>) method for interface-based projections
- Add toMaps() and toMaps(boolean includeId) for map-based results
- Projections follow Spring Data JPA pattern (IDs not auto-included)
- Maps include IDs by default with option to exclude
- Dynamic proxy implementation for projection interfaces
- Type conversion support for common types
- Comprehensive tests for both document and hash entities
- Documentation with examples and comparison of approaches