### PR TITLE
Fix ClassCastException in SearchStreamImpl count() method

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -496,7 +496,8 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
       return searchResult.getTotalResults();
     } else {
       var info = search.getInfo();
-      return (long) info.get("num_docs");
+      //return (long) info.get("num_docs");
+      return Long.parseLong(info.get("num_docs").toString());
     }
   }
 


### PR DESCRIPTION
Fixes #639

Hotfix to solve this exeception on count() method in SearchStreamImpl.java

```
java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Long (java.lang.String and java.lang.Long are in module java.base of loader 'bootstrap')
	at com.redis.om.spring.search.stream.SearchStreamImpl.count(SearchStreamImpl.java:499)
SearchStreamImpl.java:499
```