### PR TITLE
Added the NUMERIC_IN query clause to manage the Spring-like methods '…

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/RediSearchIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/RediSearchIndexer.java
@@ -1148,8 +1148,9 @@ public class RediSearchIndexer {
 
   private boolean isAnnotationPreset(java.lang.reflect.Field idField, List<SchemaField> fields) {
     return (!idField.isAnnotationPresent(Indexed.class) && !idField.isAnnotationPresent(Searchable.class) && !idField
-        .isAnnotationPresent(TagIndexed.class) && !idField.isAnnotationPresent(TextIndexed.class) && (fields.stream()
-            .noneMatch(f -> f.getName().equals(idField.getName()))));
+        .isAnnotationPresent(TagIndexed.class) && !idField.isAnnotationPresent(TextIndexed.class) && !idField
+            .isAnnotationPresent(NumericIndexed.class) && (fields.stream().noneMatch(f -> f.getName().equals(idField
+                .getName()))));
   }
 
   private List<SearchField> createIndexedFieldsForIdFields(Class<?> cl, List<SchemaField> fields, boolean isDocument) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/clause/QueryClause.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/query/clause/QueryClause.java
@@ -174,6 +174,20 @@ public enum QueryClause {
       QueryClauseTemplate.of(FieldType.NUMERIC, Part.Type.BETWEEN, QueryClause.FIELD_NUMERIC_BETWEEN, 2) //
   ),
   /**
+   * Numeric field query clause for range matching.
+   * Matches numeric fields that are equal to any of the specified values.
+   */
+  NUMERIC_IN( //
+      QueryClauseTemplate.of(FieldType.NUMERIC, Part.Type.IN, QueryClause.FIELD_EQUAL, 1) //
+  ),
+  /**
+   * Numeric field query clause for negated membership testing.
+   * Matches numeric fields that are not equal to any of the specified values.
+   */
+  NUMERIC_NOT_IN( //
+      QueryClauseTemplate.of(FieldType.NUMERIC, Part.Type.NOT_IN, QueryClause.FIELD_EQUAL, 1) //
+  ),
+  /**
    * Numeric field query clause for "less than" comparisons.
    * Matches numeric fields whose values are less than the specified value.
    */
@@ -569,31 +583,40 @@ public enum QueryClause {
             if (this == QueryClause.TAG_CONTAINING_ALL) {
               value = c.stream().map(n -> "@" + field + ":{" + QueryUtils.escape(ObjectUtils.asString(n,
                   converter)) + "}").collect(Collectors.joining(" "));
+              prepared = prepared.replace(PARAM_PREFIX + i++, value);
             } else if (this == QueryClause.NUMERIC_CONTAINING) {
               value = c.stream().map(n -> "@" + field + ":[" + QueryUtils.escape(ObjectUtils.asString(n,
                   converter)) + " " + QueryUtils.escape(ObjectUtils.asString(n, converter)) + "]").collect(Collectors
                       .joining("|"));
+              prepared = prepared.replace(PARAM_PREFIX + i++, value);
+            } else if (this == QueryClause.NUMERIC_IN) {
+              value = c.stream().map(n -> "@" + field + ":[" + QueryUtils.escape(ObjectUtils.asString(n,
+                  converter)) + " " + QueryUtils.escape(ObjectUtils.asString(n, converter)) + "]").collect(Collectors
+                      .joining("|"));
+              prepared = value;
             } else if (this == QueryClause.NUMERIC_CONTAINING_ALL) {
               value = c.stream().map(n -> "@" + field + ":[" + QueryUtils.escape(ObjectUtils.asString(n,
                   converter)) + " " + QueryUtils.escape(ObjectUtils.asString(n, converter)) + "]").collect(Collectors
                       .joining(" "));
+              prepared = prepared.replace(PARAM_PREFIX + i++, value);
             } else if (this == QueryClause.GEO_CONTAINING) {
               value = c.stream().map(n -> {
                 Point p = (Point) n;
                 return "@" + field + ":[" + p.getX() + " " + p.getY() + " .000001 ft]";
               }).collect(Collectors.joining("|"));
+              prepared = prepared.replace(PARAM_PREFIX + i++, value);
             } else if (this == QueryClause.GEO_CONTAINING_ALL) {
               value = c.stream().map(n -> {
                 Point p = (Point) n;
                 return "@" + field + ":[" + p.getX() + " " + p.getY() + " .000001 ft]";
               }).collect(Collectors.joining(" "));
+              prepared = prepared.replace(PARAM_PREFIX + i++, value);
             } else {
               value = c.stream()//
                   .map(n -> QueryUtils.escape(ObjectUtils.asString(n, converter), false)).collect(Collectors.joining(
                       "|"));
+              prepared = prepared.replace(PARAM_PREFIX + i++, value);
             }
-
-            prepared = prepared.replace(PARAM_PREFIX + i++, value);
           } else {
             if (clauseTemplate.getIndexType() == FieldType.TEXT) {
               prepared = prepared.replace(PARAM_PREFIX + i++, param.toString());


### PR DESCRIPTION
# Changes
feat(query): add `NUMERIC_IN` query clause for Redis repository 'In' methods
fix(indexing): enable `@NumericIndexed` type for `@Id` fields without schema duplication error

## Query
Introduced support for the `NUMERIC_IN` query clause to handle Spring Data style repository methods ending with 'In'.
This enables querying Redis repositories using a collection of numeric values, improving parity with Spring Data JPA query method conventions and enhancing developer ergonomics.

Example:
```java
  findByIdIn(List<Integer> ids)
```

## Indexing
Previously, configuring an `@Id` field with the `@NumericIndexed` index type was technically possible but caused index creation to fail with:

>  2025-08-11T16:42:09.406+02:00 WARN  c.r.o.s.indexing.RediSearchIndexer - [main] - createIndexFor - Skipping index creation for com.foogaro.modeling.model.DocumentsIdx because Duplicate field in schema - id

This happened because the Id field was already implicitly added to the index schema, and explicitly declaring it as `@NumericIndexed` created a duplicate entry.
Now, the check also considers `@NumericIndexed` in the “already indexed” list, so it won’t add it twice.
