### PR TITLE
fix: change auto-service scope from implementation to compileOnly

### DIFF
--- a/redis-om-spring/build.gradle
+++ b/redis-om-spring/build.gradle
@@ -18,6 +18,6 @@ dependencies {
 	api "com.squareup:javapoet:${javapoetVersion}"
 
 	compileOnly "javax.enterprise:cdi-api:${cdi}"
-	implementation "com.google.auto.service:auto-service:${autoServiceVersion}"
+	compileOnly "com.google.auto.service:auto-service:${autoServiceVersion}"
 	annotationProcessor "com.google.auto.service:auto-service:${autoServiceVersion}"
 }

--- a/tests/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
+++ b/tests/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
@@ -8,10 +8,12 @@ import com.karuslabs.elementary.junit.annotations.Processors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import javax.annotation.processing.Processor;
 import javax.tools.JavaFileObject;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +32,26 @@ import static org.junit.jupiter.api.Assertions.assertAll;
   { MetamodelGenerator.class }
 )
 class MetamodelGeneratorTest {
+  
+  @Test
+  void testAnnotationProcessorServiceRegistration() {
+    // Verify that MetamodelGenerator is properly registered as a service
+    // This ensures that the @AutoService annotation is working correctly
+    ServiceLoader<Processor> loader = ServiceLoader.load(Processor.class);
+    boolean foundMetamodelGenerator = false;
+    
+    for (Processor processor : loader) {
+      if (processor instanceof MetamodelGenerator) {
+        foundMetamodelGenerator = true;
+        break;
+      }
+    }
+    
+    assertThat(foundMetamodelGenerator)
+        .as("MetamodelGenerator should be discoverable via ServiceLoader")
+        .isTrue();
+  }
+  
   @Test
   @Classpath(
     "data.metamodel.ValidDocumentIndexed"


### PR DESCRIPTION
- Changed auto-service from 'implementation' to 'compileOnly' in redis-om-spring module
- Added test to verify annotation processor service registration via ServiceLoader
- auto-service is only needed during compilation to generate META-INF/services files

This prevents auto-service from being a transitive dependency at runtime, reducing the dependency footprint as it's not needed after compilation.

Fixes #651