### PR TITLE
fix: resolve docs deployment failures due to environment protection r…

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,6 @@
 name: Deploy Docs
 on:
   workflow_dispatch:
-  release:
-    types: [published]
   repository_dispatch:
     types: [build-docs]
 
@@ -27,6 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          ref: main  # Always checkout main branch for docs builds
           fetch-depth: 0  # Fetch all history for all branches and tags
           fetch-tags: true  # Explicitly fetch tags
 
@@ -61,7 +60,13 @@ jobs:
 
       - name: Set Release Version in Docs
         run: |
-          VERSION=$(cat gradle.properties | grep "version" | cut -d'=' -f2 | tr -d ' ')
+          # Use the release tag version if triggered by release, otherwise use gradle.properties
+          if [ "${{ github.event_name }}" = "release" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION=${VERSION#v}  # Remove 'v' prefix if present
+          else
+            VERSION=$(cat gradle.properties | grep "version" | cut -d'=' -f2 | tr -d ' ')
+          fi
           echo "Setting documentation version to $VERSION"
           
           # For current version


### PR DESCRIPTION
…ules

The docs workflow was failing when triggered by release events because GitHub Pages environment protection rules block deployments from tags. This fix ensures docs are always built from the main branch while maintaining correct version information.

Changes:
- Remove direct release event trigger to prevent duplicate workflow runs
- Always checkout main branch to satisfy environment protection rules
- Enhance version detection to use release tag when available
- Rely on repository_dispatch from release workflow for docs deployment

The release workflow already triggers docs via repository_dispatch, making the direct release trigger redundant and problematic. This change creates a single, reliable docs deployment path that works with GitHub Pages protection rules.

Resolves deployment failures: "Tag 'v1.0.1' is not allowed to deploy to github-pages"