### PR TITLE
feat: add SearchStream return type support for repository methods

### DIFF
--- a/docs/content/modules/ROOT/pages/hash-mappings.adoc
+++ b/docs/content/modules/ROOT/pages/hash-mappings.adoc
@@ -54,7 +54,7 @@ Redis OM Spring creates full RediSearch indexes using `FT.CREATE` commands, prov
 
 |Query Methods
 |Limited to findBy patterns
-|Complex queries, @Query, Entity Streams
+|Complex queries, @Query, Entity Streams, SearchStream returns
 |===
 
 == Basic Usage
@@ -424,6 +424,75 @@ List<Person> admins = entityStream
   .sorted(Person$.EMAIL, SortOrder.ASC)
   .collect(Collectors.toList());
 ----
+
+=== Entity Streams Integration with Repositories
+
+Repositories can return `SearchStream` for fluent query operations:
+
+[source,java]
+----
+import com.redis.om.spring.search.stream.SearchStream;
+
+public interface PersonRepository extends RedisEnhancedRepository<Person, String> {
+    // Return SearchStream for advanced operations
+    SearchStream<Person> findByDepartment(String department);
+    
+    SearchStream<Person> findByAgeGreaterThan(int age);
+    
+    SearchStream<Person> findByActive(boolean active);
+    
+    // Usage example:
+    // SearchStream<Person> stream = repository.findByDepartment("Engineering");
+    // List<String> names = stream
+    //     .filter(Person$.ACTIVE.eq(true))
+    //     .map(Person$.NAME)
+    //     .collect(Collectors.toList());
+}
+----
+
+This allows you to combine repository query methods with the power of Entity Streams:
+
+[source,java]
+----
+@Service
+public class PersonService {
+    @Autowired
+    PersonRepository repository;
+    
+    public List<String> getActiveEngineerNames() {
+        return repository.findByDepartment("Engineering")
+            .filter(Person$.ACTIVE.eq(true))
+            .map(Person$.NAME)
+            .sorted()
+            .collect(Collectors.toList());
+    }
+    
+    public long countSeniorEmployees(int minAge) {
+        return repository.findByAgeGreaterThan(minAge)
+            .filter(Person$.DEPARTMENT.in("Engineering", "Management"))
+            .count();
+    }
+    
+    public List<Person> getTopPerformers() {
+        return repository.findByActive(true)
+            .filter(Person$.PERFORMANCE_SCORE.gte(90))
+            .sorted(Person$.PERFORMANCE_SCORE, SortOrder.DESC)
+            .limit(10)
+            .collect(Collectors.toList());
+    }
+}
+----
+
+The `SearchStream` returned by repository methods supports all Entity Stream operations:
+
+* **Filtering**: `filter()` with field predicates
+* **Mapping**: `map()` to transform results
+* **Sorting**: `sorted()` with field and order
+* **Limiting**: `limit()` to restrict results
+* **Aggregation**: `count()`, `findFirst()`, `anyMatch()`, `allMatch()`
+* **Collection**: `collect()` to lists, sets, or custom collectors
+
+NOTE: Fields used in SearchStream operations must be properly indexed with `@Indexed`, `@Searchable`, or other indexing annotations.
 
 == Time To Live (TTL)
 

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/HashWithSearchStream.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/HashWithSearchStream.java
@@ -1,0 +1,50 @@
+package com.redis.om.spring.fixtures.hash.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.*;
+
+/**
+ * Test entity for SearchStream with properly indexed fields
+ */
+@Data
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@RedisHash("hash_with_search_stream")
+public class HashWithSearchStream {
+
+  @Id
+  String id;
+
+  @NonNull
+  @Searchable
+  String name;
+
+  @NonNull
+  @Indexed
+  String email;
+
+  @NonNull
+  @Indexed
+  String department;
+  
+  @NonNull
+  @Indexed
+  Integer age;
+  
+  @NonNull
+  @Indexed
+  Boolean active;
+
+  @NonNull
+  @Indexed
+  Set<String> skills = new HashSet<>();
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/HashWithSearchStreamRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/HashWithSearchStreamRepository.java
@@ -1,0 +1,24 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import java.util.Set;
+
+import org.springframework.stereotype.Repository;
+
+import com.redis.om.spring.fixtures.hash.model.HashWithSearchStream;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+import com.redis.om.spring.search.stream.SearchStream;
+
+@Repository
+public interface HashWithSearchStreamRepository extends RedisEnhancedRepository<HashWithSearchStream, String> {
+  
+  // Methods that return SearchStream for testing
+  SearchStream<HashWithSearchStream> findByEmail(String email);
+  
+  SearchStream<HashWithSearchStream> findByDepartment(String department);
+  
+  SearchStream<HashWithSearchStream> findByAgeGreaterThan(Integer age);
+  
+  SearchStream<HashWithSearchStream> findByActive(Boolean active);
+  
+  SearchStream<HashWithSearchStream> findBySkills(Set<String> skills);
+}

--- a/tests/src/test/java/com/redis/om/spring/repository/SearchStreamHashRepositoryTest.java
+++ b/tests/src/test/java/com/redis/om/spring/repository/SearchStreamHashRepositoryTest.java
@@ -1,0 +1,206 @@
+package com.redis.om.spring.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.fixtures.hash.model.HashWithSearchStream;
+import com.redis.om.spring.fixtures.hash.model.HashWithSearchStream$;
+import com.redis.om.spring.fixtures.hash.repository.HashWithSearchStreamRepository;
+import com.redis.om.spring.search.stream.SearchStream;
+
+/**
+ * Test to verify that hash repositories can return SearchStream for fluent query operations.
+ * This validates that SearchStream works for both JSON documents and Redis Hash entities.
+ */
+class SearchStreamHashRepositoryTest extends AbstractBaseEnhancedRedisTest {
+  
+  @Autowired
+  HashWithSearchStreamRepository repository;
+  
+  private HashWithSearchStream john;
+  private HashWithSearchStream jane;
+  private HashWithSearchStream bob;
+  private HashWithSearchStream alice;
+  private HashWithSearchStream charlie;
+  
+  @BeforeEach
+  void setUp() {
+    // Create test people with properly indexed fields
+    john = HashWithSearchStream.of("John Doe", "john@example.com", "Engineering", 35, true);
+    john.setSkills(Set.of("Java", "Spring", "Redis"));
+    
+    jane = HashWithSearchStream.of("Jane Smith", "jane@example.com", "Marketing", 28, true);
+    jane.setSkills(Set.of("SEO", "Content", "Analytics"));
+    
+    bob = HashWithSearchStream.of("Bob Johnson", "bob@example.com", "Engineering", 42, false);
+    bob.setSkills(Set.of("Python", "Docker", "Kubernetes"));
+    
+    alice = HashWithSearchStream.of("Alice Williams", "alice@example.com", "HR", 31, true);
+    alice.setSkills(Set.of("Recruiting", "Training", "Compliance"));
+    
+    charlie = HashWithSearchStream.of("Charlie Brown", "charlie@example.com", "Engineering", 55, false);
+    charlie.setSkills(Set.of("Java", "Architecture", "Microservices"));
+    
+    repository.saveAll(List.of(john, jane, bob, alice, charlie));
+  }
+  
+  @AfterEach
+  void tearDown() {
+    repository.deleteAll();
+  }
+  
+  @Test
+  void testHashRepositoryReturnsSearchStream() {
+    // Test that repository method returns SearchStream for hash entities
+    SearchStream<HashWithSearchStream> stream = repository.findByEmail("john@example.com");
+    
+    assertNotNull(stream, "Repository should return a SearchStream");
+    assertThat(stream).isInstanceOf(SearchStream.class);
+    
+    // Verify the stream contains the expected person
+    List<HashWithSearchStream> people = stream.collect(Collectors.toList());
+    assertEquals(1, people.size(), "Should find 1 person with john@example.com email");
+    assertEquals("John Doe", people.get(0).getName());
+  }
+  
+  @Test
+  void testHashSearchStreamFluentOperations() {
+    // Test fluent operations on SearchStream returned from repository
+    SearchStream<HashWithSearchStream> stream = repository.findByDepartment("Engineering");
+    
+    // Further filter by active status
+    List<HashWithSearchStream> activePeople = stream
+        .filter(HashWithSearchStream$.ACTIVE.eq(true))
+        .collect(Collectors.toList());
+    
+    assertEquals(1, activePeople.size(), "Should find 1 active person in Engineering");
+    assertEquals("John Doe", activePeople.get(0).getName());
+  }
+  
+  @Test
+  void testHashSearchStreamMapOperation() {
+    // Test map operation on SearchStream to extract emails
+    SearchStream<HashWithSearchStream> stream = repository.findByDepartment("Engineering");
+    
+    // Map to names
+    List<String> names = stream
+        .map(HashWithSearchStream$.NAME)
+        .collect(Collectors.toList());
+    
+    assertEquals(3, names.size(), "Should find 3 people in Engineering");
+    assertThat(names).containsExactlyInAnyOrder("John Doe", "Bob Johnson", "Charlie Brown");
+  }
+  
+  @Test
+  void testHashSearchStreamChainedFilters() {
+    // Test multiple chained filter operations
+    SearchStream<HashWithSearchStream> stream = repository.findByAgeGreaterThan(30);
+    
+    // Chain multiple filters - age > 30 and active
+    List<HashWithSearchStream> filteredPeople = stream
+        .filter(HashWithSearchStream$.ACTIVE.eq(true))
+        .collect(Collectors.toList());
+    
+    assertEquals(2, filteredPeople.size(), "Should find 2 active people over 30");
+    
+    List<String> names = filteredPeople.stream()
+        .map(HashWithSearchStream::getName)
+        .sorted()
+        .collect(Collectors.toList());
+    
+    assertThat(names).containsExactly("Alice Williams", "John Doe");
+  }
+  
+  @Test
+  void testHashSearchStreamWithSort() {
+    // Test sorting capabilities of SearchStream
+    SearchStream<HashWithSearchStream> stream = repository.findByDepartment("Engineering");
+    
+    // Sort by age ascending
+    List<HashWithSearchStream> sortedPeople = stream
+        .sorted(HashWithSearchStream$.AGE, redis.clients.jedis.search.aggr.SortedField.SortOrder.ASC)
+        .collect(Collectors.toList());
+    
+    assertEquals(3, sortedPeople.size());
+    
+    // Verify sorting order by age
+    assertEquals("John Doe", sortedPeople.get(0).getName());     // 35
+    assertEquals("Bob Johnson", sortedPeople.get(1).getName());  // 42
+    assertEquals("Charlie Brown", sortedPeople.get(2).getName()); // 55
+  }
+  
+  @Test
+  void testHashSearchStreamLimit() {
+    // Test limit operation on SearchStream
+    SearchStream<HashWithSearchStream> stream = repository.findByDepartment("Engineering");
+    
+    // Limit to first 2 results
+    List<HashWithSearchStream> limitedPeople = stream
+        .limit(2)
+        .collect(Collectors.toList());
+    
+    assertEquals(2, limitedPeople.size(), "Should return only 2 people due to limit");
+  }
+  
+  @Test
+  void testHashSearchStreamCount() {
+    // Test count operation on SearchStream
+    SearchStream<HashWithSearchStream> stream = repository.findByDepartment("Engineering");
+    
+    long count = stream.count();
+    
+    assertEquals(3, count, "Should count 3 people in Engineering department");
+  }
+  
+  @Test
+  void testHashSearchStreamEmptyResult() {
+    // Test SearchStream with no matching results
+    SearchStream<HashWithSearchStream> stream = repository.findByEmail("nonexistent@example.com");
+    
+    List<HashWithSearchStream> people = stream.collect(Collectors.toList());
+    
+    assertTrue(people.isEmpty(), "Should return empty list for nonexistent email");
+  }
+  
+  @Test
+  void testHashSearchStreamComplexQuery() {
+    // Test a complex query combining multiple operations
+    SearchStream<HashWithSearchStream> stream = repository.findByActive(true);
+    
+    // Complex query: active people, filter by department, map to emails
+    List<String> emails = stream
+        .filter(HashWithSearchStream$.DEPARTMENT.in("Engineering", "HR"))
+        .map(HashWithSearchStream$.EMAIL)
+        .collect(Collectors.toList());
+    
+    assertEquals(2, emails.size(), "Should find 2 active people in Engineering or HR");
+    assertThat(emails).containsExactlyInAnyOrder("john@example.com", "alice@example.com");
+  }
+  
+  @Test
+  void testHashSearchStreamWithSkills() {
+    // Test SearchStream with Set field (skills)
+    SearchStream<HashWithSearchStream> stream = repository.findBySkills(Set.of("Java"));
+    
+    List<HashWithSearchStream> javaDevs = stream.collect(Collectors.toList());
+    
+    assertEquals(2, javaDevs.size(), "Should find 2 people with Java skill");
+    
+    List<String> names = javaDevs.stream()
+        .map(HashWithSearchStream::getName)
+        .sorted()
+        .collect(Collectors.toList());
+    
+    assertThat(names).containsExactly("Charlie Brown", "John Doe");
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/repository/SearchStreamRepositoryTest.java
+++ b/tests/src/test/java/com/redis/om/spring/repository/SearchStreamRepositoryTest.java
@@ -1,0 +1,219 @@
+package com.redis.om.spring.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.geo.Point;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.Company;
+import com.redis.om.spring.fixtures.document.model.Company$;
+import com.redis.om.spring.fixtures.document.model.CompanyMeta;
+import com.redis.om.spring.fixtures.document.model.Employee;
+import com.redis.om.spring.fixtures.document.repository.CompanyRepository;
+import com.redis.om.spring.search.stream.SearchStream;
+import redis.clients.jedis.search.aggr.SortedField.SortOrder;
+
+/**
+ * Test to verify that repositories can return SearchStream for fluent query operations.
+ * This validates the documentation claim that "Repositories can return SearchStream for fluent query operations"
+ */
+class SearchStreamRepositoryTest extends AbstractBaseDocumentTest {
+  
+  @Autowired
+  CompanyRepository repository;
+  
+  private Company redis;
+  private Company microsoft;
+  private Company apple;
+  private Company ibm;
+  private Company oracle;
+  
+  @BeforeEach
+  void setUp() {
+    // Create test companies with various founding years
+    redis = Company.of("RedisInc", 2011, LocalDate.of(2021, 5, 1), 
+        new Point(-122.066540, 37.377690), "stack@redis.com");
+    redis.setTags(Set.of("database", "nosql", "redis"));
+    redis.setMetaList(Set.of(CompanyMeta.of("Redis", 100, Set.of("RedisTag"))));
+    redis.setPubliclyListed(false);
+    redis.setEmployees(Set.of(Employee.of("John Doe"), Employee.of("Jane Smith")));
+    
+    microsoft = Company.of("Microsoft", 1975, LocalDate.of(2022, 8, 15), 
+        new Point(-122.124500, 47.640160), "research@microsoft.com");
+    microsoft.setTags(Set.of("software", "cloud", "windows"));
+    microsoft.setMetaList(Set.of(CompanyMeta.of("MS", 50, Set.of("MsTag"))));
+    microsoft.setPubliclyListed(true);
+    
+    apple = Company.of("Apple", 1976, LocalDate.of(2022, 9, 10), 
+        new Point(-122.0322, 37.3220), "info@apple.com");
+    apple.setTags(Set.of("hardware", "software", "mobile"));
+    apple.setMetaList(Set.of(CompanyMeta.of("AAPL", 75, Set.of("AppleTag"))));
+    apple.setPubliclyListed(true);
+    
+    ibm = Company.of("IBM", 1911, LocalDate.of(2022, 6, 1), 
+        new Point(-73.8007, 41.0504), "contact@ibm.com");
+    ibm.setTags(Set.of("enterprise", "cloud", "ai"));
+    ibm.setPubliclyListed(true);
+    
+    oracle = Company.of("Oracle", 1977, LocalDate.of(2022, 7, 1), 
+        new Point(-122.2659, 37.5314), "info@oracle.com");
+    oracle.setTags(Set.of("database", "enterprise", "cloud"));
+    oracle.setPubliclyListed(true);
+    
+    repository.saveAll(List.of(redis, microsoft, apple, ibm, oracle));
+  }
+  
+  @AfterEach
+  void tearDown() {
+    repository.deleteAll();
+  }
+  
+  @Test
+  void testRepositoryReturnsSearchStream() {
+    // Test that repository method returns SearchStream
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(1970);
+    
+    assertNotNull(stream, "Repository should return a SearchStream");
+    assertThat(stream).isInstanceOf(SearchStream.class);
+    
+    // Verify the stream contains the expected companies
+    List<Company> companies = stream.collect(Collectors.toList());
+    assertEquals(4, companies.size(), "Should find 4 companies founded after 1970");
+    
+    // Verify companies are: Microsoft (1975), Apple (1976), Oracle (1977), RedisInc (2011)
+    List<String> companyNames = companies.stream()
+        .map(Company::getName)
+        .sorted()
+        .collect(Collectors.toList());
+    
+    assertThat(companyNames).containsExactly("Apple", "Microsoft", "Oracle", "RedisInc");
+  }
+  
+  @Test
+  void testSearchStreamFluentOperations() {
+    // Test fluent operations on SearchStream returned from repository
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(1970);
+    
+    // Filter for publicly listed companies only
+    List<Company> publicCompanies = stream
+        .filter(Company$.PUBLICLY_LISTED.eq(true))
+        .collect(Collectors.toList());
+    
+    assertEquals(3, publicCompanies.size(), "Should find 3 publicly listed companies");
+    
+    // Verify the publicly listed companies
+    List<String> publicCompanyNames = publicCompanies.stream()
+        .map(Company::getName)
+        .sorted()
+        .collect(Collectors.toList());
+    
+    assertThat(publicCompanyNames).containsExactly("Apple", "Microsoft", "Oracle");
+  }
+  
+  @Test
+  void testSearchStreamMapOperation() {
+    // Test map operation on SearchStream to extract company names
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(2000);
+    
+    // Map to company names
+    List<String> companyNames = stream
+        .map(Company$.NAME)
+        .collect(Collectors.toList());
+    
+    assertEquals(1, companyNames.size(), "Should find 1 company founded after 2000");
+    assertEquals("RedisInc", companyNames.get(0));
+  }
+  
+  @Test
+  void testSearchStreamChainedFilters() {
+    // Test multiple chained filter operations
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(1900);
+    
+    // Filter for publicly listed companies with "database" tag
+    List<Company> databaseCompanies = stream
+        .filter(Company$.PUBLICLY_LISTED.eq(true))
+        .filter(Company$.TAGS.in("database"))
+        .collect(Collectors.toList());
+    
+    assertEquals(1, databaseCompanies.size(), "Should find 1 publicly listed database company");
+    assertEquals("Oracle", databaseCompanies.get(0).getName());
+  }
+  
+  @Test
+  void testSearchStreamWithSort() {
+    // Test sorting capabilities of SearchStream
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(1970);
+    
+    // Sort by year founded ascending
+    List<Company> sortedCompanies = stream
+        .sorted(Company$.YEAR_FOUNDED, SortOrder.ASC)
+        .collect(Collectors.toList());
+    
+    assertEquals(4, sortedCompanies.size());
+    
+    // Verify sorting order
+    assertEquals("Microsoft", sortedCompanies.get(0).getName()); // 1975
+    assertEquals("Apple", sortedCompanies.get(1).getName());     // 1976
+    assertEquals("Oracle", sortedCompanies.get(2).getName());    // 1977
+    assertEquals("RedisInc", sortedCompanies.get(3).getName());  // 2011
+  }
+  
+  @Test
+  void testSearchStreamLimit() {
+    // Test limit operation on SearchStream
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(1900);
+    
+    // Limit to first 2 results
+    List<Company> limitedCompanies = stream
+        .limit(2)
+        .collect(Collectors.toList());
+    
+    assertEquals(2, limitedCompanies.size(), "Should return only 2 companies due to limit");
+  }
+  
+  @Test
+  void testSearchStreamCount() {
+    // Test count operation on SearchStream
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(1970);
+    
+    long count = stream.count();
+    
+    assertEquals(4, count, "Should count 4 companies founded after 1970");
+  }
+  
+  @Test
+  void testSearchStreamEmptyResult() {
+    // Test SearchStream with no matching results
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(2020);
+    
+    List<Company> companies = stream.collect(Collectors.toList());
+    
+    assertTrue(companies.isEmpty(), "Should return empty list for companies founded after 2020");
+  }
+  
+  @Test
+  void testSearchStreamComplexQuery() {
+    // Test a complex query combining multiple operations as shown in documentation
+    SearchStream<Company> stream = repository.findByYearFoundedGreaterThan(1970);
+    
+    // Complex query: publicly listed companies, map to names, filter names starting with 'A'
+    List<String> names = stream
+        .filter(Company$.PUBLICLY_LISTED.eq(true))
+        .map(Company$.NAME)
+        .filter(name -> ((String) name).startsWith("A"))
+        .collect(Collectors.toList());
+    
+    assertEquals(1, names.size(), "Should find 1 publicly listed company starting with 'A'");
+    assertEquals("Apple", names.get(0));
+  }
+}


### PR DESCRIPTION
Add support for repositories to return SearchStream for fluent query operations. This enables combining Spring Data repository methods with Entity Stream capabilities for both JSON documents and Redis Hashes.

Changes:
- Implement SearchStream detection and handling in RediSearchQuery for JSON documents
- Implement SearchStream detection and handling in RedisEnhancedQuery for Redis Hashes
- Create EntityStream instances that are configured with query filters
- Support lazy execution when terminal operations are called

Documentation:
- Add Entity Streams Integration section to hash-mappings.adoc
- Update comparison table to mention SearchStream return capability

This feature allows repository methods to return SearchStream<T> enabling:
- Fluent filtering with field predicates
- Mapping and transformation operations
- Sorting, limiting, and counting
- Lazy evaluation for better performance