### PR TITLE
feat(#677): generate indexed subfields for @Reference fields

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
@@ -853,7 +853,7 @@ public final class MetamodelGenerator extends AbstractProcessor {
       boolean fieldIsIndexed = (field.getAnnotation(Indexed.class) != null) || (field.getAnnotation(
           Searchable.class) != null) || (field.getAnnotation(NumericIndexed.class) != null) || (field.getAnnotation(
               TagIndexed.class) != null) || (field.getAnnotation(TextIndexed.class) != null) || (field.getAnnotation(
-                  GeoIndexed.class) != null);
+                  GeoIndexed.class) != null) || (field.getAnnotation(VectorIndexed.class) != null);
 
       // Skip @Id fields and @Reference fields (to avoid infinite recursion)
       boolean isIdField = field.getAnnotation(Id.class) != null;

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/ReferenceIndexedSubfieldsTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/ReferenceIndexedSubfieldsTest.java
@@ -244,4 +244,75 @@ class ReferenceIndexedSubfieldsTest extends AbstractBaseDocumentTest {
       assertThat(value).as("Field %s should have a non-null value", fieldName).isNotNull();
     }
   }
+
+  // ==================================================================================
+  // Tests for Date/time and UUID types (PR review feedback)
+  // ==================================================================================
+
+  /**
+   * Test that the metamodel generates OWNER_BIRTH_DATE field for @Indexed LocalDate fields.
+   */
+  @Test
+  void testMetamodelGeneratesOwnerBirthDateField() throws Exception {
+    Class<?> metamodelClass = Class.forName("com.redis.om.spring.fixtures.document.model.RefVehicle$");
+
+    // Check that the static field OWNER_BIRTH_DATE exists (from @Indexed LocalDate)
+    Field ownerBirthDateField = metamodelClass.getDeclaredField("OWNER_BIRTH_DATE");
+    assertThat(ownerBirthDateField).isNotNull();
+
+    Object ownerBirthDateValue = ownerBirthDateField.get(null);
+    assertThat(ownerBirthDateValue).isNotNull();
+  }
+
+  /**
+   * Test that the metamodel generates OWNER_CREATED_AT field for @Indexed LocalDateTime fields.
+   */
+  @Test
+  void testMetamodelGeneratesOwnerCreatedAtField() throws Exception {
+    Class<?> metamodelClass = Class.forName("com.redis.om.spring.fixtures.document.model.RefVehicle$");
+
+    // Check that the static field OWNER_CREATED_AT exists (from @Indexed LocalDateTime)
+    Field ownerCreatedAtField = metamodelClass.getDeclaredField("OWNER_CREATED_AT");
+    assertThat(ownerCreatedAtField).isNotNull();
+
+    Object ownerCreatedAtValue = ownerCreatedAtField.get(null);
+    assertThat(ownerCreatedAtValue).isNotNull();
+  }
+
+  /**
+   * Test that the metamodel generates OWNER_EXTERNAL_ID field for @Indexed UUID fields.
+   */
+  @Test
+  void testMetamodelGeneratesOwnerExternalIdField() throws Exception {
+    Class<?> metamodelClass = Class.forName("com.redis.om.spring.fixtures.document.model.RefVehicle$");
+
+    // Check that the static field OWNER_EXTERNAL_ID exists (from @Indexed UUID)
+    Field ownerExternalIdField = metamodelClass.getDeclaredField("OWNER_EXTERNAL_ID");
+    assertThat(ownerExternalIdField).isNotNull();
+
+    Object ownerExternalIdValue = ownerExternalIdField.get(null);
+    assertThat(ownerExternalIdValue).isNotNull();
+  }
+
+  /**
+   * Test that all Date/time and UUID fields from Owner are generated in RefVehicle$.
+   */
+  @Test
+  void testAllDateTimeAndUuidFieldsAreGenerated() throws Exception {
+    Class<?> metamodelClass = Class.forName("com.redis.om.spring.fixtures.document.model.RefVehicle$");
+
+    // Verify Date/time and UUID fields exist
+    String[] expectedFields = {
+        "OWNER_BIRTH_DATE",   // @Indexed LocalDate
+        "OWNER_CREATED_AT",   // @Indexed LocalDateTime
+        "OWNER_EXTERNAL_ID"   // @Indexed UUID
+    };
+
+    for (String fieldName : expectedFields) {
+      Field field = metamodelClass.getDeclaredField(fieldName);
+      assertThat(field).as("Field %s should exist", fieldName).isNotNull();
+      Object value = field.get(null);
+      assertThat(value).as("Field %s should have a non-null value", fieldName).isNotNull();
+    }
+  }
 }

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/Owner.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/Owner.java
@@ -1,5 +1,9 @@
 package com.redis.om.spring.fixtures.document.model;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
 import org.springframework.data.annotation.Id;
 
 import com.redis.om.spring.annotations.Document;
@@ -21,6 +25,8 @@ import lombok.*;
  * - @TagIndexed with indexMissing/indexEmpty
  * - @NumericIndexed with sortable
  * - @Indexed on Boolean
+ * - @Indexed on Date/time types (LocalDate, LocalDateTime)
+ * - @Indexed on UUID
  */
 @Data
 @RequiredArgsConstructor(staticName = "of")
@@ -47,4 +53,13 @@ public class Owner {
 
   @Indexed(sortable = true, indexMissing = true, indexEmpty = true)
   private Boolean active;
+
+  @Indexed(sortable = true)
+  private LocalDate birthDate;
+
+  @Indexed(sortable = true)
+  private LocalDateTime createdAt;
+
+  @Indexed
+  private UUID externalId;
 }


### PR DESCRIPTION
When a document has a @Reference @Indexed field pointing to another entity, the metamodel now generates field accessors for the referenced entity's indexed/searchable fields, enabling queries like:

  entityStream.of(RefVehicle.class)
    .filter(RefVehicle$.OWNER_NAME.eq("John"))
    .collect(...)

Changes:
- MetamodelGenerator: Add processReferencedEntityIndexableFields() to generate metamodel fields for all indexed annotations (@Indexed, @Searchable, @TagIndexed, @TextIndexed, @NumericIndexed, @GeoIndexed, @VectorIndexed)
- RediSearchIndexer: Add createIndexedFieldsForReferencedEntity() to create index fields with full attribute support (sortable, noindex, indexMissing, indexEmpty, phonetic, weight, nostem, separator)
- Support for VectorIndexed fields with FLAT/HNSW algorithms
- Support for Date/time types (LocalDateTime, LocalDate, Date, Instant, OffsetDateTime) as numeric fields
- Support for UUID and Ulid types as tag fields

Note: @Reference fields store only the entity ID, not the full object. Searching by referenced entity properties requires denormalized data. The metamodel fields are generated for API consistency.