### PR TITLE
fix(serialization): use Gson JsonObject for projection field serializ…

### DIFF
--- a/tests/src/test/java/com/redis/om/spring/annotations/document/QueryProjectionJsonSerializationTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/QueryProjectionJsonSerializationTest.java
@@ -1,0 +1,74 @@
+package com.redis.om.spring.annotations.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.ProductDoc;
+import com.redis.om.spring.fixtures.document.repository.ProductDocRepository;
+
+import redis.clients.jedis.search.SearchResult;
+
+/**
+ * Tests for Issue #676: Gson JSON serialization bug with spaces in projected fields.
+ *
+ * When using FT.SEARCH with field projections (returnFields), a JsonSyntaxException
+ * occurs if projected TEXT fields contain values with spaces (e.g., "makeup spatula premium").
+ *
+ * The issue is in RediSearchQuery.parseDocumentResult() which manually constructs JSON
+ * strings via StringBuilder without properly quoting string values.
+ *
+ * @see <a href="https://github.com/redis/redis-om-spring/issues/676">Issue #676</a>
+ */
+class QueryProjectionJsonSerializationTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  ProductDocRepository productDocRepository;
+
+  @BeforeEach
+  void setup() {
+    productDocRepository.deleteAll();
+
+    // Create products with multi-word keywords (spaces in the value)
+    productDocRepository.save(ProductDoc.of("makeup spatula premium", "beauty", 19.99));
+    productDocRepository.save(ProductDoc.of("kitchen knife set", "kitchen", 49.99));
+    productDocRepository.save(ProductDoc.of("wireless bluetooth headphones", "electronics", 89.99));
+    productDocRepository.save(ProductDoc.of("organic green tea", "food", 12.99));
+    productDocRepository.save(ProductDoc.of("simple", "beauty", 9.99)); // single word for comparison
+  }
+
+  /**
+   * Test that projected fields with spaces are correctly serialized.
+   * This test would fail before the fix with a JsonSyntaxException because
+   * the manual JSON construction didn't quote string values properly.
+   */
+  @Test
+  void testProjectedFieldsWithSpacesDoNotCauseJsonSyntaxException() {
+    // First verify data was saved
+    assertThat(productDocRepository.count()).isEqualTo(5);
+
+    // This query returns projected fields (keyword, category) as domain objects
+    // The keyword field contains spaces which should be properly quoted in JSON
+    List<ProductDoc> products = productDocRepository.findByCategoryWithProjection("beauty");
+
+    assertThat(products).hasSize(2);
+    assertThat(products).extracting("keyword")
+        .containsExactlyInAnyOrder("makeup spatula premium", "simple");
+    assertThat(products).extracting("category")
+        .containsOnly("beauty");
+  }
+
+  /**
+   * Test that the raw SearchResult query works (baseline).
+   */
+  @Test
+  void testSearchResultQueryWorks() {
+    SearchResult result = productDocRepository.findByCategoryReturningSearchResult("beauty");
+    assertThat(result.getTotalResults()).isEqualTo(2);
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/ProductDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/ProductDoc.java
@@ -1,0 +1,34 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.*;
+
+/**
+ * Model for testing Issue #676: Gson JSON serialization bug with spaces in projected fields.
+ */
+@Data
+@RequiredArgsConstructor(staticName = "of")
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(force = true)
+@Document("productdoc")
+public class ProductDoc {
+  @Id
+  private String id;
+
+  @NonNull
+  @Searchable
+  private String keyword;
+
+  @NonNull
+  @Indexed
+  private String category;
+
+  @NonNull
+  @Indexed
+  private Double price;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/ProductDocRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/ProductDocRepository.java
@@ -1,0 +1,30 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import java.util.List;
+
+import org.springframework.data.repository.query.Param;
+
+import com.redis.om.spring.annotations.Query;
+import com.redis.om.spring.fixtures.document.model.ProductDoc;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+import redis.clients.jedis.search.SearchResult;
+
+/**
+ * Repository for testing Issue #676: Gson JSON serialization bug with spaces in projected fields.
+ */
+public interface ProductDocRepository extends RedisDocumentRepository<ProductDoc, String> {
+
+  /**
+   * Query that returns projected fields (keyword, category) as domain objects.
+   * This triggers the parseDocumentResult projection logic path.
+   */
+  @Query(value = "@category:{$category}", returnFields = {"keyword", "category"})
+  List<ProductDoc> findByCategoryWithProjection(@Param("category") String category);
+
+  /**
+   * Baseline query returning SearchResult to verify search works.
+   */
+  @Query(value = "@category:{$category}", returnFields = {"keyword", "category"})
+  SearchResult findByCategoryReturningSearchResult(@Param("category") String category);
+}


### PR DESCRIPTION
…ation (#676)

Replace manual StringBuilder JSON construction with Gson's JsonObject in parseDocumentResult() to properly handle string values with spaces and special characters preventing MalformedJsonException when projected TEXT fields contained spaces (e.g., "makeup spatula premium").

Changes:
- Use JsonObject.addProperty() which handles quoting and escaping
- Parse numeric values as Double/Long instead of raw strings
- Properly handle already-quoted strings by removing outer quotes

Closes #676