### PR TITLE
fix(autocomplete): use Tuple.getElement() for payload lookup in autoc…

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/ops/search/SearchOperationsImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/ops/search/SearchOperationsImpl.java
@@ -135,7 +135,7 @@ public class SearchOperationsImpl<K> implements SearchOperations<K> {
           String[] keyParts = key.split(":");
           String payLoadKey = String.format("sugg:payload:%s:%s", keyParts[keyParts.length - 2],
               keyParts[keyParts.length - 1]);
-          Object payload = template.opsForHash().get(payLoadKey, suggestion);
+          Object payload = template.opsForHash().get(payLoadKey, suggestion.getElement());
           String json = payload != null ? payload.toString() : "{}";
           Map<String, Object> payloadMap = gson.fromJson(json, new TypeToken<Map<String, Object>>() {
           }.getType());


### PR DESCRIPTION
…omplete (#673)

When both withScore() and withPayload() options are enabled, the code incorrectly passed the Tuple object directly to the hash lookup instead of extracting the string element first.

This caused a ClassCastException: "class redis.clients.jedis.resps.Tuple cannot be cast to class java.lang.String"

Closes #673