### PR TITLE
fix: resolve Spring Boot 4.0.0 compatibility issues (#697)

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisRepositoriesExcludeFilter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisRepositoriesExcludeFilter.java
@@ -33,7 +33,10 @@ public class RedisRepositoriesExcludeFilter implements AutoConfigurationImportFi
   }
 
   private static final Set<String> SHOULD_SKIP = new HashSet<>(List.of(
-      "org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration"));
+      // Spring Boot 3.x class name
+      "org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration",
+      // Spring Boot 4.0+ class name (modular autoconfigure)
+      "org.springframework.boot.data.redis.autoconfigure.DataRedisRepositoriesAutoConfiguration"));
 
   @Override
   public boolean[] match(String[] autoConfigurationClasses, AutoConfigurationMetadata autoConfigurationMetadata) {

--- a/redis-om-spring/src/main/resources/META-INF/spring.factories
+++ b/redis-om-spring/src/main/resources/META-INF/spring.factories
@@ -1,6 +1,6 @@
 # Auto Configure
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-com.redis.om.spring.RedisModulesConfiguration
+com.redis.om.spring.RedisModulesConfiguration,\
 com.redis.om.spring.EntraIDConfiguration
 org.springframework.boot.autoconfigure.AutoConfigurationImportFilter=\
 com.redis.om.spring.RedisRepositoriesExcludeFilter


### PR DESCRIPTION
Fix two issues reported when using Redis OM Spring 2.0.0 with Spring Boot 4.0.0:

1. Bean definition conflict: Update RedisRepositoriesExcludeFilter to exclude the new modular autoconfiguration class name used in Spring Boot 4.0 (DataRedisRepositoriesAutoConfiguration) in addition to the legacy class name.

2. Missing JedisConnectionFactory: Add JedisConnectionFactory and StringRedisTemplate beans to RedisModulesConfiguration that are created when Spring Boot's Redis autoconfiguration is not present. This ensures Redis OM Spring works regardless of whether spring-boot-data-redis is explicitly included.

Also fix spring.factories formatting (missing line continuation backslash).