### PR TITLE
feat: allowing in filtering to accept a collection as a parameter

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/NumericField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/NumericField.java
@@ -1,6 +1,8 @@
 package com.redis.om.spring.metamodel.indexed;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -137,7 +139,7 @@ public class NumericField<E, T> extends MetamodelField<E, T> {
 
   /**
    * Creates an in predicate for this numeric field to match any of the specified values.
-   * 
+   *
    * @param values the values to match against
    * @return an InPredicate that matches entities where this field equals any of the specified values
    */
@@ -146,6 +148,22 @@ public class NumericField<E, T> extends MetamodelField<E, T> {
   )
   public InPredicate<E, ?> in(T... values) {
     return new InPredicate<>(searchFieldAccessor, Arrays.asList(values));
+  }
+
+  /**
+   * Creates an in predicate for this numeric field to match any of the specified values from a collection.
+   * <p>
+   * This is useful when you already have your values in a Collection (List, Set, etc.) and want to
+   * avoid converting to an array.
+   *
+   * @param values the collection of values to match against
+   * @return an InPredicate that matches entities where this field equals any of the specified values
+   */
+  @SuppressWarnings(
+    "unchecked"
+  )
+  public InPredicate<E, ?> in(Collection<T> values) {
+    return new InPredicate<>(searchFieldAccessor, new ArrayList<>(values));
   }
 
   /**
@@ -172,7 +190,7 @@ public class NumericField<E, T> extends MetamodelField<E, T> {
    * Creates an array membership predicate for this numeric field to check if the array contains any of the specified
    * Double values.
    * This method is similar to TagField.in() but for numeric arrays.
-   * 
+   *
    * @param values the Double values to check for membership in the array
    * @return an InPredicate that matches entities where this numeric array field contains any of the specified values
    */
@@ -185,9 +203,26 @@ public class NumericField<E, T> extends MetamodelField<E, T> {
 
   /**
    * Creates an array membership predicate for this numeric field to check if the array contains any of the specified
+   * Double values from a collection.
+   * <p>
+   * This is useful when you already have your Double values in a Collection (List, Set, etc.) and want to
+   * avoid converting to an array.
+   *
+   * @param values the collection of Double values to check for membership in the array
+   * @return an InPredicate that matches entities where this numeric array field contains any of the specified values
+   */
+  @SuppressWarnings(
+    "unchecked"
+  )
+  public InPredicate<E, ?> containsDouble(Collection<Double> values) {
+    return new InPredicate<>(searchFieldAccessor, new ArrayList<>(values));
+  }
+
+  /**
+   * Creates an array membership predicate for this numeric field to check if the array contains any of the specified
    * Long values.
    * This method is similar to TagField.in() but for numeric arrays.
-   * 
+   *
    * @param values the Long values to check for membership in the array
    * @return an InPredicate that matches entities where this numeric array field contains any of the specified values
    */
@@ -200,9 +235,26 @@ public class NumericField<E, T> extends MetamodelField<E, T> {
 
   /**
    * Creates an array membership predicate for this numeric field to check if the array contains any of the specified
+   * Long values from a collection.
+   * <p>
+   * This is useful when you already have your Long values in a Collection (List, Set, etc.) and want to
+   * avoid converting to an array.
+   *
+   * @param values the collection of Long values to check for membership in the array
+   * @return an InPredicate that matches entities where this numeric array field contains any of the specified values
+   */
+  @SuppressWarnings(
+    "unchecked"
+  )
+  public InPredicate<E, ?> containsLong(Collection<Long> values) {
+    return new InPredicate<>(searchFieldAccessor, new ArrayList<>(values));
+  }
+
+  /**
+   * Creates an array membership predicate for this numeric field to check if the array contains any of the specified
    * Integer values.
    * This method is similar to TagField.in() but for numeric arrays.
-   * 
+   *
    * @param values the Integer values to check for membership in the array
    * @return an InPredicate that matches entities where this numeric array field contains any of the specified values
    */
@@ -211,6 +263,23 @@ public class NumericField<E, T> extends MetamodelField<E, T> {
   )
   public InPredicate<E, ?> containsInt(Integer... values) {
     return new InPredicate<>(searchFieldAccessor, Arrays.asList(values));
+  }
+
+  /**
+   * Creates an array membership predicate for this numeric field to check if the array contains any of the specified
+   * Integer values from a collection.
+   * <p>
+   * This is useful when you already have your Integer values in a Collection (List, Set, etc.) and want to
+   * avoid converting to an array.
+   *
+   * @param values the collection of Integer values to check for membership in the array
+   * @return an InPredicate that matches entities where this numeric array field contains any of the specified values
+   */
+  @SuppressWarnings(
+    "unchecked"
+  )
+  public InPredicate<E, ?> containsInt(Collection<Integer> values) {
+    return new InPredicate<>(searchFieldAccessor, new ArrayList<>(values));
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/indexed/TagField.java
@@ -1,8 +1,8 @@
 package com.redis.om.spring.metamodel.indexed;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.ToLongFunction;
@@ -118,6 +118,20 @@ public class TagField<E, T> extends MetamodelField<E, T> {
   }
 
   /**
+   * Creates a not-equal predicate for a collection of string values.
+   * <p>
+   * This predicate matches entities where the tag field does not contain any of the specified values.
+   * This is useful for excluding entities tagged with any of several tags when the values are already
+   * in a Collection (List, Set, etc.).
+   *
+   * @param values the collection of tag values to exclude from results
+   * @return a not-equal predicate for query building
+   */
+  public NotEqualPredicate<E, T> notEq(Collection<String> values) {
+    return new NotEqualPredicate<>(searchFieldAccessor, new ArrayList<>(values));
+  }
+
+  /**
    * Creates an IN predicate for multiple string values.
    * <p>
    * This predicate matches entities where the tag field contains any of the specified values.
@@ -154,7 +168,7 @@ public class TagField<E, T> extends MetamodelField<E, T> {
    * @return an IN predicate for query building
    */
   public InPredicate<E, ?> in(Collection<String> values) {
-    return new InPredicate<>(searchFieldAccessor, List.copyOf(values));
+    return new InPredicate<>(searchFieldAccessor, new ArrayList<>(values));
   }
 
   /**
@@ -181,6 +195,20 @@ public class TagField<E, T> extends MetamodelField<E, T> {
    */
   public ContainsAllPredicate<E, ?> containsAll(Object... values) {
     return new ContainsAllPredicate<>(searchFieldAccessor, Arrays.stream(values).map(Object::toString).toList());
+  }
+
+  /**
+   * Creates a contains-all predicate for a collection of string values.
+   * <p>
+   * This predicate matches entities where the tag field contains all of the specified values.
+   * This is useful for finding entities that have been tagged with a specific combination of tags
+   * when the values are already in a Collection (List, Set, etc.).
+   *
+   * @param values the collection of tag values that must all be present
+   * @return a contains-all predicate for query building
+   */
+  public ContainsAllPredicate<E, ?> containsAll(Collection<String> values) {
+    return new ContainsAllPredicate<>(searchFieldAccessor, new ArrayList<>(values));
   }
 
   /**

--- a/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
@@ -256,6 +256,20 @@ class EntityStreamDocsTest extends AbstractBaseDocumentTest {
   }
 
   @Test
+  void testFindByIntegerNumericPropertyInWithCollection() {
+    // Test passing a Collection directly to the in() method for Integer fields
+    List<Integer> yearsToSearch = List.of(2011, 1975, 2003);
+
+    List<String> names = entityStream //
+        .of(Company.class) //
+        .filter(Company$.YEAR_FOUNDED.in(yearsToSearch)) //
+        .map(Company$.NAME) //
+        .collect(Collectors.toList());
+
+    assertThat(names).contains("RedisInc", "Microsoft", "Tesla");
+  }
+
+  @Test
   void testFindByTwoPropertiesAndedNotEquals() {
     SearchStream<Company> stream = entityStream.of(Company.class);
 
@@ -787,10 +801,62 @@ class EntityStreamDocsTest extends AbstractBaseDocumentTest {
   }
 
   @Test
+  void testFindByRolesInWithSet() {
+    // Test passing a Set directly to the in() method
+    Set<String> rolesToSearch = Set.of("educator", "devrel");
+
+    List<String> names = entityStream //
+        .of(User.class) //
+        .filter(User$.ROLES.in(rolesToSearch)) //
+        .map(User$.NAME) //
+        .collect(Collectors.toList());
+
+    assertEquals(4, names.size());
+
+    assertTrue(names.contains("Steve Lorello"));
+    assertTrue(names.contains("Nava Levy"));
+    assertTrue(names.contains("Savannah Norem"));
+    assertTrue(names.contains("Suze Shardlow"));
+  }
+
+  @Test
+  void testFindByRolesNotEqWithCollection() {
+    // Test passing a Collection to the notEq() method
+    List<String> rolesToExclude = List.of("guru");
+
+    List<String> names = entityStream //
+        .of(User.class) //
+        .filter(User$.ROLES.notEq(rolesToExclude)) //
+        .map(User$.NAME) //
+        .collect(Collectors.toList());
+
+    assertEquals(2, names.size());
+
+    assertTrue(names.contains("Savannah Norem"));
+    assertTrue(names.contains("Suze Shardlow"));
+  }
+
+  @Test
   void testFindByTagsContainingAll() {
     List<String> names = entityStream //
         .of(Company.class) //
         .filter(Company$.TAGS.containsAll("fast", "scalable", "reliable", "database", "nosql")) //
+        .map(Company$.NAME) //
+        .collect(Collectors.toList());
+
+    assertEquals(1, names.size());
+
+    assertTrue(names.contains("RedisInc"));
+  }
+
+  @Test
+  void testFindByTagsContainingAllWithCollection() {
+    // Test passing a Collection to the containsAll() method
+    List<String> requiredTags = List.of("fast", "scalable", "reliable");
+
+    List<String> names = entityStream //
+        .of(Company.class) //
+        .filter(Company$.TAGS.containsAll(requiredTags)) //
         .map(Company$.NAME) //
         .collect(Collectors.toList());
 
@@ -1329,6 +1395,20 @@ class EntityStreamDocsTest extends AbstractBaseDocumentTest {
         .collect(Collectors.toList());
 
     List<String> names = users.stream().map(User::getName).toList();
+    assertThat(names).containsExactly("Nava Levy", "Savannah Norem");
+  }
+
+  @Test
+  void testFindByDoubleNumericPropertyInWithCollection() {
+    // Test passing a Collection directly to the in() method
+    List<Double> winningsToSearch = List.of(1234.5678, 999.99);
+
+    List<String> names = entityStream //
+        .of(User.class) //
+        .filter(User$.LOTTERY_WINNINGS.in(winningsToSearch)) //
+        .map(User$.NAME) //
+        .collect(Collectors.toList());
+
     assertThat(names).containsExactly("Nava Levy", "Savannah Norem");
   }
 


### PR DESCRIPTION
This PR adds a new in(Collection<String> values) method to the TagField class, allowing users to pass Collections (List, Set, etc.) directly to the in() predicate without needing to convert them to arrays first.

**Motivation**
Previously, users who had their filter values in a List or other Collection had to manually convert them to arrays using .toArray(new String[0]) before passing them to the in() method:

This was inconvenient and not intuitive, especially since Collections are a common way to store and pass around groups of values in Java.