### PR TITLE
feat: support FT.SEARCH SCORER and WITHSCORES in SearchStream

### DIFF
--- a/docs/content/modules/ROOT/pages/entity-streams.adoc
+++ b/docs/content/modules/ROOT/pages/entity-streams.adoc
@@ -516,6 +516,119 @@ List<String> namesOnly = entityStream.of(Company.class)
 4. **Index appropriately**: Ensure fields used in filters are properly indexed
 5. **Combine filters**: Use compound filters rather than multiple filter calls when possible
 
+== Relevance Scoring
+
+Entity Streams support retrieving relevance scores from the Redis Query Engine alongside search results, and controlling the scoring algorithm used for ranking.
+
+=== Retrieving Scores
+
+Use `toListWithScores()` to retrieve entities paired with their relevance scores. This terminal operation returns `List<Pair<E, Double>>` where each pair contains the entity and its score:
+
+[source,java]
+----
+import com.redis.om.spring.search.stream.Scorer;
+
+// Get results with relevance scores
+List<Pair<Company, Double>> results = entityStream.of(Company.class)
+    .filter(Company$.NAME.containing("Redis"))
+    .toListWithScores();
+
+results.forEach(pair -> {
+    Company company = pair.getFirst();
+    Double score = pair.getSecond();
+    System.out.println(company.getName() + " (score: " + score + ")");
+});
+----
+
+NOTE: `toListWithScores()` implicitly enables the Redis `WITHSCORES` flag. You do not need to call `withScores()` separately when using this terminal operation.
+
+=== Choosing a Scoring Algorithm
+
+The `scorer()` method lets you select the algorithm Redis uses to compute relevance scores. The default is `TFIDF`.
+
+[source,java]
+----
+// Use BM25 scoring
+List<Pair<Company, Double>> bm25Results = entityStream.of(Company.class)
+    .filter(Company$.NAME.containing("Redis"))
+    .scorer(Scorer.BM25STD)
+    .toListWithScores();
+
+// Use DISMAX scoring
+List<Pair<Company, Double>> dismaxResults = entityStream.of(Company.class)
+    .filter(Company$.NAME.containing("Redis"))
+    .scorer(Scorer.DISMAX)
+    .toListWithScores();
+----
+
+Available scorers:
+
+[cols="1,3"]
+|===
+|Scorer |Description
+
+|`TFIDF`
+|Term Frequency-Inverse Document Frequency (default)
+
+|`TFIDF_DOCNORM`
+|TF-IDF with document-length normalization
+
+|`BM25STD`
+|BM25 standard scoring
+
+|`BM25STD_NORM`
+|BM25 standard with document-length normalization
+
+|`BM25STD_TANH`
+|BM25 standard with hyperbolic tangent normalization
+
+|`DISMAX`
+|Maximum of per-term scores
+
+|`DOCSCORE`
+|Uses the document's static score (set at index time)
+
+|`HAMMING`
+|Hamming distance scorer (for binary data)
+|===
+
+=== Combining with Other Operations
+
+Scoring works with sorting, limiting, skipping, and filtering:
+
+[source,java]
+----
+// Combine with sort and limit
+List<Pair<Company, Double>> topResults = entityStream.of(Company.class)
+    .filter(Company$.NAME.containing("Redis")
+        .or(Company$.NAME.containing("Microsoft")))
+    .scorer(Scorer.BM25STD)
+    .sorted(Company$.NAME, SortOrder.ASC)
+    .limit(5)
+    .toListWithScores();
+
+// Skip and limit with scores
+List<Pair<Company, Double>> page2 = entityStream.of(Company.class)
+    .filter(Company$.NAME.containing("tech"))
+    .skip(10)
+    .limit(10)
+    .toListWithScores();
+----
+
+=== Using withScores() with Regular Terminal Operations
+
+The `withScores()` method enables the Redis `WITHSCORES` flag without changing the terminal operation. This is useful when you want Redis to compute scores (e.g., for logging or debugging) but still collect results as plain entities:
+
+[source,java]
+----
+// withScores() with regular collect — entities are returned normally
+List<Company> companies = entityStream.of(Company.class)
+    .filter(Company$.NAME.containing("Redis"))
+    .scorer(Scorer.BM25STD)
+    .withScores()
+    .collect(Collectors.toList());
+----
+
 == Integration with Query By Example
 
 Entity Streams can work with Spring Data Query By Example:

--- a/docs/content/modules/ROOT/pages/hash-mappings.adoc
+++ b/docs/content/modules/ROOT/pages/hash-mappings.adoc
@@ -491,6 +491,7 @@ The `SearchStream` returned by repository methods supports all Entity Stream ope
 * **Limiting**: `limit()` to restrict results
 * **Aggregation**: `count()`, `findFirst()`, `anyMatch()`, `allMatch()`
 * **Collection**: `collect()` to lists, sets, or custom collectors
+* **Scoring**: `scorer()` to choose the ranking algorithm, `toListWithScores()` to retrieve entity-score pairs
 
 NOTE: Fields used in SearchStream operations must be properly indexed with `@Indexed`, `@Searchable`, or other indexing annotations.
 

--- a/docs/content/modules/ROOT/pages/search.adoc
+++ b/docs/content/modules/ROOT/pages/search.adoc
@@ -185,6 +185,43 @@ List<Game> results = entityStream
   .collect(Collectors.toList());
 ----
 
+=== Retrieving Relevance Scores
+
+You can retrieve the relevance score for each result using `toListWithScores()`. This returns `List<Pair<E, Double>>` where each pair contains the entity and its score:
+
+[source,java]
+----
+import com.redis.om.spring.search.stream.Scorer;
+import com.redis.om.spring.tuple.Pair;
+
+List<Pair<Game, Double>> scored = entityStream
+  .of(Game.class)
+  .filter(Game$.TITLE.containing("adventure"))
+  .toListWithScores();
+
+scored.forEach(pair -> {
+    System.out.println(pair.getFirst().getTitle() + " → " + pair.getSecond());
+});
+----
+
+=== Choosing a Scoring Algorithm
+
+Use `scorer()` to select the algorithm Redis uses for ranking. The default is `TFIDF`.
+
+[source,java]
+----
+// BM25 scoring
+List<Pair<Game, Double>> results = entityStream
+  .of(Game.class)
+  .filter(Game$.TITLE.containing("adventure"))
+  .scorer(Scorer.BM25STD)
+  .toListWithScores();
+----
+
+Available scorers: `TFIDF`, `TFIDF_DOCNORM`, `BM25STD`, `BM25STD_NORM`, `BM25STD_TANH`, `DISMAX`, `DOCSCORE`, `HAMMING`.
+
+TIP: See xref:entity-streams.adoc#_relevance_scoring[Entity Streams — Relevance Scoring] for the full scorer reference and more examples.
+
 == Lexicographic String Indexing
 
 Redis OM Spring supports lexicographic (alphabetical) string comparisons through the `lexicographic` parameter on `@Indexed` and `@Searchable` annotations. This feature enables string range queries using Redis sorted sets.

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/ReturnFieldsSearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/ReturnFieldsSearchStreamImpl.java
@@ -590,4 +590,19 @@ public class ReturnFieldsSearchStreamImpl<E, T> implements SearchStream<T> {
     throw new UnsupportedOperationException("findFirstOrElse is not supported on a ReturnFieldSearchStream");
   }
 
+  @Override
+  public SearchStream<T> withScores() {
+    throw new UnsupportedOperationException("withScores is not supported on a ReturnFieldSearchStream");
+  }
+
+  @Override
+  public SearchStream<T> scorer(Scorer scorer) {
+    throw new UnsupportedOperationException("scorer is not supported on a ReturnFieldSearchStream");
+  }
+
+  @Override
+  public List<Pair<T, Double>> toListWithScores() {
+    throw new UnsupportedOperationException("toListWithScores is not supported on a ReturnFieldSearchStream");
+  }
+
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/Scorer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/Scorer.java
@@ -1,0 +1,55 @@
+package com.redis.om.spring.search.stream;
+
+/**
+ * Defines the scoring algorithm used by Redis FT.SEARCH to rank results.
+ * <p>
+ * Each scorer implements a different relevance ranking strategy. The default
+ * scorer used by Redis is TFIDF. Set a scorer on a {@link SearchStream} via
+ * {@link SearchStream#scorer(Scorer)}.
+ * </p>
+ *
+ * @since 2.1.0
+ * @see SearchStream#scorer(Scorer)
+ * @see SearchStream#withScores()
+ */
+public enum Scorer {
+
+  /** Term Frequency-Inverse Document Frequency (default). */
+  TFIDF("TFIDF"),
+
+  /** TF-IDF with document-length normalization. */
+  TFIDF_DOCNORM("TFIDF.DOCNORM"),
+
+  /** BM25 standard scoring. */
+  BM25STD("BM25STD"),
+
+  /** BM25 standard with document-length normalization. */
+  BM25STD_NORM("BM25STD.NORM"),
+
+  /** BM25 standard with hyperbolic tangent normalization. */
+  BM25STD_TANH("BM25STD.TANH"),
+
+  /** Maximum of per-term scores. */
+  DISMAX("DISMAX"),
+
+  /** Uses the document's static score (set at index time). */
+  DOCSCORE("DOCSCORE"),
+
+  /** Hamming distance scorer (for binary data). */
+  HAMMING("HAMMING");
+
+  private final String value;
+
+  Scorer(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Returns the Redis protocol string for this scorer.
+   *
+   * @return the scorer name as expected by FT.SEARCH SCORER parameter
+   */
+  public String getValue() {
+    return value;
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStream.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStream.java
@@ -2,6 +2,7 @@ package com.redis.om.spring.search.stream;
 
 import java.time.Duration;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.*;
@@ -614,8 +615,53 @@ public interface SearchStream<E> extends BaseStream<E, SearchStream<E>> {
   <R> SearchStream<E> highlight(Function<? super E, ? extends R> field, Pair<String, String> tags);
 
   /**
+   * Enables returning relevance scores alongside search results.
+   * <p>
+   * When enabled, the Redis FT.SEARCH command includes the WITHSCORES flag,
+   * causing each result to carry a relevance score. Use {@link #toListWithScores()}
+   * to retrieve entity-score pairs.
+   * </p>
+   *
+   * @return this SearchStream instance
+   * @since 2.1.0
+   * @see #scorer(Scorer)
+   * @see #toListWithScores()
+   */
+  SearchStream<E> withScores();
+
+  /**
+   * Sets the scoring algorithm for the search query.
+   * <p>
+   * Redis FT.SEARCH supports multiple scoring algorithms (e.g. BM25, TFIDF, DISMAX).
+   * This method allows selecting the algorithm used to compute relevance scores.
+   * </p>
+   *
+   * @param scorer the scoring algorithm to use
+   * @return this SearchStream instance
+   * @since 2.1.0
+   * @see Scorer
+   * @see #withScores()
+   * @see #toListWithScores()
+   */
+  SearchStream<E> scorer(Scorer scorer);
+
+  /**
+   * Terminal operation that returns entities paired with their relevance scores.
+   * <p>
+   * This method implicitly enables WITHSCORES even if {@link #withScores()} was not
+   * called, since returning zero scores would be confusing.
+   * </p>
+   *
+   * @return a list of entity-score pairs ordered by relevance
+   * @since 2.1.0
+   * @see #withScores()
+   * @see #scorer(Scorer)
+   */
+  List<Pair<E, Double>> toListWithScores();
+
+  /**
    * Returns whether this stream operates on JSON documents or hash structures.
-   * 
+   *
    * @return true if operating on JSON documents, false for hash structures
    */
   boolean isDocument();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -900,10 +900,6 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
   }
 
   /**
-   * Converts a list of {@link redis.clients.jedis.search.Document} objects
-   * (from SearchResult) to a list of entity instances.
-   */
-  /**
    * Converts a single {@link redis.clients.jedis.search.Document} to an entity instance,
    * handling both JSON document and Hash structures.
    */
@@ -1294,6 +1290,10 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
     if (hybridText != null) {
       throw new UnsupportedOperationException(
           "toListWithScores() is not supported after hybridSearch(). " + "Hybrid search uses FT.AGGREGATE/FT.HYBRID which are incompatible with FT.SEARCH WITHSCORES. " + "Use HybridQuery score aliases for explicit score access.");
+    }
+    if (!projections.isEmpty()) {
+      throw new UnsupportedOperationException(
+          "toListWithScores() is not supported after project(). " + "Projections return partial documents that cannot be deserialized into full entities. " + "Remove the project() call or use collect() instead.");
     }
     withScores = true;
     SearchResult searchResult = executeQuery();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -39,6 +39,7 @@ import com.redis.om.spring.search.stream.predicates.vector.KNNPredicate;
 import com.redis.om.spring.tuple.AbstractTupleMapper;
 import com.redis.om.spring.tuple.Pair;
 import com.redis.om.spring.tuple.TupleMapper;
+import com.redis.om.spring.tuple.Tuples;
 import com.redis.om.spring.util.ObjectUtils;
 import com.redis.om.spring.util.SearchResultRawResponseToObjectConverter;
 import com.redis.vl.query.AggregateHybridQuery;
@@ -123,6 +124,8 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
   private SummarizeParams summarizeParams;
   private Pair<String, String> highlightTags;
   private boolean isQBE = false;
+  private boolean withScores = false;
+  private Scorer scorer;
 
   /**
    * Creates a new SearchStreamImpl for the given entity class.
@@ -712,6 +715,13 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
       query.setSortBy(sortField.getField(), sortField.getOrder().equals("ASC"));
     }
 
+    if (withScores) {
+      query.setWithScores();
+    }
+    if (scorer != null) {
+      query.setScorer(scorer.getValue());
+    }
+
     if (!summaryFields.isEmpty()) {
       var fields = summaryFields.stream() //
           .map(foi -> ObjectUtils.isCollection(foi.getTargetClass()) ?
@@ -909,6 +919,32 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
       return (List<E>) documents.stream().map(d -> {
         Object entity = ObjectUtils.documentToObject(d, entityClass, mappingConverter);
         return ObjectUtils.populateRedisKey(entity, d.getId());
+      }).toList();
+    }
+  }
+
+  /**
+   * Converts a list of {@link redis.clients.jedis.search.Document} objects
+   * to a list of entity-score pairs.
+   */
+  @SuppressWarnings(
+    "unchecked"
+  )
+  private List<Pair<E, Double>> documentsToEntityScorePairs(List<redis.clients.jedis.search.Document> documents) {
+    if (isDocument) {
+      Gson g = getGson();
+      return documents.stream().map(d -> {
+        Object rawJson = d.get("$");
+        String json = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
+        E entity = g.fromJson(json, entityClass);
+        entity = ObjectUtils.populateRedisKey(entity, d.getId());
+        return Tuples.of(entity, d.getScore());
+      }).toList();
+    } else {
+      return (List<Pair<E, Double>>) documents.stream().map(d -> {
+        Object entity = ObjectUtils.documentToObject(d, entityClass, mappingConverter);
+        entity = ObjectUtils.populateRedisKey(entity, d.getId());
+        return Tuples.of((E) entity, d.getScore());
       }).toList();
     }
   }
@@ -1251,6 +1287,25 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
   public <R> SearchStream<E> highlight(Function<? super E, ? extends R> field, Pair<String, String> tags) {
     highlightTags = tags;
     return highlight(field);
+  }
+
+  @Override
+  public SearchStream<E> withScores() {
+    this.withScores = true;
+    return this;
+  }
+
+  @Override
+  public SearchStream<E> scorer(Scorer scorer) {
+    this.scorer = scorer;
+    return this;
+  }
+
+  @Override
+  public List<Pair<E, Double>> toListWithScores() {
+    withScores = true;
+    SearchResult searchResult = executeQuery();
+    return documentsToEntityScorePairs(searchResult.getDocuments());
   }
 
   @Override

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -903,50 +903,38 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
    * Converts a list of {@link redis.clients.jedis.search.Document} objects
    * (from SearchResult) to a list of entity instances.
    */
+  /**
+   * Converts a single {@link redis.clients.jedis.search.Document} to an entity instance,
+   * handling both JSON document and Hash structures.
+   */
+  @SuppressWarnings(
+    "unchecked"
+  )
+  private E documentToEntity(redis.clients.jedis.search.Document d) {
+    E entity;
+    if (isDocument) {
+      Object rawJson = d.get("$");
+      String json = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
+      entity = getGson().fromJson(json, entityClass);
+    } else {
+      entity = (E) ObjectUtils.documentToObject(d, entityClass, mappingConverter);
+    }
+    return ObjectUtils.populateRedisKey(entity, d.getId());
+  }
+
   @SuppressWarnings(
     "unchecked"
   )
   private List<E> documentsToEntities(List<redis.clients.jedis.search.Document> documents) {
-    if (isDocument) {
-      Gson g = getGson();
-      return documents.stream().map(d -> {
-        Object rawJson = d.get("$");
-        String json = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
-        E entity = g.fromJson(json, entityClass);
-        return ObjectUtils.populateRedisKey(entity, d.getId());
-      }).toList();
-    } else {
-      return (List<E>) documents.stream().map(d -> {
-        Object entity = ObjectUtils.documentToObject(d, entityClass, mappingConverter);
-        return ObjectUtils.populateRedisKey(entity, d.getId());
-      }).toList();
-    }
+    return documents.stream().map(this::documentToEntity).toList();
   }
 
   /**
    * Converts a list of {@link redis.clients.jedis.search.Document} objects
    * to a list of entity-score pairs.
    */
-  @SuppressWarnings(
-    "unchecked"
-  )
   private List<Pair<E, Double>> documentsToEntityScorePairs(List<redis.clients.jedis.search.Document> documents) {
-    if (isDocument) {
-      Gson g = getGson();
-      return documents.stream().map(d -> {
-        Object rawJson = d.get("$");
-        String json = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
-        E entity = g.fromJson(json, entityClass);
-        entity = ObjectUtils.populateRedisKey(entity, d.getId());
-        return Tuples.of(entity, d.getScore());
-      }).toList();
-    } else {
-      return (List<Pair<E, Double>>) documents.stream().map(d -> {
-        Object entity = ObjectUtils.documentToObject(d, entityClass, mappingConverter);
-        entity = ObjectUtils.populateRedisKey(entity, d.getId());
-        return Tuples.of((E) entity, d.getScore());
-      }).toList();
-    }
+    return documents.stream().map(d -> Tuples.of(documentToEntity(d), d.getScore())).toList();
   }
 
   /**

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -1305,9 +1305,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
   public List<Pair<E, Double>> toListWithScores() {
     if (hybridText != null) {
       throw new UnsupportedOperationException(
-          "toListWithScores() is not supported after hybridSearch(). " +
-          "Hybrid search uses FT.AGGREGATE/FT.HYBRID which are incompatible with FT.SEARCH WITHSCORES. " +
-          "Use HybridQuery score aliases for explicit score access.");
+          "toListWithScores() is not supported after hybridSearch(). " + "Hybrid search uses FT.AGGREGATE/FT.HYBRID which are incompatible with FT.SEARCH WITHSCORES. " + "Use HybridQuery score aliases for explicit score access.");
     }
     withScores = true;
     SearchResult searchResult = executeQuery();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -1303,6 +1303,12 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
   @Override
   public List<Pair<E, Double>> toListWithScores() {
+    if (hybridText != null) {
+      throw new UnsupportedOperationException(
+          "toListWithScores() is not supported after hybridSearch(). " +
+          "Hybrid search uses FT.AGGREGATE/FT.HYBRID which are incompatible with FT.SEARCH WITHSCORES. " +
+          "Use HybridQuery score aliases for explicit score access.");
+    }
     withScores = true;
     SearchResult searchResult = executeQuery();
     return documentsToEntityScorePairs(searchResult.getDocuments());

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/WrapperSearchStream.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/WrapperSearchStream.java
@@ -416,6 +416,21 @@ public class WrapperSearchStream<E> implements SearchStream<E> {
   }
 
   @Override
+  public SearchStream<E> withScores() {
+    throw new UnsupportedOperationException("withScores is not supported on a WrappedSearchStream");
+  }
+
+  @Override
+  public SearchStream<E> scorer(Scorer scorer) {
+    throw new UnsupportedOperationException("scorer is not supported on a WrappedSearchStream");
+  }
+
+  @Override
+  public List<Pair<E, Double>> toListWithScores() {
+    throw new UnsupportedOperationException("toListWithScores is not supported on a WrappedSearchStream");
+  }
+
+  @Override
   public boolean isDocument() {
     return false;
   }

--- a/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
@@ -3129,4 +3129,16 @@ class EntityStreamDocsTest extends AbstractBaseDocumentTest {
     assertThat(tfIdfResults.get(0).getSecond()).isGreaterThan(0.0);
     assertThat(bm25Results.get(0).getSecond()).isGreaterThan(0.0);
   }
+
+  @Test
+  void testToListWithScoresThrowsAfterProject() {
+    UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class, () -> {
+      entityStream.of(Company.class) //
+          .filter(Company$.NAME.containing("Red")) //
+          .project(Company$.NAME) //
+          .toListWithScores();
+    });
+    assertThat(ex.getMessage()).contains("toListWithScores()");
+    assertThat(ex.getMessage()).contains("project");
+  }
 }

--- a/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
@@ -2963,4 +2963,170 @@ class EntityStreamDocsTest extends AbstractBaseDocumentTest {
     assertThat(ex.getMessage()).contains("MetamodelField");
     assertThat(ex.getMessage()).contains("sorted(MyEntity$.FIELD, SortOrder)");
   }
+
+  // ── SCORER / WITHSCORES tests ──────────────────────────────────────────────
+
+  @Test
+  void testWithScoresReturnsScores() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .withScores() //
+        .toListWithScores();
+
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getFirst().getName()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testScorerWithEnum() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .scorer(Scorer.BM25STD) //
+        .toListWithScores();
+
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testToListWithScoresImplicitlyEnablesScores() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .toListWithScores();
+
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testWithScoresWorksWithSortAndLimit() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red") //
+            .or(Company$.NAME.containing("Micro"))) //
+        .sorted(Company$.NAME, SortOrder.ASC) //
+        .limit(2) //
+        .withScores() //
+        .toListWithScores();
+
+    assertThat(results).hasSizeLessThanOrEqualTo(2);
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testScorerTFIDF() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .scorer(Scorer.TFIDF) //
+        .toListWithScores();
+
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testScorerDISMAX() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .scorer(Scorer.DISMAX) //
+        .toListWithScores();
+
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testWithScoresDoesNotBreakRegularCollect() {
+    List<Company> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .withScores() //
+        .collect(Collectors.toList());
+
+    assertThat(results).isNotEmpty();
+    assertThat(results.get(0).getName()).contains("Red");
+  }
+
+  @Test
+  void testScorerWithRegularCollect() {
+    List<Company> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .scorer(Scorer.BM25STD) //
+        .collect(Collectors.toList());
+
+    assertThat(results).isNotEmpty();
+    assertThat(results.get(0).getName()).contains("Red");
+  }
+
+  @Test
+  void testToListWithScoresNoFilter() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .toListWithScores();
+
+    assertThat(results).hasSize(3);
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getFirst().getName()).isNotNull();
+    });
+  }
+
+  @Test
+  void testToListWithScoresWithSkip() {
+    List<Pair<Company, Double>> allResults = entityStream.of(Company.class) //
+        .sorted(Company$.NAME, SortOrder.ASC) //
+        .toListWithScores();
+
+    List<Pair<Company, Double>> skippedResults = entityStream.of(Company.class) //
+        .sorted(Company$.NAME, SortOrder.ASC) //
+        .skip(1) //
+        .toListWithScores();
+
+    assertThat(skippedResults).hasSize(allResults.size() - 1);
+    // The first result after skipping should match the second result from the full list
+    assertThat(skippedResults.get(0).getFirst().getName()) //
+        .isEqualTo(allResults.get(1).getFirst().getName());
+  }
+
+  @Test
+  void testDifferentScorersProduceDifferentScores() {
+    List<Pair<Company, Double>> tfIdfResults = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .scorer(Scorer.TFIDF) //
+        .toListWithScores();
+
+    List<Pair<Company, Double>> bm25Results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .scorer(Scorer.BM25STD) //
+        .toListWithScores();
+
+    assertThat(tfIdfResults).isNotEmpty();
+    assertThat(bm25Results).isNotEmpty();
+
+    // Both should return the same entities
+    assertThat(tfIdfResults.get(0).getFirst().getName()) //
+        .isEqualTo(bm25Results.get(0).getFirst().getName());
+
+    // Scores from different algorithms should differ (not guaranteed but highly likely)
+    // At minimum, both should be positive
+    assertThat(tfIdfResults.get(0).getSecond()).isGreaterThan(0.0);
+    assertThat(bm25Results.get(0).getSecond()).isGreaterThan(0.0);
+  }
 }

--- a/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamHashTest.java
@@ -1813,4 +1813,89 @@ class EntityStreamHashTest extends AbstractBaseEnhancedRedisTest {
     List<String> names1 = page1.stream().map(Company::getName).collect(Collectors.toList());
     assertThat(names1).containsExactly("Tesla");
   }
+
+  // ── SCORER / WITHSCORES tests (Hash path) ─────────────────────────────────
+
+  @Test
+  void testWithScoresReturnsScores() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .withScores() //
+        .toListWithScores();
+
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getFirst().getName()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testScorerWithEnum() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .scorer(Scorer.BM25STD) //
+        .toListWithScores();
+
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testToListWithScoresImplicitlyEnablesScores() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .toListWithScores();
+
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testWithScoresWorksWithSortAndLimit() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red") //
+            .or(Company$.NAME.containing("Micro"))) //
+        .sorted(Company$.NAME, SortOrder.ASC) //
+        .limit(2) //
+        .withScores() //
+        .toListWithScores();
+
+    assertThat(results).hasSizeLessThanOrEqualTo(2);
+    assertThat(results).isNotEmpty();
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getSecond()).isGreaterThan(0.0);
+    });
+  }
+
+  @Test
+  void testWithScoresDoesNotBreakRegularCollect() {
+    List<Company> results = entityStream.of(Company.class) //
+        .filter(Company$.NAME.containing("Red")) //
+        .withScores() //
+        .collect(Collectors.toList());
+
+    assertThat(results).isNotEmpty();
+    assertThat(results.get(0).getName()).contains("Red");
+  }
+
+  @Test
+  void testToListWithScoresNoFilter() {
+    List<Pair<Company, Double>> results = entityStream.of(Company.class) //
+        .toListWithScores();
+
+    assertThat(results).hasSize(3);
+    results.forEach(pair -> {
+      assertThat(pair.getFirst()).isNotNull();
+      assertThat(pair.getFirst().getName()).isNotNull();
+    });
+  }
 }

--- a/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamHybridQueryTests.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamHybridQueryTests.java
@@ -763,4 +763,22 @@ class EntityStreamHybridQueryTests extends AbstractBaseEnhancedRedisTest {
         () -> assertThat(linearResults).isNotEmpty()
     );
   }
+
+  @Test
+  void testToListWithScoresThrowsAfterHybridSearch() {
+    float[] queryVector = new float[]{0.15f, 0.85f, 0.8f, 0.25f};
+
+    assertThatThrownBy(() -> entityStream.of(HashWithTextAndVector.class)
+        .hybridSearch(
+            "machine learning",
+            HashWithTextAndVector$.DESCRIPTION,
+            queryVector,
+            HashWithTextAndVector$.EMBEDDING,
+            0.7f
+        )
+        .toListWithScores()
+    ).isInstanceOf(UnsupportedOperationException.class)
+     .hasMessageContaining("toListWithScores()")
+     .hasMessageContaining("hybridSearch");
+  }
 }


### PR DESCRIPTION
## Summary

- Add `withScores()`, `scorer(Scorer)`, and `toListWithScores()` to `SearchStream`, enabling users to control the scoring algorithm and retrieve per-document relevance scores from entity stream queries (#510)
- Introduce `Scorer` enum with all 8 Redis FT.SEARCH scoring algorithms (TFIDF, BM25STD, DISMAX, etc.)
- Document the new API in entity-streams, search, and hash-mappings docs

## Changes

### New file
- `Scorer.java` — enum with 8 Redis scorer algorithms, each mapping to the Redis protocol string

### Modified files
- `SearchStream.java` — 3 new interface methods: `withScores()`, `scorer(Scorer)`, `toListWithScores()`
- `SearchStreamImpl.java` — implementation with `documentsToEntityScorePairs()` (handles both JSON and Hash paths) and `prepareQuery()` integration
- `WrapperSearchStream.java` — stubs throwing `UnsupportedOperationException`
- `ReturnFieldsSearchStreamImpl.java` — stubs throwing `UnsupportedOperationException`

### Tests (17 integration tests)
- `EntityStreamDocsTest.java` — 11 tests covering the JSON/Document path: explicit `withScores()`, implicit via `toListWithScores()`, multiple scorer variants (BM25STD, TFIDF, DISMAX), sort+limit+skip combinations, regular `collect()` with scorer/withScores, no-filter wildcard, and cross-scorer comparison
- `EntityStreamHashTest.java` — 6 tests covering the Hash path: `withScores()`, scorer, implicit scores, sort+limit, regular collect, no-filter wildcard

### Docs
- `entity-streams.adoc` — new "Relevance Scoring" section with full scorer reference table and usage examples
- `search.adoc` — expanded "Scoring and Sorting" with score retrieval and scorer selection subsections
- `hash-mappings.adoc` — added scoring to the Entity Stream operations list

## Test plan

- [x] `./gradlew :redis-om-spring:compileJava` passes
- [x] All 17 new integration tests pass (11 document + 6 hash)
- [x] JSON document path of `documentsToEntityScorePairs()` covered
- [x] Hash path of `documentsToEntityScorePairs()` covered
- [x] Multiple scorer enum variants verified against live Redis
- [x] Scoring combined with sort, limit, skip verified
- [x] `withScores()`/`scorer()` with regular `collect()` verified (no breakage)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core query construction/execution for `FT.SEARCH`, so incorrect flag/scorer handling could change result ordering or performance, but the change is additive and covered by new integration tests.
> 
> **Overview**
> Adds relevance-scoring support to `SearchStream` by introducing `withScores()`, `scorer(Scorer)`, and `toListWithScores()` (returning `List<Pair<E, Double>>`).
> 
> `SearchStreamImpl` now wires these options into the underlying `FT.SEARCH` query (`WITHSCORES` + `SCORER`) and maps results into entity/score pairs, while explicitly rejecting unsupported combinations (after `hybridSearch()` or `project()`). Wrapper/projection stream implementations (`WrapperSearchStream`, `ReturnFieldsSearchStreamImpl`) stub the new API with `UnsupportedOperationException`.
> 
> Updates docs to describe score retrieval and scorer selection, and adds integration tests covering JSON and hash entities, pagination/sort interactions, and the unsupported cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec0ce3afc15a49a5b669acdb0e001b9a305dc506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->