### PR TITLE
fix: resolve NPE in getTTLForEntity() for entities without standard J…

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisJSONKeyValueAdapter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisJSONKeyValueAdapter.java
@@ -3,7 +3,6 @@ package com.redis.om.spring;
 import static com.redis.om.spring.util.ObjectUtils.isPrimitiveOfType;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -453,35 +452,27 @@ public class RedisJSONKeyValueAdapter extends RedisKeyValueAdapter {
 
   private Optional<Long> getTTLForEntity(Object entity) {
     Class<?> entityClass = entity.getClass();
-    Class<?> entityClassKey;
-    try {
-      entityClassKey = ClassLoader.getSystemClassLoader().loadClass(entity.getClass().getTypeName());
-    } catch (ClassNotFoundException e) {
-      entityClassKey = entity.getClass();
-    }
 
     // Use the resolver if available for cross-class-loader compatibility
     KeyspaceConfiguration.KeyspaceSettings settings = null;
     if (mappingContext instanceof com.redis.om.spring.mapping.RedisEnhancedMappingContext) {
       var resolver = ((com.redis.om.spring.mapping.RedisEnhancedMappingContext) mappingContext).getKeyspaceResolver();
-      if (resolver.hasSettingsFor(entityClassKey)) {
-        settings = resolver.getKeyspaceSettings(entityClassKey);
+      if (resolver.hasSettingsFor(entityClass)) {
+        settings = resolver.getKeyspaceSettings(entityClass);
       }
     } else {
       KeyspaceConfiguration keyspaceConfig = mappingContext.getMappingConfiguration().getKeyspaceConfiguration();
-      if (keyspaceConfig.hasSettingsFor(entityClassKey)) {
-        settings = keyspaceConfig.getKeyspaceSettings(entityClassKey);
+      if (keyspaceConfig.hasSettingsFor(entityClass)) {
+        settings = keyspaceConfig.getKeyspaceSettings(entityClass);
       }
     }
 
     if (settings != null) {
       if (StringUtils.hasText(settings.getTimeToLivePropertyName())) {
-        Method ttlGetter;
         try {
           Field fld = ReflectionUtils.findField(entityClass, settings.getTimeToLivePropertyName());
           if (fld != null) {
-            ttlGetter = ObjectUtils.getGetterForField(entityClass, fld);
-            long ttlPropertyValue = ((Number) ReflectionUtils.invokeMethod(ttlGetter, entity)).longValue();
+            long ttlPropertyValue = getTtlFieldValue(entityClass, fld, entity);
 
             TimeToLive ttl = fld.getAnnotation(TimeToLive.class);
             if (!ttl.unit().equals(TimeUnit.SECONDS)) {
@@ -500,6 +491,10 @@ public class RedisJSONKeyValueAdapter extends RedisKeyValueAdapter {
       }
     }
     return Optional.empty();
+  }
+
+  private long getTtlFieldValue(Class<?> entityClass, Field fld, Object entity) {
+    return ObjectUtils.getNumericFieldValue(entityClass, fld, entity);
   }
 
   @SuppressWarnings(

--- a/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/metamodel/MetamodelGenerator.java
@@ -1029,8 +1029,10 @@ public final class MetamodelGenerator extends AbstractProcessor {
       }
     }
 
-    // default to thrower
-    messager.printMessage(Diagnostic.Kind.ERROR, "Class " + entityName + " is not a proper JavaBean because " + field
+    // default to thrower — downgraded from ERROR to WARNING because the runtime
+    // handles getter-less fields via direct field access (e.g. for @TimeToLive fields
+    // in Groovy classes or non-standard JavaBean entities)
+    messager.printMessage(Diagnostic.Kind.WARNING, "Class " + entityName + " is not a proper JavaBean because " + field
         .getSimpleName().toString() + " has no standard getter.");
     return lambdaName + " -> {throw new " + IllegalJavaBeanException.class
         .getSimpleName() + "(" + entityName + ".class, \"" + fieldName + "\");}";

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -6,7 +6,6 @@ import static redis.clients.jedis.json.JsonProtocol.JsonCommand;
 import java.io.IOException;
 import java.io.Reader;
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
@@ -522,37 +521,37 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
    * @return an {@link Optional} containing the TTL in seconds, or empty if no TTL is configured
    */
   private Optional<Long> getTTLForEntity(Object entity) {
+    Class<?> entityClass = entity.getClass();
+
     // Use the resolver if available for cross-class-loader compatibility
     KeyspaceConfiguration.KeyspaceSettings settings = null;
     if (mappingContext instanceof com.redis.om.spring.mapping.RedisEnhancedMappingContext) {
       var resolver = ((com.redis.om.spring.mapping.RedisEnhancedMappingContext) mappingContext).getKeyspaceResolver();
-      if (resolver.hasSettingsFor(entity.getClass())) {
-        settings = resolver.getKeyspaceSettings(entity.getClass());
+      if (resolver.hasSettingsFor(entityClass)) {
+        settings = resolver.getKeyspaceSettings(entityClass);
       }
     } else {
       KeyspaceConfiguration keyspaceConfig = mappingContext.getMappingConfiguration().getKeyspaceConfiguration();
-      if (keyspaceConfig.hasSettingsFor(entity.getClass())) {
-        settings = keyspaceConfig.getKeyspaceSettings(entity.getClass());
+      if (keyspaceConfig.hasSettingsFor(entityClass)) {
+        settings = keyspaceConfig.getKeyspaceSettings(entityClass);
       }
     }
 
     if (settings != null) {
-
       if (org.springframework.util.StringUtils.hasText(settings.getTimeToLivePropertyName())) {
-        Method ttlGetter;
         try {
-          Field fld = ReflectionUtils.findField(entity.getClass(), settings.getTimeToLivePropertyName());
-          ttlGetter = ObjectUtils.getGetterForField(entity.getClass(), Objects.requireNonNull(fld));
-          long ttlPropertyValue = ((Number) Objects.requireNonNull(ReflectionUtils.invokeMethod(ttlGetter, entity)))
-              .longValue();
+          Field fld = ReflectionUtils.findField(entityClass, settings.getTimeToLivePropertyName());
+          if (fld != null) {
+            long ttlPropertyValue = getTtlFieldValue(entityClass, fld, entity);
 
-          ReflectionUtils.invokeMethod(ttlGetter, entity);
-
-          TimeToLive ttl = fld.getAnnotation(TimeToLive.class);
-          if (!ttl.unit().equals(TimeUnit.SECONDS)) {
-            return Optional.of(TimeUnit.SECONDS.convert(ttlPropertyValue, ttl.unit()));
+            TimeToLive ttl = fld.getAnnotation(TimeToLive.class);
+            if (!ttl.unit().equals(TimeUnit.SECONDS)) {
+              return Optional.of(TimeUnit.SECONDS.convert(ttlPropertyValue, ttl.unit()));
+            } else {
+              return Optional.of(ttlPropertyValue);
+            }
           } else {
-            return Optional.of(ttlPropertyValue);
+            return Optional.empty();
           }
         } catch (SecurityException | IllegalArgumentException e) {
           return Optional.empty();
@@ -562,6 +561,10 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
       }
     }
     return Optional.empty();
+  }
+
+  private long getTtlFieldValue(Class<?> entityClass, Field fld, Object entity) {
+    return ObjectUtils.getNumericFieldValue(entityClass, fld, entity);
   }
 
   /**

--- a/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
@@ -325,6 +325,33 @@ public class ObjectUtils {
   }
 
   /**
+   * Retrieves a numeric field value via getter if available, falling back to direct field access.
+   * <p>
+   * This handles entities without standard JavaBean getters (e.g. Groovy classes, Kotlin data
+   * classes, records, or non-standard property naming) as well as the case where the system
+   * classloader cannot find Spring-managed classes (e.g. JDK 25+).
+   *
+   * @param entityClass the class of the entity
+   * @param fld         the field to read
+   * @param entity      the entity instance
+   * @return the field value as a {@code long}, or {@code 0L} if the value is null or non-numeric
+   */
+  public static long getNumericFieldValue(Class<?> entityClass, Field fld, Object entity) {
+    Method ttlGetter = getGetterForField(entityClass, fld);
+    if (ttlGetter != null) {
+      return ((Number) ReflectionUtils.invokeMethod(ttlGetter, entity)).longValue();
+    }
+    // Fall back to direct field access when no getter exists (e.g. Groovy classes,
+    // records, or non-standard property naming)
+    ReflectionUtils.makeAccessible(fld);
+    Object value = ReflectionUtils.getField(fld, entity);
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    return 0L;
+  }
+
+  /**
    * Finds the setter method for a specific field in a class.
    * Constructs the setter name using JavaBeans naming conventions.
    *

--- a/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
@@ -337,14 +337,16 @@ public class ObjectUtils {
    * @return the field value as a {@code long}, or {@code 0L} if the value is null or non-numeric
    */
   public static long getNumericFieldValue(Class<?> entityClass, Field fld, Object entity) {
-    Method ttlGetter = getGetterForField(entityClass, fld);
-    if (ttlGetter != null) {
-      return ((Number) ReflectionUtils.invokeMethod(ttlGetter, entity)).longValue();
+    Object value;
+    Method getter = getGetterForField(entityClass, fld);
+    if (getter != null) {
+      value = ReflectionUtils.invokeMethod(getter, entity);
+    } else {
+      // Fall back to direct field access when no getter exists (e.g. Groovy classes,
+      // records, or non-standard property naming)
+      ReflectionUtils.makeAccessible(fld);
+      value = ReflectionUtils.getField(fld, entity);
     }
-    // Fall back to direct field access when no getter exists (e.g. Groovy classes,
-    // records, or non-standard property naming)
-    ReflectionUtils.makeAccessible(fld);
-    Object value = ReflectionUtils.getField(fld, entity);
     if (value instanceof Number number) {
       return number.longValue();
     }

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/DocumentTTLClassLoaderTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/DocumentTTLClassLoaderTest.java
@@ -99,6 +99,18 @@ class DocumentTTLClassLoaderTest extends AbstractBaseDocumentTest {
   }
 
   @Test
+  void testSaveEntityWithNullTtlDirectFieldAccessDoesNotThrowNPE() {
+    // A null TTL field value must not cause NPE in either getter or
+    // direct field access paths
+    ExpiringPersonDirectFieldAccess entity = ExpiringPersonDirectFieldAccess.of("Null TTL Direct", null);
+    directFieldAccessRepository.save(entity);
+
+    assertThat(entity.getId()).isNotNull();
+    Long expire = directFieldAccessRepository.getExpiration(entity.getId());
+    assertThat(expire).isEqualTo(-1L);
+  }
+
+  @Test
   void testStandardEntityTTLStillWorks() {
     // Sanity: existing entities with getters still work after the fix
     ExpiringPerson person = ExpiringPerson.of("Mike Woodger", 15L);

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/DocumentTTLClassLoaderTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/DocumentTTLClassLoaderTest.java
@@ -1,0 +1,110 @@
+package com.redis.om.spring.annotations.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.ReflectionUtils;
+
+import com.redis.om.spring.AbstractBaseDocumentTest;
+import com.redis.om.spring.fixtures.document.model.ExpiringPerson;
+import com.redis.om.spring.fixtures.document.model.ExpiringPersonDirectFieldAccess;
+import com.redis.om.spring.fixtures.document.repository.ExpiringPersonDirectFieldAccessRepository;
+import com.redis.om.spring.fixtures.document.repository.ExpiringPersonRepository;
+import com.redis.om.spring.util.ObjectUtils;
+
+/**
+ * Tests for the JDK 25 classloader / null-getter TTL bug.
+ * <p>
+ * When an entity has a {@code @TimeToLive} field without a standard JavaBean getter,
+ * {@code ObjectUtils.getGetterForField()} returns {@code null}. Prior to the fix,
+ * this caused an NPE in {@code getTTLForEntity()} when passed to
+ * {@code ReflectionUtils.invokeMethod()}.
+ *
+ * Reported via customer email.
+ */
+class DocumentTTLClassLoaderTest extends AbstractBaseDocumentTest {
+
+  @Autowired
+  ExpiringPersonDirectFieldAccessRepository directFieldAccessRepository;
+
+  @Autowired
+  ExpiringPersonRepository standardGetterRepository;
+
+  @BeforeEach
+  void cleanUp() {
+    directFieldAccessRepository.deleteAll();
+    standardGetterRepository.deleteAll();
+  }
+
+  @Test
+  void testGetterForFieldReturnsNullWhenNoGetter() {
+    // Verify the test entity actually has no getter for the ttl field —
+    // this is the precondition for the bug to manifest
+    Field ttlField = ReflectionUtils.findField(ExpiringPersonDirectFieldAccess.class, "ttl");
+    assertThat(ttlField).isNotNull();
+
+    Method getter = ObjectUtils.getGetterForField(ExpiringPersonDirectFieldAccess.class, ttlField);
+    assertThat(getter).isNull();
+  }
+
+  @Test
+  void testGetterForFieldWorksWithStandardGetter() {
+    // Sanity check: standard Lombok-generated getter IS found
+    Field ttlField = ReflectionUtils.findField(ExpiringPerson.class, "ttl");
+    assertThat(ttlField).isNotNull();
+
+    Method getter = ObjectUtils.getGetterForField(ExpiringPerson.class, ttlField);
+    assertThat(getter).isNotNull();
+  }
+
+  @Test
+  void testSaveEntityWithoutTtlGetterDoesNotThrowNPE() {
+    // This is the core regression test: save() must not throw NPE
+    // when the @TimeToLive field has no JavaBean getter
+    ExpiringPersonDirectFieldAccess entity = ExpiringPersonDirectFieldAccess.of("Alan Turing", 10L);
+    directFieldAccessRepository.save(entity);
+
+    assertThat(entity.getId()).isNotNull();
+    assertThat(directFieldAccessRepository.existsById(entity.getId())).isTrue();
+  }
+
+  @Test
+  void testSaveEntityWithoutTtlGetterAppliesTTL() {
+    // After the fix, TTL should still be applied via direct field access
+    ExpiringPersonDirectFieldAccess entity = ExpiringPersonDirectFieldAccess.of("Grace Hopper", 15L);
+    directFieldAccessRepository.save(entity);
+
+    Long expire = directFieldAccessRepository.getExpiration(entity.getId());
+    assertThat(expire).isEqualTo(15L);
+  }
+
+  @Test
+  void testSaveAllEntitiesWithoutTtlGetterDoesNotThrowNPE() {
+    // Verify saveAll also works (uses SimpleRedisDocumentRepository.getTTLForEntity)
+    var e1 = ExpiringPersonDirectFieldAccess.of("Ada Lovelace", 20L);
+    var e2 = ExpiringPersonDirectFieldAccess.of("Charles Babbage", 20L);
+
+    directFieldAccessRepository.saveAll(java.util.List.of(e1, e2));
+
+    Long expire1 = directFieldAccessRepository.getExpiration(e1.getId());
+    Long expire2 = directFieldAccessRepository.getExpiration(e2.getId());
+
+    assertThat(expire1).isEqualTo(20L);
+    assertThat(expire2).isEqualTo(20L);
+  }
+
+  @Test
+  void testStandardEntityTTLStillWorks() {
+    // Sanity: existing entities with getters still work after the fix
+    ExpiringPerson person = ExpiringPerson.of("Mike Woodger", 15L);
+    standardGetterRepository.save(person);
+
+    Long expire = standardGetterRepository.getExpiration(person.getId());
+    assertThat(expire).isEqualTo(15L);
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/ReferenceTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/ReferenceTest.java
@@ -80,11 +80,14 @@ class ReferenceTest extends AbstractBaseDocumentTest {
       }
       refRepository.saveAll(refs);
 
-      Set<TooManyReferences> tmrs = new HashSet<>();
       List<Ref> refList = new ArrayList<>(refs);
       Random random = new Random();
 
-      for (int i = 0; i < 10000; i++) {
+      // Save in batches to avoid pipeline socket timeouts on CI
+      int batchSize = 1000;
+      int total = 10000;
+      List<TooManyReferences> batch = new ArrayList<>(batchSize);
+      for (int i = 0; i < total; i++) {
         TooManyReferences tmr = TooManyReferences.of("ref" + i);
 
         tmr.setRef1(refList.get(random.nextInt(refList.size())));
@@ -98,10 +101,15 @@ class ReferenceTest extends AbstractBaseDocumentTest {
         tmr.setRef9(refList.get(random.nextInt(refList.size())));
         tmr.setRef10(refList.get(random.nextInt(refList.size())));
 
-        tmrs.add(tmr);
+        batch.add(tmr);
+        if (batch.size() == batchSize) {
+          tooManyReferencesRepository.saveAll(batch);
+          batch.clear();
+        }
       }
-
-      tooManyReferencesRepository.saveAll(tmrs);
+      if (!batch.isEmpty()) {
+        tooManyReferencesRepository.saveAll(batch);
+      }
     }
   }
 

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/ExpiringPersonDirectFieldAccess.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/ExpiringPersonDirectFieldAccess.java
@@ -1,0 +1,60 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.TimeToLive;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+
+/**
+ * Test entity that has a {@link TimeToLive} field but deliberately omits a
+ * JavaBean getter for it. This reproduces the JDK 25 classloader bug where
+ * {@code ObjectUtils.getGetterForField()} returns {@code null} and
+ * {@code ReflectionUtils.invokeMethod(null, entity)} throws NPE.
+ * <p>
+ * This also simulates Groovy/Kotlin entities where property access patterns
+ * may differ from standard JavaBean conventions.
+ */
+@Document
+public class ExpiringPersonDirectFieldAccess {
+  @Id
+  private String id;
+
+  @Indexed
+  private String name;
+
+  @TimeToLive
+  private Long ttl;
+
+  public ExpiringPersonDirectFieldAccess() {
+  }
+
+  public ExpiringPersonDirectFieldAccess(String name, Long ttl) {
+    this.name = name;
+    this.ttl = ttl;
+  }
+
+  public static ExpiringPersonDirectFieldAccess of(String name, Long ttl) {
+    return new ExpiringPersonDirectFieldAccess(name, ttl);
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  // Deliberately NO getter/setter for ttl field.
+  // This reproduces the scenario where ObjectUtils.getGetterForField()
+  // returns null, causing NPE in getTTLForEntity().
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/ExpiringPersonDirectFieldAccessRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/ExpiringPersonDirectFieldAccessRepository.java
@@ -1,0 +1,11 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import com.redis.om.spring.fixtures.document.model.ExpiringPersonDirectFieldAccess;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+@SuppressWarnings(
+  "unused"
+)
+public interface ExpiringPersonDirectFieldAccessRepository
+    extends RedisDocumentRepository<ExpiringPersonDirectFieldAccess, String> {
+}

--- a/tests/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
+++ b/tests/src/test/java/com/redis/om/spring/metamodel/MetamodelGeneratorTest.java
@@ -406,14 +406,16 @@ class MetamodelGeneratorTest {
   void testValidDocumentInBadJavaBean(Results results) {
     assertThat(results.generated).hasSize(1);
 
-    List<String> errors = getErrorStrings(results);
+    // Missing getters produce warnings (not errors) since the runtime handles
+    // getter-less fields via direct field access
+    List<String> warnings = getWarningStrings(results);
     assertAll( //
-        () -> assertThat(errors).hasSize(3), //
-        () -> assertThat(errors).contains(
+        () -> assertThat(warnings).hasSize(3), //
+        () -> assertThat(warnings).contains(
             "Class valid.BadBean is not a proper JavaBean because id has no standard getter."), //
-        () -> assertThat(errors).contains(
+        () -> assertThat(warnings).contains(
             "Class valid.BadBean is not a proper JavaBean because name has no standard getter."), //
-        () -> assertThat(errors).contains(
+        () -> assertThat(warnings).contains(
             "Class valid.BadBean is not a proper JavaBean because age has no standard getter.") //
     );
   }


### PR DESCRIPTION
…avaBean getters

Remove ClassLoader.getSystemClassLoader() from RedisJSONKeyValueAdapter.getTTLForEntity() which fails on JDK 25 for Spring-managed classes. Use entity.getClass() directly instead, consistent with SimpleRedisDocumentRepository.

Add null-safety for ObjectUtils.getGetterForField() which returns null for entities without standard getters (Groovy classes, records, non-standard naming). When no getter is found, fall back to direct field access via ReflectionUtils.makeAccessible(). Extract shared helper ObjectUtils.getNumericFieldValue() used by both adapters.

Downgrade MetamodelGenerator diagnostic from ERROR to WARNING for missing getters since the runtime now handles getter-less fields gracefully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TTL resolution in both JSON adapter and document repository to fall back to direct field access when getters are missing, which can affect expiration behavior for existing entities. Also relaxes metamodel generation from compile-time errors to warnings, potentially changing build outcomes for projects relying on strict JavaBean enforcement.
> 
> **Overview**
> Fixes `getTTLForEntity()` to be classloader-safe and null-safe by using `entity.getClass()` and reading `@TimeToLive` values via new `ObjectUtils.getNumericFieldValue()` (getter if present, otherwise direct field access), preventing NPEs and allowing TTL to be applied for getter-less entities.
> 
> Downgrades metamodel generator “missing getter” diagnostics from **ERROR** to **WARNING**, updates metamodel tests to expect warnings, and adds regression coverage (new direct-field TTL fixture + `DocumentTTLClassLoaderTest`). Separately, `ReferenceTest` now saves large datasets in batches to avoid CI pipeline timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c1809ab643abf4d9bee9835b5fab6cbb7da374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->