### PR TITLE
feat: separate index definitions via repository-level @IndexingOptions (#638)

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -2,11 +2,11 @@ package com.redis.om.spring;
 
 import static com.redis.om.spring.util.ObjectUtils.getBeanDefinitionsFor;
 import static com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively;
+import static com.redis.om.spring.util.ObjectUtils.getRepositoryInterfacesWithIndexingOptions;
+import static com.redis.om.spring.util.ObjectUtils.resolveEntityTypeFromRepository;
 
 import java.time.*;
-import java.util.Date;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.logging.Log;
@@ -41,6 +41,7 @@ import com.google.gson.GsonBuilder;
 import com.redis.om.spring.annotations.Bloom;
 import com.redis.om.spring.annotations.Cuckoo;
 import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.IndexingOptions;
 import com.redis.om.spring.client.RedisModulesClient;
 import com.redis.om.spring.indexing.RediSearchIndexer;
 import com.redis.om.spring.mapping.RedisEnhancedMappingContext;
@@ -51,6 +52,8 @@ import com.redis.om.spring.ops.json.JSONOperations;
 import com.redis.om.spring.ops.pds.BloomOperations;
 import com.redis.om.spring.ops.pds.CountMinSketchOperations;
 import com.redis.om.spring.ops.pds.CuckooFilterOperations;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
 import com.redis.om.spring.search.stream.EntityStream;
 import com.redis.om.spring.search.stream.EntityStreamImpl;
 import com.redis.om.spring.serialization.gson.*;
@@ -614,6 +617,62 @@ public class RedisModulesConfiguration {
     RediSearchIndexer indexer = (RediSearchIndexer) ac.getBean("rediSearchIndexer");
     indexer.createIndicesFor(Document.class);
     indexer.createIndicesFor(RedisHash.class);
+
+    // Create indexes from repository-level @IndexingOptions annotations
+    createRepoLevelIndexes(ac, indexer);
+  }
+
+  @SuppressWarnings(
+    "rawtypes"
+  )
+  private void createRepoLevelIndexes(ApplicationContext ac, RediSearchIndexer indexer) {
+    Set<Class<?>> repoInterfaces = new HashSet<>();
+
+    // Scan repository beans for @IndexingOptions on their interfaces
+    try {
+      Map<String, RedisDocumentRepository> docRepos = ac.getBeansOfType(RedisDocumentRepository.class);
+      for (RedisDocumentRepository repo : docRepos.values()) {
+        collectIndexingOptionsInterfaces(repo, repoInterfaces);
+      }
+    } catch (Exception e) {
+      logger.debug("Could not scan document repository beans: " + e.getMessage());
+    }
+
+    try {
+      Map<String, RedisEnhancedRepository> enhancedRepos = ac.getBeansOfType(RedisEnhancedRepository.class);
+      for (RedisEnhancedRepository repo : enhancedRepos.values()) {
+        collectIndexingOptionsInterfaces(repo, repoInterfaces);
+      }
+    } catch (Exception e) {
+      logger.debug("Could not scan enhanced repository beans: " + e.getMessage());
+    }
+
+    // Also try classpath scanning as a fallback
+    repoInterfaces.addAll(getRepositoryInterfacesWithIndexingOptions(ac));
+
+    for (Class<?> repoInterface : repoInterfaces) {
+      IndexingOptions options = repoInterface.getAnnotation(IndexingOptions.class);
+      if (options != null && !options.indexName().isBlank()) {
+        Class<?> entityClass = resolveEntityTypeFromRepository(repoInterface, RedisDocumentRepository.class);
+        if (entityClass == null) {
+          entityClass = resolveEntityTypeFromRepository(repoInterface, RedisEnhancedRepository.class);
+        }
+        if (entityClass != null) {
+          logger.info(String.format("Creating repo-level index for %s from repository %s", entityClass.getSimpleName(),
+              repoInterface.getSimpleName()));
+          indexer.createIndexFor(entityClass, options);
+        }
+      }
+    }
+  }
+
+  private void collectIndexingOptionsInterfaces(Object bean, Set<Class<?>> result) {
+    for (Class<?> iface : bean.getClass().getInterfaces()) {
+      IndexingOptions options = iface.getAnnotation(IndexingOptions.class);
+      if (options != null) {
+        result.add(iface);
+      }
+    }
   }
 
   /**

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/IndexingOptions.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/IndexingOptions.java
@@ -3,9 +3,13 @@ package com.redis.om.spring.annotations;
 import java.lang.annotation.*;
 
 /**
- * Annotation to configure indexing options for Redis OM entities.
+ * Annotation to configure indexing options for Redis OM entities or repositories.
  * This annotation allows customization of search index creation behavior,
- * including the index name, key prefix, and creation mode.
+ * including the index name, key prefix, filter expression, and creation mode.
+ *
+ * <p>When placed on a repository interface, it enables multiple indexes over the same
+ * entity type with different filters, prefixes, or index names. This supports use cases
+ * such as per-team filtered indexes, blue/green index aliasing, and CQRS patterns.
  *
  * <p>Supports Spring Expression Language (SpEL) for dynamic configuration:
  * <ul>
@@ -51,6 +55,40 @@ public @interface IndexingOptions {
    * @return the custom key prefix, or empty string to use default
    */
   String keyPrefix() default "";
+
+  /**
+   * Specifies multiple key prefixes that this index should cover.
+   * When set, the index will be created over all specified prefixes.
+   * This is useful for creating indexes that span multiple key namespaces.
+   *
+   * <p>If both {@link #keyPrefix()} and {@code prefixes()} are specified,
+   * {@code prefixes()} takes precedence.
+   *
+   * @return array of key prefixes for the index, or empty array to use default
+   */
+  String[] prefixes() default {};
+
+  /**
+   * Specifies a RediSearch filter expression for the index.
+   * When set, only documents matching this filter will be included in the index.
+   * This enables creating filtered/subset indexes over the same entity type.
+   *
+   * <p><b>Important:</b> This filter uses the RediSearch <i>aggregation expression
+   * language</i> (as accepted by the {@code FT.CREATE ... FILTER} command), not the
+   * {@code FT.SEARCH} query syntax. For example, to match a tag field, use
+   * {@code @team=="TeamA"}, not the query form {@code @team:&#123;TeamA&#125;}.
+   *
+   * <p>Example usage for per-team indexes:
+   * <pre>
+   * &#64;IndexingOptions(indexName = "ticket_team_a_idx", filter = "&#64;team==\"TeamA\"")
+   * public interface TeamATicketRepository extends RedisDocumentRepository&lt;Ticket, String&gt; {}
+   * </pre>
+   *
+   * <p>Supports SpEL expressions for dynamic filters.
+   *
+   * @return the RediSearch filter expression, or empty string for no filter
+   */
+  String filter() default "";
 
   /**
    * Specifies the index creation mode that determines how the search index

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/RediSearchIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/RediSearchIndexer.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BooleanSupplier;
 
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.logging.Log;
@@ -136,13 +137,17 @@ public class RediSearchIndexer {
   }
 
   /**
-   * Evaluates a SpEL expression if it's detected, otherwise returns the original value.
+   * Evaluates a string that may contain Spring Expression Language (SpEL) template
+   * expressions of the form {@code #{...}}. If the expression is {@code null}, does
+   * not contain a SpEL marker, or successfully evaluates, the resulting string is
+   * returned. If any SpEL part fails to evaluate or the expression is malformed,
+   * {@code defaultValue} is returned instead.
    *
-   * @param expression   the expression to evaluate (may contain SpEL syntax)
-   * @param defaultValue the default value to use if evaluation fails or expression is empty
-   * @return the evaluated expression result or the original value
+   * @param expression   the raw string, possibly containing SpEL templates
+   * @param defaultValue the value to return if evaluation fails or yields null parts
+   * @return the evaluated string, or {@code defaultValue} on failure
    */
-  private String evaluateExpression(String expression, String defaultValue) {
+  public String evaluateExpression(String expression, String defaultValue) {
     if (expression == null) {
       return defaultValue;
     }
@@ -213,6 +218,108 @@ public class RediSearchIndexer {
   }
 
   /**
+   * Reads a repository interface's {@link IndexingOptions} annotation and resolves the
+   * declared {@code indexName}, evaluating any SpEL template expressions. Returns
+   * {@code null} when the interface is {@code null}, has no annotation, or declares a
+   * blank index name.
+   *
+   * @param repositoryInterface the repository interface class to inspect, may be {@code null}
+   * @return the resolved index name, or {@code null} if none is configured
+   */
+  public String resolveRepositoryIndexName(Class<?> repositoryInterface) {
+    if (repositoryInterface == null) {
+      return null;
+    }
+    IndexingOptions repoOptions = repositoryInterface.getAnnotation(IndexingOptions.class);
+    if (repoOptions == null || repoOptions.indexName().isBlank()) {
+      return null;
+    }
+    String rawIndexName = repoOptions.indexName();
+    String resolved = evaluateExpression(rawIndexName, rawIndexName);
+    return (resolved == null || resolved.isBlank()) ? null : resolved;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Shared helpers for the createIndexFor(...) family of methods.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Runs the common field processing pipeline for an entity class: executes
+   * {@link #processIndexedFields}, registers per-field aliases via {@link #registerAlias}
+   * and appends ID-field indexed fields via {@link #createIndexedFieldsForIdFields}. The
+   * returned list contains every {@link SearchField} the caller needs to turn into
+   * {@link SchemaField}s.
+   *
+   * @param entityClass    the entity class being indexed
+   * @param isDocument     whether the entity targets a JSON document index
+   * @param allClassFields transitively resolved declared fields for the entity class
+   * @return the full list of search fields, already enriched with ID-field entries
+   */
+  private List<SearchField> prepareSearchFields(Class<?> entityClass, boolean isDocument,
+      List<java.lang.reflect.Field> allClassFields) {
+    List<SearchField> searchFields = processIndexedFields(allClassFields, isDocument);
+    for (SearchField field : searchFields) {
+      registerAlias(entityClass, field.getField().getName(), field.getSchemaField().getFieldName().getAttribute());
+    }
+    createIndexedFieldsForIdFields(entityClass, searchFields.stream().map(SearchField::getSchemaField).toList(),
+        isDocument).forEach(searchFields::add);
+    return searchFields;
+  }
+
+  /**
+   * Evaluates any SpEL templates in each raw prefix and normalizes the result with a
+   * trailing colon via {@link #getKeyspace(String)}. Used when an
+   * {@link IndexingOptions#prefixes()} array is present.
+   */
+  private String[] resolveAndNormalizePrefixArray(String[] rawPrefixes) {
+    String[] resolved = new String[rawPrefixes.length];
+    for (int i = 0; i < rawPrefixes.length; i++) {
+      resolved[i] = getKeyspace(evaluateExpression(rawPrefixes[i], rawPrefixes[i]));
+    }
+    return resolved;
+  }
+
+  /**
+   * Executes the {@link IndexCreationMode} switch shared by every {@code createIndexFor}
+   * variant that honors {@link IndexingOptions#creationMode()}. The variance between
+   * callers — whether to check a specific index name for existence, and what side-effects
+   * to run after a successful create — is supplied via {@code indexExists} and
+   * {@code postCreateHook} respectively.
+   *
+   * @param opsForSearch   the search operations bound to {@code indexName}
+   * @param params         the fully-configured {@link FTCreateParams}
+   * @param fields         the schema fields to declare on the index
+   * @param creationMode   the mode declared by the owning {@link IndexingOptions}
+   * @param indexName      the resolved index name (for logging)
+   * @param entityClass    the entity class (for logging)
+   * @param indexExists    supplier that returns {@code true} iff the index already exists
+   * @param postCreateHook side-effect to run after a successful create (e.g. lex sorted sets)
+   */
+  private void applyCreationMode(SearchOperations<String> opsForSearch, FTCreateParams params, List<SchemaField> fields,
+      IndexCreationMode creationMode, String indexName, Class<?> entityClass, BooleanSupplier indexExists,
+      Runnable postCreateHook) {
+    switch (creationMode) {
+      case SKIP_IF_EXIST:
+        opsForSearch.createIndex(params, fields);
+        logger.info(String.format("Created index %s", indexName));
+        postCreateHook.run();
+        break;
+      case DROP_AND_RECREATE:
+        if (indexExists.getAsBoolean()) {
+          opsForSearch.dropIndex();
+          logger.info(String.format("Dropped index %s", indexName));
+        }
+        opsForSearch.createIndex(params, fields);
+        logger.info(String.format("Created index %s", indexName));
+        postCreateHook.run();
+        break;
+      case SKIP_ALWAYS:
+        logger.info(String.format("Skipped index creation for %s", entityClass.getSimpleName()));
+        break;
+    }
+  }
+
+  /**
    * Creates search indices for all entities annotated with the specified annotation class.
    * Scans for bean definitions and creates indices for each discovered entity class.
    *
@@ -243,12 +350,10 @@ public class RediSearchIndexer {
    */
   public void createIndexFor(Class<?> cl) {
     Optional<IndexDataType> maybeType = determineIndexTarget(cl);
-    IndexDataType idxType;
-    if (maybeType.isPresent()) {
-      idxType = maybeType.get();
-    } else {
+    if (maybeType.isEmpty()) {
       return;
     }
+    IndexDataType idxType = maybeType.get();
     boolean isDocument = idxType == IndexDataType.JSON;
     Optional<Document> document = isDocument ? Optional.of(cl.getAnnotation(Document.class)) : Optional.empty();
     Optional<RedisHash> hash = !isDocument ? Optional.of(cl.getAnnotation(RedisHash.class)) : Optional.empty();
@@ -256,21 +361,18 @@ public class RediSearchIndexer {
 
     String indexName = "";
     String defaultIndexName = cl.getName() + "Idx";
-    Optional<String> maybeScoreField;
     try {
       if (isDocument) {
         // IndexingOptions overrides Document#
         if (maybeIndexingOptions.isPresent()) {
-          String rawIndexName = maybeIndexingOptions.get().indexName();
-          indexName = evaluateExpression(rawIndexName, defaultIndexName);
+          indexName = evaluateExpression(maybeIndexingOptions.get().indexName(), defaultIndexName);
         } else {
           indexName = document.get().indexName();
         }
         indexName = indexName.isBlank() ? defaultIndexName : indexName;
       } else {
         if (maybeIndexingOptions.isPresent()) {
-          String rawIndexName = maybeIndexingOptions.get().indexName();
-          indexName = evaluateExpression(rawIndexName, defaultIndexName);
+          indexName = evaluateExpression(maybeIndexingOptions.get().indexName(), defaultIndexName);
         } else {
           indexName = defaultIndexName;
         }
@@ -279,19 +381,10 @@ public class RediSearchIndexer {
       logger.info(String.format("Found @%s annotated class: %s", idxType, cl.getName()));
 
       final List<java.lang.reflect.Field> allClassFields = getDeclaredFieldsTransitively(cl);
-
-      List<SearchField> searchFields = processIndexedFields(allClassFields, isDocument);
-
-      for (SearchField field : searchFields) {
-        registerAlias(cl, field.getField().getName(), field.getSchemaField().getFieldName().getAttribute());
-      }
-
-      maybeScoreField = getDocumentScoreField(allClassFields, isDocument);
-      createIndexedFieldsForIdFields(cl, searchFields.stream().map(SearchField::getSchemaField).toList(), isDocument)
-          .forEach(searchFields::add);
+      List<SearchField> searchFields = prepareSearchFields(cl, isDocument, allClassFields);
+      Optional<String> maybeScoreField = getDocumentScoreField(allClassFields, isDocument);
 
       SearchOperations<String> opsForSearch = rmo.opsForSearch(indexName);
-
       FTCreateParams params = createIndexDefinition(cl, idxType);
 
       Optional<String> maybeEntityPrefix;
@@ -302,52 +395,46 @@ public class RediSearchIndexer {
         maybeEntityPrefix = hash.map(RedisHash::value).filter(ObjectUtils::isNotEmpty);
       }
 
-      // Check for dynamic key prefix in IndexingOptions
+      // Resolve prefixes (entity-level @IndexingOptions may override the @Document/@RedisHash default)
       String entityPrefix;
-      if (maybeIndexingOptions.isPresent() && !maybeIndexingOptions.get().keyPrefix().isBlank()) {
-        String rawKeyPrefix = maybeIndexingOptions.get().keyPrefix();
+      if (maybeIndexingOptions.isPresent() && maybeIndexingOptions.get().prefixes().length > 0) {
+        String[] resolvedPrefixes = resolveAndNormalizePrefixArray(maybeIndexingOptions.get().prefixes());
+        params.prefix(resolvedPrefixes);
+        // The first prefix is canonical: it populates both the forward and reverse
+        // mappings (so updateTTLSettings / getKeyspaceForEntityClass stay consistent).
+        // Any additional prefixes only populate the forward map, never overwriting the
+        // canonical reverse entry for this entity class.
+        entityPrefix = resolvedPrefixes[0];
+        addKeySpaceMapping(resolvedPrefixes[0], cl);
+        for (int i = 1; i < resolvedPrefixes.length; i++) {
+          registerSecondaryKeyspace(resolvedPrefixes[i], cl);
+        }
+      } else if (maybeIndexingOptions.isPresent() && !maybeIndexingOptions.get().keyPrefix().isBlank()) {
         String defaultPrefix = maybeEntityPrefix.orElse(getEntityPrefix(cl));
-        entityPrefix = evaluateExpression(rawKeyPrefix, defaultPrefix);
+        entityPrefix = getKeyspace(evaluateExpression(maybeIndexingOptions.get().keyPrefix(), defaultPrefix));
+        params.prefix(entityPrefix);
+        addKeySpaceMapping(entityPrefix, cl);
       } else {
-        entityPrefix = maybeEntityPrefix.orElse(getEntityPrefix(cl));
+        entityPrefix = getKeyspace(maybeEntityPrefix.orElse(getEntityPrefix(cl)));
+        params.prefix(entityPrefix);
+        addKeySpaceMapping(entityPrefix, cl);
       }
-      entityPrefix = entityPrefix.endsWith(":") ? entityPrefix : entityPrefix + ":";
-      params.prefix(entityPrefix);
-      addKeySpaceMapping(entityPrefix, cl);
+
       updateTTLSettings(cl, entityPrefix, isDocument, document, allClassFields);
       List<SchemaField> fields = searchFields.stream().map(SearchField::getSchemaField).toList();
       entityClassToSchema.put(cl, searchFields);
       entityClassToIndexName.put(cl, indexName);
+
+      final String capturedPrefix = entityPrefix;
       if (maybeIndexingOptions.isPresent()) {
-        IndexingOptions options = maybeIndexingOptions.get();
-        switch (options.creationMode()) {
-          case SKIP_IF_EXIST:
-            opsForSearch.createIndex(params, fields);
-            logger.info(String.format("Created index %s...", indexName));
-            // Create sorted sets for lexicographic fields
-            createSortedSetsForLexicographicFields(cl, entityPrefix);
-            break;
-          case DROP_AND_RECREATE:
-            if (indexExistsFor(cl)) {
-              opsForSearch.dropIndex();
-              logger.info(String.format("Dropped index %s", indexName));
-            }
-            opsForSearch.createIndex(params, fields);
-            logger.info(String.format("Created index %s", indexName));
-            // Create sorted sets for lexicographic fields
-            createSortedSetsForLexicographicFields(cl, entityPrefix);
-            break;
-          case SKIP_ALWAYS:
-            // do nothing and like it!
-            logger.info(String.format("Skipped index creation for %s", cl.getSimpleName()));
-            break;
-        }
+        applyCreationMode(opsForSearch, params, fields, maybeIndexingOptions.get().creationMode(), indexName, cl,
+            () -> indexExistsFor(cl), () -> createSortedSetsForLexicographicFields(cl, capturedPrefix));
       } else {
         opsForSearch.createIndex(params, fields);
         logger.info(String.format("Created index %s", indexName));
       }
 
-      // Create sorted sets for lexicographic fields
+      // Always (re)create sorted sets for lexicographic fields at the end
       createSortedSetsForLexicographicFields(cl, entityPrefix);
     } catch (Exception e) {
       logger.warn(String.format(SKIPPING_INDEX_CREATION, indexName, e.getMessage()));
@@ -447,6 +534,27 @@ public class RediSearchIndexer {
     String key = getKeyspace(keyspace);
     keyspaceToEntityClass.put(key, entityClass);
     entityClassToKeySpace.put(entityClass, key);
+    indexedEntityClasses.add(entityClass);
+  }
+
+  /**
+   * Registers a secondary key prefix → entity class mapping without disturbing the
+   * entity's canonical keyspace. Unlike {@link #addKeySpaceMapping(String, Class)},
+   * this method only populates the forward {@code keyspace → entityClass} lookup via
+   * {@code putIfAbsent} and never overwrites {@code entityClassToKeySpace} (the canonical
+   * reverse mapping used by {@link #getKeyspaceForEntityClass(Class)} and friends).
+   * <p>
+   * Used both for repository-level indexes (where the entity already has its own
+   * canonical keyspace declared on {@code @Document}/{@code @RedisHash}) and for
+   * entity-level {@code @IndexingOptions.prefixes()} where the first element is the
+   * canonical prefix and any remaining elements are additional coverage.
+   *
+   * @param keyspace    the additional key prefix covered by an index
+   * @param entityClass the entity class the index is defined for
+   */
+  private void registerSecondaryKeyspace(String keyspace, Class<?> entityClass) {
+    String key = getKeyspace(keyspace);
+    keyspaceToEntityClass.putIfAbsent(key, entityClass);
     indexedEntityClasses.add(entityClass);
   }
 
@@ -1711,6 +1819,11 @@ public class RediSearchIndexer {
   }
 
   private FTCreateParams createIndexDefinition(Class<?> cl, IndexDataType idxType) {
+    return createIndexDefinition(cl, idxType, null);
+  }
+
+  private FTCreateParams createIndexDefinition(Class<?> cl, IndexDataType idxType,
+      IndexingOptions repoIndexingOptions) {
     FTCreateParams params = FTCreateParams.createParams();
     params.on(idxType);
 
@@ -1721,6 +1834,23 @@ public class RediSearchIndexer {
           .getValue()));
       Optional.ofNullable(document.languageField()).filter(ObjectUtils::isNotEmpty).ifPresent(params::languageField);
       params.score(document.score());
+    }
+
+    // Entity-level @IndexingOptions filter overrides @Document filter
+    IndexingOptions entityOptions = cl.getAnnotation(IndexingOptions.class);
+    if (entityOptions != null && !entityOptions.filter().isBlank()) {
+      String filter = evaluateExpression(entityOptions.filter(), "");
+      if (!filter.isBlank()) {
+        params.filter(filter);
+      }
+    }
+
+    // Repository-level @IndexingOptions filter overrides everything
+    if (repoIndexingOptions != null && !repoIndexingOptions.filter().isBlank()) {
+      String filter = evaluateExpression(repoIndexingOptions.filter(), "");
+      if (!filter.isBlank()) {
+        params.filter(filter);
+      }
     }
 
     return params;
@@ -1969,31 +2099,20 @@ public class RediSearchIndexer {
       logger.info(String.format("Found @%s annotated class: %s", idxType, entityClass.getName()));
 
       final List<java.lang.reflect.Field> allClassFields = getDeclaredFieldsTransitively(entityClass);
-
-      List<SearchField> searchFields = processIndexedFields(allClassFields, isDocument);
-
-      for (SearchField field : searchFields) {
-        registerAlias(entityClass, field.getField().getName(), field.getSchemaField().getFieldName().getAttribute());
-      }
-
+      List<SearchField> searchFields = prepareSearchFields(entityClass, isDocument, allClassFields);
       Optional<String> maybeScoreField = getDocumentScoreField(allClassFields, isDocument);
-      createIndexedFieldsForIdFields(entityClass, searchFields.stream().map(SearchField::getSchemaField).toList(),
-          isDocument).forEach(searchFields::add);
 
       SearchOperations<String> opsForSearch = rmo.opsForSearch(indexName);
-
       FTCreateParams params = createIndexDefinition(entityClass, idxType);
 
       if (isDocument) {
         maybeScoreField.ifPresent(params::scoreField);
       }
 
-      // Ensure keyPrefix ends with colon
-      String entityPrefix = keyPrefix.endsWith(":") ? keyPrefix : keyPrefix + ":";
+      String entityPrefix = getKeyspace(keyPrefix);
       params.prefix(entityPrefix);
       addKeySpaceMapping(entityPrefix, entityClass);
 
-      // Update TTL settings
       Optional<Document> document = isDocument ?
           Optional.of(entityClass.getAnnotation(Document.class)) :
           Optional.empty();
@@ -2006,35 +2125,84 @@ public class RediSearchIndexer {
       // The global mappings should only be updated by the main createIndexFor(Class) method.
 
       if (maybeIndexingOptions.isPresent()) {
-        IndexingOptions options = maybeIndexingOptions.get();
-        switch (options.creationMode()) {
-          case SKIP_IF_EXIST:
-            opsForSearch.createIndex(params, fields);
-            logger.info(String.format("Created index %s...", indexName));
-            // Create sorted sets for lexicographic fields
-            createSortedSetsForLexicographicFields(entityClass, entityPrefix);
-            break;
-          case DROP_AND_RECREATE:
-            if (indexExistsFor(entityClass, indexName)) {
-              opsForSearch.dropIndex();
-              logger.info(String.format("Dropped index %s", indexName));
-            }
-            opsForSearch.createIndex(params, fields);
-            logger.info(String.format("Created index %s", indexName));
-            // Create sorted sets for lexicographic fields
-            createSortedSetsForLexicographicFields(entityClass, entityPrefix);
-            break;
-          case SKIP_ALWAYS:
-            // do nothing and like it!
-            logger.info(String.format("Skipped index creation for %s", entityClass.getSimpleName()));
-            break;
-        }
+        applyCreationMode(opsForSearch, params, fields, maybeIndexingOptions.get().creationMode(), indexName,
+            entityClass, () -> indexExistsFor(entityClass, indexName), () -> createSortedSetsForLexicographicFields(
+                entityClass, entityPrefix));
       } else {
         opsForSearch.createIndex(params, fields);
         logger.info(String.format("Created index %s", indexName));
-        // Create sorted sets for lexicographic fields
         createSortedSetsForLexicographicFields(entityClass, entityPrefix);
       }
+
+      return true;
+    } catch (Exception e) {
+      logger.warn(String.format(SKIPPING_INDEX_CREATION, indexName, e.getMessage()));
+      return false;
+    }
+  }
+
+  /**
+   * Creates an index for the specified entity class using repository-level {@link IndexingOptions}.
+   * This method reads all settings from the annotation, including index name, key prefix,
+   * filter expression, and creation mode.
+   *
+   * @param entityClass         the entity class
+   * @param repoIndexingOptions the {@link IndexingOptions} annotation from the repository interface
+   * @return true if successful, false otherwise
+   */
+  public boolean createIndexFor(Class<?> entityClass, IndexingOptions repoIndexingOptions) {
+    String defaultIndexName = entityClass.getName() + "Idx";
+    String indexName = repoIndexingOptions.indexName().isBlank() ?
+        defaultIndexName :
+        evaluateExpression(repoIndexingOptions.indexName(), defaultIndexName);
+
+    try {
+      Optional<IndexDataType> maybeType = determineIndexTarget(entityClass);
+      if (maybeType.isEmpty()) {
+        return false;
+      }
+      IndexDataType idxType = maybeType.get();
+      boolean isDocument = idxType == IndexDataType.JSON;
+
+      logger.info(String.format("Creating repo-level index %s for class: %s", indexName, entityClass.getName()));
+
+      final List<java.lang.reflect.Field> allClassFields = getDeclaredFieldsTransitively(entityClass);
+      List<SearchField> searchFields = prepareSearchFields(entityClass, isDocument, allClassFields);
+      Optional<String> maybeScoreField = getDocumentScoreField(allClassFields, isDocument);
+
+      SearchOperations<String> opsForSearch = rmo.opsForSearch(indexName);
+      FTCreateParams params = createIndexDefinition(entityClass, idxType, repoIndexingOptions);
+
+      if (isDocument) {
+        maybeScoreField.ifPresent(params::scoreField);
+      }
+
+      // Resolve prefixes — also register each resolved prefix in the keyspace→entity map
+      // so lookups (e.g. getEntityClassForKeyspace) know about every prefix the repo-level
+      // index covers, not just the entity-level one.
+      if (repoIndexingOptions.prefixes().length > 0) {
+        String[] resolvedPrefixes = resolveAndNormalizePrefixArray(repoIndexingOptions.prefixes());
+        params.prefix(resolvedPrefixes);
+        for (String p : resolvedPrefixes) {
+          registerSecondaryKeyspace(p, entityClass);
+        }
+      } else {
+        String defaultPrefix = getKeyspaceForEntityClass(entityClass);
+        if (defaultPrefix == null || defaultPrefix.isBlank()) {
+          defaultPrefix = getKeyspace(getEntityPrefix(entityClass));
+        }
+        String entityPrefix = repoIndexingOptions.keyPrefix().isBlank() ?
+            defaultPrefix :
+            getKeyspace(evaluateExpression(repoIndexingOptions.keyPrefix(), defaultPrefix));
+        params.prefix(entityPrefix);
+        registerSecondaryKeyspace(entityPrefix, entityClass);
+      }
+
+      List<SchemaField> fields = searchFields.stream().map(SearchField::getSchemaField).toList();
+
+      applyCreationMode(opsForSearch, params, fields, repoIndexingOptions.creationMode(), indexName, entityClass,
+          () -> indexExistsFor(entityClass, indexName), () -> {
+          });
 
       return true;
     } catch (Exception e) {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactory.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisDocumentRepositoryFactory.java
@@ -211,7 +211,8 @@ public class RedisDocumentRepositoryFactory extends KeyValueRepositoryFactory {
         mappingContext, //
         gsonBuilder, //
         embedder, //
-        properties //
+        properties, //
+        repositoryInformation.getRepositoryInterface() //
     );
   }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisEnhancedRepositoryFactory.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/RedisEnhancedRepositoryFactory.java
@@ -200,7 +200,7 @@ public class RedisEnhancedRepositoryFactory extends RepositoryFactorySupport {
   protected Object getTargetRepository(RepositoryInformation repositoryInformation) {
     EntityInformation<?, ?> entityInformation = getEntityInformation(repositoryInformation.getDomainType());
     return super.getTargetRepositoryViaReflection(repositoryInformation, entityInformation, keyValueOperations, rmo,
-        indexer, embedder, properties);
+        indexer, embedder, properties, repositoryInformation.getRepositoryInterface());
   }
 
   /* (non-Javadoc)

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisDocumentRepository.java
@@ -136,12 +136,10 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
   private final RedisMappingContext mappingContext;
   private final EntityStream entityStream;
   private final LexicographicIndexer lexicographicIndexer;
+  private final String repositoryIndexName;
 
   /**
    * Constructs a new {@code SimpleRedisDocumentRepository} with the required dependencies.
-   * <p>
-   * This constructor initializes all necessary components for Redis document operations
-   * including JSON operations, search capabilities, entity mapping, and auditing.
    *
    * @param metadata       entity information containing type and ID metadata
    * @param operations     Spring Data Key-Value operations for basic CRUD
@@ -151,6 +149,34 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
    * @param gsonBuilder    Gson builder for JSON serialization customization
    * @param embedder       embedder for AI-powered vector generation (may be no-op)
    * @param properties     Redis OM configuration properties
+   */
+  public SimpleRedisDocumentRepository( //
+      EntityInformation<T, ID> metadata, //
+      KeyValueOperations operations, //
+      RedisModulesOperations<?> rmo, //
+      RediSearchIndexer indexer, //
+      RedisMappingContext mappingContext, //
+      GsonBuilder gsonBuilder, //
+      Embedder embedder, //
+      RedisOMProperties properties) {
+    this(metadata, operations, rmo, indexer, mappingContext, gsonBuilder, embedder, properties, null);
+  }
+
+  /**
+   * Constructs a new {@code SimpleRedisDocumentRepository} with the required dependencies.
+   * <p>
+   * This constructor initializes all necessary components for Redis document operations
+   * including JSON operations, search capabilities, entity mapping, and auditing.
+   *
+   * @param metadata            entity information containing type and ID metadata
+   * @param operations          Spring Data Key-Value operations for basic CRUD
+   * @param rmo                 Redis modules operations for JSON and search functionality
+   * @param indexer             RediSearch indexer for managing search indexes
+   * @param mappingContext      Redis mapping context for entity metadata
+   * @param gsonBuilder         Gson builder for JSON serialization customization
+   * @param embedder            embedder for AI-powered vector generation (may be no-op)
+   * @param properties          Redis OM configuration properties
+   * @param repositoryInterface the repository interface class (used for repo-level @IndexingOptions)
    */
   @SuppressWarnings(
     "unchecked"
@@ -165,7 +191,8 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
       RedisMappingContext mappingContext, //
       GsonBuilder gsonBuilder, //
       Embedder embedder, //
-      RedisOMProperties properties) {
+      RedisOMProperties properties, //
+      Class<?> repositoryInterface) {
     super(metadata, operations);
     this.modulesOperations = (RedisModulesOperations<String>) rmo;
     this.metadata = metadata;
@@ -180,6 +207,7 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
     this.properties = properties;
     this.entityStream = new EntityStreamImpl(modulesOperations, modulesOperations.gsonBuilder(), indexer);
     this.lexicographicIndexer = new LexicographicIndexer(modulesOperations.template(), indexer);
+    this.repositoryIndexName = indexer.resolveRepositoryIndexName(repositoryInterface);
   }
 
   @Override
@@ -673,9 +701,7 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
     }
 
     if (indexer.indexDefinitionExistsFor(metadata.getJavaType())) {
-      String searchIndex = indexer.getIndexName(metadata.getJavaType());
-
-      SearchOperations<String> searchOps = modulesOperations.opsForSearch(searchIndex);
+      SearchOperations<String> searchOps = getSearchOps();
       Query query = new Query("*");
       query.limit(Math.toIntExact(pageable.getOffset()), pageable.getPageSize());
 
@@ -714,6 +740,27 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
     Pageable pageRequest = PageRequest.of(0, properties.getRepository().getQuery().getLimit(), sort);
 
     return findAll(pageRequest).toList();
+  }
+
+  @Override
+  public List<T> findAll() {
+    if (repositoryIndexName != null) {
+      // When using a repo-level custom index (e.g., with a filter), route through search
+      return findAll(PageRequest.of(0, properties.getRepository().getQuery().getLimit())).toList();
+    }
+    return super.findAll();
+  }
+
+  @Override
+  public long count() {
+    if (repositoryIndexName != null) {
+      SearchOperations<String> searchOps = getSearchOps();
+      Query query = new Query("*");
+      query.limit(0, 0);
+      SearchResult searchResult = searchOps.search(query);
+      return searchResult.getTotalResults();
+    }
+    return super.count();
   }
 
   @Override
@@ -993,6 +1040,9 @@ public class SimpleRedisDocumentRepository<T, ID> extends SimpleKeyValueReposito
    * @return configured {@link SearchOperations} for the entity type
    */
   private SearchOperations<String> getSearchOps() {
+    if (repositoryIndexName != null) {
+      return modulesOperations.opsForSearch(repositoryIndexName);
+    }
     String keyspace = indexer.getKeyspaceForEntityClass(metadata.getJavaType());
     String searchIndex = indexer.getIndexName(keyspace);
     return modulesOperations.opsForSearch(searchIndex);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/repository/support/SimpleRedisEnhancedRepository.java
@@ -104,6 +104,7 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
   private final RedisOMProperties properties;
 
   private final EntityStream entityStream;
+  private final String repositoryIndexName;
 
   /**
    * Constructs a new {@code SimpleRedisEnhancedRepository} with the specified dependencies.
@@ -114,6 +115,28 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
    * @param indexer    RediSearch indexer for managing search indexes
    * @param embedder   embedder for generating vector embeddings
    * @param properties configuration properties for Redis OM
+   */
+  public SimpleRedisEnhancedRepository( //
+      EntityInformation<T, ID> metadata, //
+      KeyValueOperations operations, //
+      RedisModulesOperations<?> rmo, //
+      RediSearchIndexer indexer, //
+      Embedder embedder, //
+      RedisOMProperties properties //
+  ) {
+    this(metadata, operations, rmo, indexer, embedder, properties, null);
+  }
+
+  /**
+   * Constructs a new {@code SimpleRedisEnhancedRepository} with the specified dependencies.
+   *
+   * @param metadata            metadata about the entity type
+   * @param operations          key-value operations for basic Redis operations
+   * @param rmo                 Redis modules operations for advanced features
+   * @param indexer             RediSearch indexer for managing search indexes
+   * @param embedder            embedder for generating vector embeddings
+   * @param properties          configuration properties for Redis OM
+   * @param repositoryInterface the repository interface class (used for repo-level @IndexingOptions)
    */
   @SuppressWarnings(
     "unchecked"
@@ -126,7 +149,8 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
       ) RedisModulesOperations<?> rmo, //
       RediSearchIndexer indexer, //
       Embedder embedder, //
-      RedisOMProperties properties //
+      RedisOMProperties properties, //
+      Class<?> repositoryInterface //
   ) {
     super(metadata, operations);
     this.modulesOperations = (RedisModulesOperations<String>) rmo;
@@ -141,6 +165,7 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
     this.properties = properties;
     this.lexicographicIndexer = new LexicographicIndexer(modulesOperations.template(), indexer);
     this.entityStream = new EntityStreamImpl(modulesOperations, modulesOperations.gsonBuilder(), indexer);
+    this.repositoryIndexName = indexer.resolveRepositoryIndexName(repositoryInterface);
   }
 
   @SuppressWarnings(
@@ -148,10 +173,7 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
   )
   @Override
   public Iterable<ID> getIds() {
-    String keyspace = indexer.getKeyspaceForEntityClass(metadata.getJavaType());
-    String searchIndex = indexer.getIndexName(keyspace);
-
-    SearchOperations<String> searchOps = modulesOperations.opsForSearch(searchIndex);
+    SearchOperations<String> searchOps = getSearchOps();
     Optional<Field> maybeIdField = ObjectUtils.getIdFieldForEntityClass(metadata.getJavaType());
     String idField = maybeIdField.map(Field::getName).orElse("id");
     Query query = new Query("*");
@@ -214,7 +236,23 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
    * @see org.springframework.data.repository.CrudRepository#findAll() */
   @Override
   public List<T> findAll() {
+    if (repositoryIndexName != null) {
+      // When using a repo-level custom index (e.g., with a filter), route through search
+      return findAll(PageRequest.of(0, properties.getRepository().getQuery().getLimit())).toList();
+    }
     return IterableConverter.toList(operations.findAll(metadata.getJavaType()));
+  }
+
+  @Override
+  public long count() {
+    if (repositoryIndexName != null) {
+      SearchOperations<String> searchOps = getSearchOps();
+      Query query = new Query("*");
+      query.limit(0, 0);
+      SearchResult searchResult = searchOps.search(query);
+      return searchResult.getTotalResults();
+    }
+    return super.count();
   }
 
   // -------------------------------------------------------------------------
@@ -251,8 +289,7 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
     }
 
     if (indexer.indexDefinitionExistsFor(metadata.getJavaType())) {
-      String searchIndex = indexer.getIndexName(metadata.getJavaType());
-      SearchOperations<String> searchOps = modulesOperations.opsForSearch(searchIndex);
+      SearchOperations<String> searchOps = getSearchOps();
       Query query = new Query("*");
       query.limit(Math.toIntExact(pageable.getOffset()), pageable.getPageSize());
 
@@ -673,6 +710,9 @@ public class SimpleRedisEnhancedRepository<T, ID> extends SimpleKeyValueReposito
   }
 
   private SearchOperations<String> getSearchOps() {
+    if (repositoryIndexName != null) {
+      return modulesOperations.opsForSearch(repositoryIndexName);
+    }
     String keyspace = indexer.getKeyspaceForEntityClass(metadata.getJavaType());
     String searchIndex = indexer.getIndexName(keyspace);
     return modulesOperations.opsForSearch(searchIndex);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/EntityStream.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/EntityStream.java
@@ -15,7 +15,7 @@ public interface EntityStream {
 
   /**
    * Create search stream with custom index and ID field.
-   * 
+   *
    * @param <E>         entity type
    * @param entityClass the entity class
    * @param searchIndex the search index name
@@ -23,4 +23,15 @@ public interface EntityStream {
    * @return search stream for the entity
    */
   <E> SearchStream<E> of(final Class<E> entityClass, String searchIndex, String idField);
+
+  /**
+   * Create search stream with a custom search index name.
+   * The ID field is auto-detected from the entity class.
+   *
+   * @param <E>         entity type
+   * @param entityClass the entity class
+   * @param searchIndex the search index name
+   * @return search stream for the entity
+   */
+  <E> SearchStream<E> of(final Class<E> entityClass, String searchIndex);
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/EntityStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/EntityStreamImpl.java
@@ -1,6 +1,7 @@
 package com.redis.om.spring.search.stream;
 
 import static com.redis.om.spring.util.ObjectUtils.getDeclaredFieldsTransitively;
+import static com.redis.om.spring.util.ObjectUtils.getIdFieldForEntityClass;
 
 import java.lang.reflect.Field;
 import java.util.Optional;
@@ -43,14 +44,30 @@ public class EntityStreamImpl implements EntityStream {
   @Override
   public <E> SearchStream<E> of(Class<E> entityClass, String searchIndex, String idField) {
     Optional<Field> maybeIdField = getDeclaredFieldsTransitively(entityClass).stream().filter(f -> f.getName().equals(
-        "id")).findFirst();
+        idField)).findFirst();
+    if (maybeIdField.isPresent()) {
+      return new SearchStreamImpl<>(entityClass, searchIndex, maybeIdField.get(), modulesOperations, gsonBuilder,
+          indexer);
+    } else {
+      throw new IllegalArgumentException(entityClass
+          .getName() + " does not appear to have a field named '" + idField + "'");
+    }
+  }
+
+  @Override
+  public <E> SearchStream<E> of(Class<E> entityClass, String searchIndex) {
+    // Prefer an explicit @Id-annotated field; fall back to a field literally named "id".
+    Optional<Field> maybeIdField = getIdFieldForEntityClass(entityClass);
+    if (maybeIdField.isEmpty()) {
+      maybeIdField = getDeclaredFieldsTransitively(entityClass).stream().filter(f -> f.getName().equals("id"))
+          .findFirst();
+    }
     if (maybeIdField.isPresent()) {
       return new SearchStreamImpl<>(entityClass, searchIndex, maybeIdField.get(), modulesOperations, gsonBuilder,
           indexer);
     } else {
       throw new IllegalArgumentException(entityClass.getName() + " does not appear to have an ID field");
     }
-
   }
 
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/util/ObjectUtils.java
@@ -43,6 +43,7 @@ import org.springframework.util.ReflectionUtils;
 
 import com.redis.om.spring.annotations.EnableRedisDocumentRepositories;
 import com.redis.om.spring.annotations.EnableRedisEnhancedRepositories;
+import com.redis.om.spring.annotations.IndexingOptions;
 import com.redis.om.spring.convert.MappingRedisOMConverter;
 import com.redis.om.spring.tuple.Tuples;
 
@@ -677,6 +678,96 @@ public class ObjectUtils {
     }
 
     return erers;
+  }
+
+  /**
+   * Finds repository interfaces annotated with {@link IndexingOptions} in the configured
+   * base packages. Returns a set of interface classes that can be inspected for their
+   * indexing options and domain type.
+   *
+   * @param ac the ApplicationContext to search
+   * @return a set of repository interface classes with @IndexingOptions
+   */
+  public static Set<Class<?>> getRepositoryInterfacesWithIndexingOptions(ApplicationContext ac) {
+    Set<Class<?>> result = new HashSet<>();
+    Set<String> packages = new HashSet<>();
+
+    // Collect all base packages from both Document and Enhanced repository configurations
+    List<Pair<EnableRedisDocumentRepositories, String>> erdrs = getEnableRedisDocumentRepositories(ac);
+    for (Pair<EnableRedisDocumentRepositories, String> pair : erdrs) {
+      EnableRedisDocumentRepositories edr = pair.getFirst();
+      if (edr.basePackages().length > 0) {
+        packages.addAll(Arrays.asList(edr.basePackages()));
+      } else if (edr.basePackageClasses().length > 0) {
+        for (Class<?> pkg : edr.basePackageClasses()) {
+          packages.add(pkg.getPackageName());
+        }
+      } else {
+        packages.add(pair.getSecond());
+      }
+    }
+
+    List<Pair<EnableRedisEnhancedRepositories, String>> erers = getEnableRedisEnhancedRepositories(ac);
+    for (Pair<EnableRedisEnhancedRepositories, String> pair : erers) {
+      EnableRedisEnhancedRepositories er = pair.getFirst();
+      if (er.basePackages().length > 0) {
+        packages.addAll(Arrays.asList(er.basePackages()));
+      } else if (er.basePackageClasses().length > 0) {
+        for (Class<?> pkg : er.basePackageClasses()) {
+          packages.add(pkg.getPackageName());
+        }
+      } else {
+        packages.add(pair.getSecond());
+      }
+    }
+
+    // Use a scanner that includes interfaces
+    ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false) {
+      @Override
+      protected boolean isCandidateComponent(
+          org.springframework.beans.factory.annotation.AnnotatedBeanDefinition beanDefinition) {
+        return beanDefinition.getMetadata().isInterface();
+      }
+    };
+    provider.addIncludeFilter(new AnnotationTypeFilter(IndexingOptions.class));
+
+    for (String pkg : packages) {
+      for (BeanDefinition bd : provider.findCandidateComponents(pkg)) {
+        try {
+          Class<?> iface = Class.forName(bd.getBeanClassName());
+          if (iface.isInterface() && iface.isAnnotationPresent(IndexingOptions.class)) {
+            result.add(iface);
+          }
+        } catch (ClassNotFoundException e) {
+          // skip
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Resolves the domain (entity) type from a repository interface by walking
+   * its generic type hierarchy to find the entity class.
+   *
+   * @param repositoryInterface the repository interface class
+   * @param repositoryBaseType  the base repository type (e.g., RedisDocumentRepository.class)
+   * @return the resolved entity class, or null if not found
+   */
+  public static Class<?> resolveEntityTypeFromRepository(Class<?> repositoryInterface, Class<?> repositoryBaseType) {
+    ResolvableType resolvable = ResolvableType.forClass(repositoryInterface);
+    ResolvableType[] supers = resolvable.getInterfaces();
+    for (ResolvableType superType : supers) {
+      if (superType.getRawClass() != null && repositoryBaseType.isAssignableFrom(superType.getRawClass())) {
+        ResolvableType resolved = resolvable.as(repositoryBaseType);
+        ResolvableType generic = resolved.getGeneric(0);
+        if (generic.getRawClass() != null) {
+          return generic.getRawClass();
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/SeparateIndexDefinitionTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/SeparateIndexDefinitionTest.java
@@ -1,0 +1,119 @@
+package com.redis.om.spring.annotations.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+
+import com.redis.om.spring.AbstractBaseOMTest;
+import com.redis.om.spring.TestConfig;
+import com.redis.om.spring.annotations.EnableRedisDocumentRepositories;
+import com.redis.om.spring.fixtures.document.model.Ticket;
+import com.redis.om.spring.fixtures.document.repository.AllTicketsRepository;
+import com.redis.om.spring.fixtures.document.repository.TeamATicketRepository;
+import com.redis.om.spring.fixtures.document.repository.TeamBTicketRepository;
+import com.redis.om.spring.search.stream.EntityStream;
+
+@DirtiesContext
+@SpringBootTest(
+    classes = SeparateIndexDefinitionTest.Config.class,
+    properties = { "spring.main.allow-bean-definition-overriding=true" }
+)
+public class SeparateIndexDefinitionTest extends AbstractBaseOMTest {
+
+  @SpringBootApplication
+  @Configuration
+  @EnableRedisDocumentRepositories(
+      basePackages = {
+          "com.redis.om.spring.fixtures.document.repository",
+          "com.redis.om.spring.fixtures.document.model"
+      }
+  )
+  static class Config extends TestConfig {
+  }
+
+  @Autowired
+  AllTicketsRepository allTicketsRepository;
+
+  @Autowired
+  TeamATicketRepository teamATicketRepository;
+
+  @Autowired
+  TeamBTicketRepository teamBTicketRepository;
+
+  @Autowired
+  EntityStream entityStream;
+
+  @BeforeEach
+  void setUp() {
+    allTicketsRepository.deleteAll();
+
+    Ticket t1 = Ticket.of("TeamA", "high", "Fix login bug");
+    Ticket t2 = Ticket.of("TeamA", "low", "Update docs");
+    Ticket t3 = Ticket.of("TeamB", "high", "Deploy new service");
+    Ticket t4 = Ticket.of("TeamB", "medium", "Refactor auth module");
+    Ticket t5 = Ticket.of("TeamC", "low", "Add logging");
+
+    allTicketsRepository.saveAll(List.of(t1, t2, t3, t4, t5));
+  }
+
+  @Test
+  void testAllTicketsRepositoryReturnAllTickets() {
+    List<Ticket> all = allTicketsRepository.findAll();
+    assertThat(all).hasSize(5);
+  }
+
+  @Test
+  void testTeamARepositoryReturnsOnlyTeamATickets() {
+    List<Ticket> teamATickets = teamATicketRepository.findAll();
+    assertThat(teamATickets).hasSize(2);
+    assertThat(teamATickets).allMatch(t -> "TeamA".equals(t.getTeam()));
+  }
+
+  @Test
+  void testTeamBRepositoryReturnsOnlyTeamBTickets() {
+    List<Ticket> teamBTickets = teamBTicketRepository.findAll();
+    assertThat(teamBTickets).hasSize(2);
+    assertThat(teamBTickets).allMatch(t -> "TeamB".equals(t.getTeam()));
+  }
+
+  @Test
+  void testEntityStreamWithCustomIndexName() {
+    List<Ticket> teamATickets = entityStream.of(Ticket.class, "ticket_team_a_idx")
+        .collect(Collectors.toList());
+    assertThat(teamATickets).hasSize(2);
+    assertThat(teamATickets).allMatch(t -> "TeamA".equals(t.getTeam()));
+  }
+
+  @Test
+  void testEntityLevelIndexingOptionsStillWorks() {
+    List<Ticket> allTickets = entityStream.of(Ticket.class)
+        .collect(Collectors.toList());
+    assertThat(allTickets).hasSize(5);
+  }
+
+  @Test
+  void testSaveThroughAllRepoQueryThroughFilteredRepo() {
+    Ticket newTicket = Ticket.of("TeamA", "critical", "Urgent security patch");
+    allTicketsRepository.save(newTicket);
+
+    List<Ticket> teamATickets = teamATicketRepository.findAll();
+    assertThat(teamATickets).hasSize(3);
+    assertThat(teamATickets).anyMatch(t -> "critical".equals(t.getPriority()));
+  }
+
+  @Test
+  void testFilteredRepoDoesNotReturnOtherTeamTickets() {
+    List<Ticket> teamATickets = teamATicketRepository.findAll();
+    assertThat(teamATickets).noneMatch(t -> "TeamB".equals(t.getTeam()));
+    assertThat(teamATickets).noneMatch(t -> "TeamC".equals(t.getTeam()));
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/hash/SeparateIndexDefinitionHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/hash/SeparateIndexDefinitionHashTest.java
@@ -1,0 +1,119 @@
+package com.redis.om.spring.annotations.hash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+
+import com.redis.om.spring.AbstractBaseOMTest;
+import com.redis.om.spring.TestConfig;
+import com.redis.om.spring.annotations.EnableRedisEnhancedRepositories;
+import com.redis.om.spring.fixtures.hash.model.TicketHash;
+import com.redis.om.spring.fixtures.hash.repository.AllTicketHashesRepository;
+import com.redis.om.spring.fixtures.hash.repository.TeamATicketHashRepository;
+import com.redis.om.spring.fixtures.hash.repository.TeamBTicketHashRepository;
+import com.redis.om.spring.search.stream.EntityStream;
+
+@DirtiesContext
+@SpringBootTest(
+    classes = SeparateIndexDefinitionHashTest.Config.class,
+    properties = { "spring.main.allow-bean-definition-overriding=true" }
+)
+public class SeparateIndexDefinitionHashTest extends AbstractBaseOMTest {
+
+  @SpringBootApplication
+  @Configuration
+  @EnableRedisEnhancedRepositories(
+      basePackages = {
+          "com.redis.om.spring.fixtures.hash.repository",
+          "com.redis.om.spring.fixtures.hash.model"
+      }
+  )
+  static class Config extends TestConfig {
+  }
+
+  @Autowired
+  AllTicketHashesRepository allTicketHashesRepository;
+
+  @Autowired
+  TeamATicketHashRepository teamATicketHashRepository;
+
+  @Autowired
+  TeamBTicketHashRepository teamBTicketHashRepository;
+
+  @Autowired
+  EntityStream entityStream;
+
+  @BeforeEach
+  void setUp() {
+    allTicketHashesRepository.deleteAll();
+
+    TicketHash t1 = TicketHash.of("TeamA", "high", "Fix login bug");
+    TicketHash t2 = TicketHash.of("TeamA", "low", "Update docs");
+    TicketHash t3 = TicketHash.of("TeamB", "high", "Deploy new service");
+    TicketHash t4 = TicketHash.of("TeamB", "medium", "Refactor auth module");
+    TicketHash t5 = TicketHash.of("TeamC", "low", "Add logging");
+
+    allTicketHashesRepository.saveAll(List.of(t1, t2, t3, t4, t5));
+  }
+
+  @Test
+  void testAllTicketHashesRepositoryReturnAllTickets() {
+    List<TicketHash> all = allTicketHashesRepository.findAll();
+    assertThat(all).hasSize(5);
+  }
+
+  @Test
+  void testTeamAHashRepositoryReturnsOnlyTeamATickets() {
+    List<TicketHash> teamATickets = teamATicketHashRepository.findAll();
+    assertThat(teamATickets).hasSize(2);
+    assertThat(teamATickets).allMatch(t -> "TeamA".equals(t.getTeam()));
+  }
+
+  @Test
+  void testTeamBHashRepositoryReturnsOnlyTeamBTickets() {
+    List<TicketHash> teamBTickets = teamBTicketHashRepository.findAll();
+    assertThat(teamBTickets).hasSize(2);
+    assertThat(teamBTickets).allMatch(t -> "TeamB".equals(t.getTeam()));
+  }
+
+  @Test
+  void testCountRespectsRepositoryLevelFilter() {
+    assertThat(allTicketHashesRepository.count()).isEqualTo(5);
+    assertThat(teamATicketHashRepository.count()).isEqualTo(2);
+    assertThat(teamBTicketHashRepository.count()).isEqualTo(2);
+  }
+
+  @Test
+  void testEntityStreamWithCustomIndexName() {
+    List<TicketHash> teamATickets = entityStream.of(TicketHash.class, "ticket_hash_team_a_idx")
+        .collect(Collectors.toList());
+    assertThat(teamATickets).hasSize(2);
+    assertThat(teamATickets).allMatch(t -> "TeamA".equals(t.getTeam()));
+  }
+
+  @Test
+  void testSaveThroughAllRepoQueryThroughFilteredRepo() {
+    TicketHash newTicket = TicketHash.of("TeamA", "critical", "Urgent security patch");
+    allTicketHashesRepository.save(newTicket);
+
+    List<TicketHash> teamATickets = teamATicketHashRepository.findAll();
+    assertThat(teamATickets).hasSize(3);
+    assertThat(teamATickets).anyMatch(t -> "critical".equals(t.getPriority()));
+  }
+
+  @Test
+  void testFilteredRepoDoesNotReturnOtherTeamTickets() {
+    List<TicketHash> teamATickets = teamATicketHashRepository.findAll();
+    assertThat(teamATickets).noneMatch(t -> "TeamB".equals(t.getTeam()));
+    assertThat(teamATickets).noneMatch(t -> "TeamC".equals(t.getTeam()));
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/Ticket.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/Ticket.java
@@ -1,0 +1,37 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(
+    staticName = "of"
+)
+@NoArgsConstructor(
+    force = true
+)
+@Document("ticket")
+public class Ticket {
+  @Id
+  private String id;
+
+  @NonNull
+  @Indexed
+  private String team;
+
+  @NonNull
+  @Indexed
+  private String priority;
+
+  @NonNull
+  @Searchable
+  private String description;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/AllTicketsRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/AllTicketsRepository.java
@@ -1,0 +1,7 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import com.redis.om.spring.fixtures.document.model.Ticket;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface AllTicketsRepository extends RedisDocumentRepository<Ticket, String> {
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/TeamATicketRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/TeamATicketRepository.java
@@ -1,0 +1,9 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import com.redis.om.spring.annotations.IndexingOptions;
+import com.redis.om.spring.fixtures.document.model.Ticket;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+@IndexingOptions(indexName = "ticket_team_a_idx", filter = "@team==\"TeamA\"")
+public interface TeamATicketRepository extends RedisDocumentRepository<Ticket, String> {
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/TeamBTicketRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/repository/TeamBTicketRepository.java
@@ -1,0 +1,9 @@
+package com.redis.om.spring.fixtures.document.repository;
+
+import com.redis.om.spring.annotations.IndexingOptions;
+import com.redis.om.spring.fixtures.document.model.Ticket;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+@IndexingOptions(indexName = "ticket_team_b_idx", filter = "@team==\"TeamB\"")
+public interface TeamBTicketRepository extends RedisDocumentRepository<Ticket, String> {
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/TicketHash.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/TicketHash.java
@@ -1,0 +1,37 @@
+package com.redis.om.spring.fixtures.hash.model;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor(
+    staticName = "of"
+)
+@NoArgsConstructor(
+    force = true
+)
+@RedisHash("ticket_hash")
+public class TicketHash {
+  @Id
+  private String id;
+
+  @NonNull
+  @Indexed
+  private String team;
+
+  @NonNull
+  @Indexed
+  private String priority;
+
+  @NonNull
+  @Searchable
+  private String description;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/AllTicketHashesRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/AllTicketHashesRepository.java
@@ -1,0 +1,7 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import com.redis.om.spring.fixtures.hash.model.TicketHash;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+public interface AllTicketHashesRepository extends RedisEnhancedRepository<TicketHash, String> {
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/TeamATicketHashRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/TeamATicketHashRepository.java
@@ -1,0 +1,11 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import com.redis.om.spring.annotations.IndexingOptions;
+import com.redis.om.spring.fixtures.hash.model.TicketHash;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+@IndexingOptions(
+    indexName = "ticket_hash_team_a_idx", filter = "@team==\"TeamA\""
+)
+public interface TeamATicketHashRepository extends RedisEnhancedRepository<TicketHash, String> {
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/TeamBTicketHashRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/TeamBTicketHashRepository.java
@@ -1,0 +1,11 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import com.redis.om.spring.annotations.IndexingOptions;
+import com.redis.om.spring.fixtures.hash.model.TicketHash;
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+
+@IndexingOptions(
+    indexName = "ticket_hash_team_b_idx", filter = "@team==\"TeamB\""
+)
+public interface TeamBTicketHashRepository extends RedisEnhancedRepository<TicketHash, String> {
+}


### PR DESCRIPTION
## Summary

Resolves #638. Allows multiple RediSearch indexes over the same entity type
by placing `@IndexingOptions` on a repository interface. Each repository can
define its own index name, key prefix(es), and `FT.CREATE FILTER` expression,
enabling per-team filtered indexes, blue/green index aliasing, and CQRS
read-side patterns without modifying the shared entity class.

## Changes

- **`@IndexingOptions`**: new `filter()` and `prefixes()` attributes. Filter
  precedence is `@Document` → entity-level `@IndexingOptions` →
  repository-level `@IndexingOptions`.
- **Repository factories**: `RedisDocumentRepositoryFactory` and
  `RedisEnhancedRepositoryFactory` now thread the repository interface class
  through to `SimpleRedis{Document,Enhanced}Repository`, which resolves the
  repository-level index name (with SpEL evaluation) and routes `findAll`,
  `count`, `findAll(Pageable)`, and `getIds` through it. The existing
  no-interface constructors are preserved for backward compatibility.
- **`RediSearchIndexer`**: new `createIndexFor(Class, IndexingOptions)`
  overload that applies repository-level overrides, and `evaluateExpression`
  is exposed so repositories can resolve SpEL in index names. The
  `createIndexDefinition` pipeline accepts an optional repository-level
  `@IndexingOptions` to apply its `filter()` last.
- **`RedisModulesConfiguration`**: scans repository beans (with a classpath
  fallback) for `@IndexingOptions` and creates the corresponding repository-
  level indexes at startup.
- **`EntityStream`**: new `of(Class, String searchIndex)` overload so ad-hoc
  streams can target a custom index. The existing three-argument overload now
  honors its `idField` parameter, and both overloads fall back cleanly when
  the entity lacks an `@Id` annotation.
- **Integration tests** (`SeparateIndexDefinitionTest`, `Ticket`,
  `AllTicketsRepository`, `TeamATicketRepository`, `TeamBTicketRepository`)
  cover: the default repository returning all documents; per-team filtered
  repositories returning only their subset; cross-repository save-and-query;
  `EntityStream` targeting a custom index; and coexistence with entity-level
  `@IndexingOptions`.

## Notes

`FT.CREATE FILTER` uses the RediSearch aggregation expression language
(e.g. `@team=="TeamA"`), not the `FT.SEARCH` query syntax
(e.g. `@team:{TeamA}`). The `@IndexingOptions#filter` Javadoc has been
updated to call this out.

## Test plan

- [x] `./gradlew :tests:test --tests "com.redis.om.spring.annotations.document.SeparateIndexDefinitionTest"` (7/7 pass)
- [x] `./gradlew :tests:test --tests "com.redis.om.spring.search.stream.*"` (all pass, including `DetachedEntityStream{Docs,Hash}Test` which exercise the three-argument `of(...)` overload with a non-`@Id` POJO)
- [x] `./gradlew build` (full multi-module build green, 1745 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes index creation and repository query routing to support multiple filtered/prefixed indexes per entity; misconfiguration or filter/prefix mistakes could lead to missing/partial query results or unexpected index creation at startup.
> 
> **Overview**
> Enables **separate RediSearch index definitions per repository** by allowing `@IndexingOptions` on repository interfaces, including new `filter` and multi-`prefixes` support with SpEL evaluation and defined precedence (document → entity → repository).
> 
> Startup index creation now scans repositories for `@IndexingOptions` and creates the corresponding repo-level indexes, while `RediSearchIndexer` gains shared helpers plus a new `createIndexFor(entity, IndexingOptions)` path (including filter and prefix handling). Repositories created by `RedisDocumentRepositoryFactory`/`RedisEnhancedRepositoryFactory` now receive the repository interface and, when a repo-level index is configured, route `findAll`/`count`/paging and `EntityStream` queries through that index; `EntityStream` also adds an `of(entityClass, searchIndex)` overload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5de25f1d4df125bb2254ddcb8fc924cdad0eb946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->