### PR TITLE
ci: parallel test sharding, Redis 8 test fixes, and temurin JDK across all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,34 @@ on:
   pull_request:
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
 
+  # ── 1. Format check (fast, ~30s, no Docker needed) ──────────────────────────
+  style:
+    name: Code Style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Spotless check
+        run: ./gradlew spotlessCheck -S
+
+  # ── 2. Compile (fast, ~1–2 min, no tests, no Docker) ────────────────────────
+  compile:
+    name: Compile
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -32,18 +56,48 @@ jobs:
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
           restore-keys: ${{ runner.os }}-gradlew-
 
-      - name: Code Style Check
-        run: |
-          ./gradlew spotlessCheck -S
+      - name: Compile (no tests)
+        run: ./gradlew assemble -S
 
-      - name: Build
-        run: |
-          ./gradlew build aggregateTestReport -S
+  # ── 3. Integration tests — 4 shards run in parallel on separate runners ───────
+  test:
+    name: Tests (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    needs: compile          # only run if compile passes
+    strategy:
+      matrix:
+        shard: [document, hash, stream, other]
+      fail-fast: false      # let all shards finish even if one fails
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Run tests (${{ matrix.shard }})
+        run: ./gradlew :tests:test aggregateTestReport -PtestShard=${{ matrix.shard }} -S
 
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
-          path: |
-            build/reports/tests/aggregate/
+          name: test-reports-${{ matrix.shard }}
+          path: build/reports/tests/aggregate/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: Cache Gradle
         uses: actions/cache@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,14 @@ jobs:
           java-version: 21
           distribution: 'temurin'
 
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Cache Gradle wrapper
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,11 +101,11 @@ jobs:
           restore-keys: ${{ runner.os }}-gradlew-
 
       - name: Run tests (${{ matrix.shard }})
-        run: ./gradlew :tests:test aggregateTestReport -PtestShard=${{ matrix.shard }} -S
+        run: ./gradlew :tests:test -PtestShard=${{ matrix.shard }} -S
 
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: test-reports-${{ matrix.shard }}
-          path: build/reports/tests/aggregate/
+          path: tests/build/reports/tests/test/

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: Cache Gradle
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 21
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: Cache Gradle
         uses: actions/cache@v4

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -128,6 +128,13 @@ ext.testShards = [
 		'com.redis.om.spring.repository.**',
 		'com.redis.om.spring.tuple.**',
 		'com.redis.om.spring.util.**',
+		// Root-level classes in com.redis.om.spring.annotations (not in a sub-package)
+		'com.redis.om.spring.annotations.LexicographicDebugTest',
+		'com.redis.om.spring.annotations.LexicographicIndexTest',
+		'com.redis.om.spring.annotations.LexicographicLessThanDebugTest',
+		'com.redis.om.spring.annotations.LexicographicMinimalTest',
+		'com.redis.om.spring.annotations.LexicographicQueryDebugTest',
+		'com.redis.om.spring.annotations.NestedArrayIndexingTest',
 		// Root-level test classes not covered by any sub-package above
 		'com.redis.om.spring.LargeNumberOfKeysDocsTest',
 		'com.redis.om.spring.RedisEnhancedKeyValueAdapterTest',

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -96,6 +96,45 @@ compileTestJava {
 	options.generatedSourceOutputDirectory = file("${buildDir}/generated/sources/annotationProcessor/java/test")
 }
 
+// Test-shard definitions — used by CI to run tests in parallel.
+// Each shard runs on its own runner with its own Testcontainers Redis instance,
+// so there are no shared-state conflicts.
+//
+// Usage:  ./gradlew :tests:test -PtestShard=document   (or hash | stream | other)
+// Omit -PtestShard to run the full suite (local dev / single-job CI).
+ext.testShards = [
+    document: [
+        'com.redis.om.spring.annotations.document.**',
+    ],
+    hash: [
+        'com.redis.om.spring.annotations.hash.**',
+    ],
+    stream: [
+        'com.redis.om.spring.search.stream.**',
+    ],
+    other: [
+        'com.redis.om.spring.annotations.autocompletable.**',
+        'com.redis.om.spring.annotations.bloom.**',
+        'com.redis.om.spring.annotations.countmin.**',
+        'com.redis.om.spring.annotations.cuckoo.**',
+        'com.redis.om.spring.client.**',
+        'com.redis.om.spring.fixtures.**',
+        'com.redis.om.spring.id.**',
+        'com.redis.om.spring.indexing.**',
+        'com.redis.om.spring.issues.**',
+        'com.redis.om.spring.mapping.**',
+        'com.redis.om.spring.metamodel.**',
+        'com.redis.om.spring.ops.**',
+        'com.redis.om.spring.repository.**',
+        'com.redis.om.spring.tuple.**',
+        'com.redis.om.spring.util.**',
+        // Root-level test classes not covered by any sub-package above
+        'com.redis.om.spring.LargeNumberOfKeysDocsTest',
+        'com.redis.om.spring.RedisEnhancedKeyValueAdapterTest',
+        'com.redis.om.spring.RedisJSONKeyValueAdapterTest',
+    ],
+]
+
 test {
 	useJUnitPlatform()
 	maxHeapSize = "1g"
@@ -103,5 +142,17 @@ test {
 	testLogging {
 		events "passed", "skipped", "failed"
 		exceptionFormat = 'full'
+	}
+
+	// Apply shard filter when -PtestShard=<name> is supplied.
+	if (project.hasProperty('testShard')) {
+		def shard = project.property('testShard') as String
+		def patterns = testShards[shard]
+		if (patterns == null) {
+			throw new GradleException("Unknown testShard '${shard}'. Valid values: ${testShards.keySet().join(', ')}")
+		}
+		filter {
+			patterns.each { includeTestsMatching it }
+		}
 	}
 }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -103,36 +103,36 @@ compileTestJava {
 // Usage:  ./gradlew :tests:test -PtestShard=document   (or hash | stream | other)
 // Omit -PtestShard to run the full suite (local dev / single-job CI).
 ext.testShards = [
-    document: [
-        'com.redis.om.spring.annotations.document.**',
-    ],
-    hash: [
-        'com.redis.om.spring.annotations.hash.**',
-    ],
-    stream: [
-        'com.redis.om.spring.search.stream.**',
-    ],
-    other: [
-        'com.redis.om.spring.annotations.autocompletable.**',
-        'com.redis.om.spring.annotations.bloom.**',
-        'com.redis.om.spring.annotations.countmin.**',
-        'com.redis.om.spring.annotations.cuckoo.**',
-        'com.redis.om.spring.client.**',
-        'com.redis.om.spring.fixtures.**',
-        'com.redis.om.spring.id.**',
-        'com.redis.om.spring.indexing.**',
-        'com.redis.om.spring.issues.**',
-        'com.redis.om.spring.mapping.**',
-        'com.redis.om.spring.metamodel.**',
-        'com.redis.om.spring.ops.**',
-        'com.redis.om.spring.repository.**',
-        'com.redis.om.spring.tuple.**',
-        'com.redis.om.spring.util.**',
-        // Root-level test classes not covered by any sub-package above
-        'com.redis.om.spring.LargeNumberOfKeysDocsTest',
-        'com.redis.om.spring.RedisEnhancedKeyValueAdapterTest',
-        'com.redis.om.spring.RedisJSONKeyValueAdapterTest',
-    ],
+	document: [
+		'com.redis.om.spring.annotations.document.**',
+	],
+	hash: [
+		'com.redis.om.spring.annotations.hash.**',
+	],
+	stream: [
+		'com.redis.om.spring.search.stream.**',
+	],
+	other: [
+		'com.redis.om.spring.annotations.autocompletable.**',
+		'com.redis.om.spring.annotations.bloom.**',
+		'com.redis.om.spring.annotations.countmin.**',
+		'com.redis.om.spring.annotations.cuckoo.**',
+		'com.redis.om.spring.client.**',
+		'com.redis.om.spring.fixtures.**',
+		'com.redis.om.spring.id.**',
+		'com.redis.om.spring.indexing.**',
+		'com.redis.om.spring.issues.**',
+		'com.redis.om.spring.mapping.**',
+		'com.redis.om.spring.metamodel.**',
+		'com.redis.om.spring.ops.**',
+		'com.redis.om.spring.repository.**',
+		'com.redis.om.spring.tuple.**',
+		'com.redis.om.spring.util.**',
+		// Root-level test classes not covered by any sub-package above
+		'com.redis.om.spring.LargeNumberOfKeysDocsTest',
+		'com.redis.om.spring.RedisEnhancedKeyValueAdapterTest',
+		'com.redis.om.spring.RedisJSONKeyValueAdapterTest',
+	],
 ]
 
 test {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -102,7 +102,12 @@ compileTestJava {
 //
 // Usage:  ./gradlew :tests:test -PtestShard=document   (or hash | stream | other)
 // Omit -PtestShard to run the full suite (local dev / single-job CI).
-ext.testShards = [
+//
+// The 'other' shard is a catch-all: it includes everything under
+// com.redis.om.spring.** and excludes the patterns claimed by the named shards.
+// This means any new test package is automatically picked up without having to
+// add it here explicitly.
+ext.namedShards = [
 	document: [
 		'com.redis.om.spring.annotations.document.**',
 	],
@@ -111,34 +116,6 @@ ext.testShards = [
 	],
 	stream: [
 		'com.redis.om.spring.search.stream.**',
-	],
-	other: [
-		'com.redis.om.spring.annotations.autocompletable.**',
-		'com.redis.om.spring.annotations.bloom.**',
-		'com.redis.om.spring.annotations.countmin.**',
-		'com.redis.om.spring.annotations.cuckoo.**',
-		'com.redis.om.spring.client.**',
-		'com.redis.om.spring.fixtures.**',
-		'com.redis.om.spring.id.**',
-		'com.redis.om.spring.indexing.**',
-		'com.redis.om.spring.issues.**',
-		'com.redis.om.spring.mapping.**',
-		'com.redis.om.spring.metamodel.**',
-		'com.redis.om.spring.ops.**',
-		'com.redis.om.spring.repository.**',
-		'com.redis.om.spring.tuple.**',
-		'com.redis.om.spring.util.**',
-		// Root-level classes in com.redis.om.spring.annotations (not in a sub-package)
-		'com.redis.om.spring.annotations.LexicographicDebugTest',
-		'com.redis.om.spring.annotations.LexicographicIndexTest',
-		'com.redis.om.spring.annotations.LexicographicLessThanDebugTest',
-		'com.redis.om.spring.annotations.LexicographicMinimalTest',
-		'com.redis.om.spring.annotations.LexicographicQueryDebugTest',
-		'com.redis.om.spring.annotations.NestedArrayIndexingTest',
-		// Root-level test classes not covered by any sub-package above
-		'com.redis.om.spring.LargeNumberOfKeysDocsTest',
-		'com.redis.om.spring.RedisEnhancedKeyValueAdapterTest',
-		'com.redis.om.spring.RedisJSONKeyValueAdapterTest',
 	],
 ]
 
@@ -154,12 +131,19 @@ test {
 	// Apply shard filter when -PtestShard=<name> is supplied.
 	if (project.hasProperty('testShard')) {
 		def shard = project.property('testShard') as String
-		def patterns = testShards[shard]
-		if (patterns == null) {
-			throw new GradleException("Unknown testShard '${shard}'. Valid values: ${testShards.keySet().join(', ')}")
+		def validShards = namedShards.keySet() + ['other']
+		if (!validShards.contains(shard)) {
+			throw new GradleException("Unknown testShard '${shard}'. Valid values: ${validShards.join(', ')}")
 		}
 		filter {
-			patterns.each { includeTestsMatching it }
+			if (shard == 'other') {
+				// Catch-all: everything not claimed by a named shard.
+				// New test packages are automatically included here.
+				includeTestsMatching 'com.redis.om.spring.**'
+				namedShards.values().flatten().each { excludeTestsMatching it }
+			} else {
+				namedShards[shard].each { includeTestsMatching it }
+			}
 		}
 	}
 }

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/RedisDocumentSearchTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/RedisDocumentSearchTest.java
@@ -123,19 +123,30 @@ class RedisDocumentSearchTest extends AbstractBaseDocumentTest {
    * @Aggregation(load = {"$.tag[1]", "AS", "tag2"})
    * }</pre>
    * <pre>
-   * > FT.AGGREGATE idx * LOAD 3 $.tag[1] AS tag2 1) (integer) 1
+   * > FT.AGGREGATE idx * LOAD 3 $.tag[1] AS tag2
+   * 1) (integer) 2
    * 2) 1) "tag2"
-   * 2) "article"
+   *    2) "article"
+   * 3) 1) "tag2"
+   *    2) "articulo"
    * </pre>
+   * The wildcard {@code *} matches all documents in the index (both doc1 and
+   * doc2 are loaded), so {@code getTotalResults()} returns 2 — one row per
+   * document. Redis 8 / modern RediSearch correctly reports the number of
+   * result rows here, unlike older Redis Stack releases.
    */
   @Test
   void testAggregationAnnotation01() {
     AggregationResult result = repository.getSecondTagWithAggregation();
-    assertEquals(1, result.getTotalResults());
+    // Both documents match the wildcard, so we get one row per document.
+    assertEquals(2, result.getTotalResults());
     Row row = result.getRow(0);
 
     assertAll( //
-        () -> assertThat(row).isNotNull(), () -> assertThat(row.getString("tag2")).isIn("news", "article"));
+        () -> assertThat(row).isNotNull(),
+        // doc1.tag[1] ∈ {"news","article"}, doc2.tag[1] ∈ {"noticias","articulo"} —
+        // either document may appear first depending on Redis internal ordering.
+        () -> assertThat(row.getString("tag2")).isIn("news", "article", "noticias", "articulo"));
   }
 
   @Test

--- a/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamHashTest.java
@@ -7,8 +7,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,25 +47,38 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
 
   private UnifiedJedis jedis;
 
+  @AfterEach
+  void afterEach() {
+    // Remove all hashbike keys so the next test (or next test class on the
+    // shared Testcontainers instance) starts from a completely clean state.
+    Set<String> staleKeys = template.keys("hashbike:*");
+    if (staleKeys != null && !staleKeys.isEmpty()) {
+      template.delete(staleKeys);
+    }
+    if (jedis != null) {
+      jedis.close();
+    }
+  }
+
   @BeforeEach
   void beforeEach() {
     jedis = new JedisPooled(Objects.requireNonNull(jedisConnectionFactory.getPoolConfig()), jedisConnectionFactory
         .getHostName(), jedisConnectionFactory.getPort());
 
+    // Drop the index if it exists from a previous run.
     try {
       jedis.ftDropIndex("idx:hashbikes");
     } catch (JedisDataException e) {
       //Do Nothing
     }
 
-    SchemaField[] schema = { redis.clients.jedis.search.schemafields.TextField.of("brand").as("brand"),
-        redis.clients.jedis.search.schemafields.TextField.of("model").as("model"),
-        redis.clients.jedis.search.schemafields.TextField.of("description").as("description"),
-        redis.clients.jedis.search.schemafields.NumericField.of("price").as("price"),
-        redis.clients.jedis.search.schemafields.TagField.of("condition").as("condition") };
-
-    jedis.ftCreate("idx:hashbikes", FTCreateParams.createParams().on(IndexDataType.HASH).addPrefix("hashbike:"),
-        schema);
+    // Remove any stale hashbike hash keys before inserting fresh data.
+    // Without this, ftCreate re-indexes leftover keys from the reused
+    // Testcontainers Redis instance, causing null deserialization entries.
+    Set<String> staleKeys = template.keys("hashbike:*");
+    if (staleKeys != null && !staleKeys.isEmpty()) {
+      template.delete(staleKeys);
+    }
 
     Bicycle[] bicycles = { new Bicycle("hashbike:0", "Velorim", "Jigger", 270.0, "new",
         "Small and powerful, the Jigger is the best ride " + "for the smallest of tikes! This is the tiniest " + "kids’ pedal bike on the market available without" + " a coaster brake, the Jigger is the vehicle of " + "choice for the rare tenacious little rider " + "raring to go."),
@@ -90,6 +105,17 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
       var map = convertBicycleToStringMap(bicycle);
       jedis.hset(bicycle.getId(), map);
     }
+
+    // Create the index AFTER data is in place so it indexes exactly these
+    // 10 keys and nothing else.
+    SchemaField[] schema = { redis.clients.jedis.search.schemafields.TextField.of("brand").as("brand"),
+        redis.clients.jedis.search.schemafields.TextField.of("model").as("model"),
+        redis.clients.jedis.search.schemafields.TextField.of("description").as("description"),
+        redis.clients.jedis.search.schemafields.NumericField.of("price").as("price"),
+        redis.clients.jedis.search.schemafields.TagField.of("condition").as("condition") };
+
+    jedis.ftCreate("idx:hashbikes", FTCreateParams.createParams().on(IndexDataType.HASH).addPrefix("hashbike:"),
+        schema);
   }
 
   @Test

--- a/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamHashTest.java
@@ -72,13 +72,28 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
       //Do Nothing
     }
 
-    // Remove any stale hashbike hash keys before inserting fresh data.
-    // Without this, ftCreate re-indexes leftover keys from the reused
-    // Testcontainers Redis instance, causing null deserialization entries.
+    // Remove any stale hashbike hash keys before creating the index.
+    // ftCreate with addPrefix("hashbike:") triggers an asynchronous background
+    // scan of existing keys — stale keys from a previous test run on the reused
+    // Testcontainers instance could be picked up and cause null deserialization.
+    // Deleting them first means the index starts empty; each subsequent hset
+    // then triggers a synchronous per-key index update, so all 10 entries are
+    // guaranteed to be indexed before the test search runs.
     Set<String> staleKeys = template.keys("hashbike:*");
     if (staleKeys != null && !staleKeys.isEmpty()) {
       template.delete(staleKeys);
     }
+
+    SchemaField[] schema = { redis.clients.jedis.search.schemafields.TextField.of("brand").as("brand"),
+        redis.clients.jedis.search.schemafields.TextField.of("model").as("model"),
+        redis.clients.jedis.search.schemafields.TextField.of("description").as("description"),
+        redis.clients.jedis.search.schemafields.NumericField.of("price").as("price"),
+        redis.clients.jedis.search.schemafields.TagField.of("condition").as("condition") };
+
+    // Create the index before inserting data. Each hset below will trigger a
+    // synchronous per-key index update, so all entries are indexed immediately.
+    jedis.ftCreate("idx:hashbikes", FTCreateParams.createParams().on(IndexDataType.HASH).addPrefix("hashbike:"),
+        schema);
 
     Bicycle[] bicycles = { new Bicycle("hashbike:0", "Velorim", "Jigger", 270.0, "new",
         "Small and powerful, the Jigger is the best ride " + "for the smallest of tikes! This is the tiniest " + "kids’ pedal bike on the market available without" + " a coaster brake, the Jigger is the vehicle of " + "choice for the rare tenacious little rider " + "raring to go."),
@@ -105,17 +120,6 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
       var map = convertBicycleToStringMap(bicycle);
       jedis.hset(bicycle.getId(), map);
     }
-
-    // Create the index AFTER data is in place so it indexes exactly these
-    // 10 keys and nothing else.
-    SchemaField[] schema = { redis.clients.jedis.search.schemafields.TextField.of("brand").as("brand"),
-        redis.clients.jedis.search.schemafields.TextField.of("model").as("model"),
-        redis.clients.jedis.search.schemafields.TextField.of("description").as("description"),
-        redis.clients.jedis.search.schemafields.NumericField.of("price").as("price"),
-        redis.clients.jedis.search.schemafields.TagField.of("condition").as("condition") };
-
-    jedis.ftCreate("idx:hashbikes", FTCreateParams.createParams().on(IndexDataType.HASH).addPrefix("hashbike:"),
-        schema);
   }
 
   @Test

--- a/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/EntityStreamDocsTest.java
@@ -62,7 +62,13 @@ class EntityStreamDocsTest extends AbstractBaseDocumentTest {
 
   @BeforeEach
   void cleanUp() {
-    if (repository.count() == 0) {
+    // Use count != 3 (not count == 0) so that stale Company data left in the
+    // shared Testcontainers Redis instance by a previous test class is purged
+    // before we call findAll().  When count is already 3 the within-class
+    // optimisation still applies and we skip the re-insert.
+    if (repository.count() != 3) {
+      repository.deleteAll();
+
       Company redis = repository.save(Company.of( //
           "RedisInc", 2011, //
           LocalDate.of(2021, 5, 1), //


### PR DESCRIPTION
## Summary

Infrastructure-only PR — no changes to application or library code.

Covers three areas:

### 1. Redis 8 test fixes

**`testAggregationAnnotation01`** — Redis 8 / modern RediSearch correctly returns `getTotalResults()` as the actual matched row count. Old Redis Stack returned `1` for a wildcard aggregate without `GROUPBY`; Redis 8 returns `2` (one per document). Updated the assertion and Javadoc example output.

**`EntityStreamDocsTest` stale container data** — The suite shares a Testcontainers Redis instance (`withReuse=true`) with no `@AfterEach deleteAll()`. A previous test class can leave Company keys that jedis 7.3.0 cannot decode, causing `@BeforeEach` to throw:
```
NullPointerException: Cannot read the array length because "bytes" is null
  at SafeEncoder.encode
```
Changed the setup guard from `count() == 0` → `count() != 3`, adding `deleteAll()` before re-inserting so stale data is always purged.

**`DetachedEntityStreamHashTest` stale hash keys** — `@BeforeEach` dropped and recreated `idx:hashbikes` but never deleted the actual `hashbike:*` hash keys. `ftCreate` with a key prefix triggers an asynchronous background scan of existing keys — stale keys from a previous run caused null deserialization entries or missing results. Fix: delete stale keys before `ftCreate` (so the index starts empty), then `hset` x10 (each `hset` triggers a synchronous per-key index update). Added `@AfterEach` to clean up keys and close the `JedisPooled` connection.

### 2. Parallel test sharding

The single sequential test job is replaced with a **4-way GitHub Actions matrix** — each shard runs on its own runner with its own Testcontainers Redis instance, eliminating shared-state conflicts and cutting wall-clock CI time roughly 4×:

| Shard | Covers |
|-------|--------|
| `document` | `com.redis.om.spring.annotations.document.**` |
| `hash` | `com.redis.om.spring.annotations.hash.**` |
| `stream` | `com.redis.om.spring.search.stream.**` |
| `other` | catch-all — everything not claimed by the three named shards; new test packages are picked up automatically |

`tests/build.gradle` gains an `ext.namedShards` map and a `testShard` Gradle property so shards can also be run locally:
```
./gradlew :tests:test -PtestShard=document
```
The `other` shard uses `includeTestsMatching 'com.redis.om.spring.**'` + `excludeTestsMatching` for the three named shards' patterns, so it never silently drops newly added test packages.

### 3. Temurin JDK across all workflows

Azul's CDN (`distribution: 'zulu'`) returns intermittent HTTP 520 Cloudflare errors at the `Set up Java` step. All four workflow files are switched to Eclipse Adoptium (`distribution: 'temurin'`), which uses a separate, stable CDN. Java 21 functionality is identical.

| Workflow | Before | After |
|----------|--------|-------|
| `build.yml` | `zulu` | `temurin` |
| `docs.yml` | `zulu` | `temurin` |
| `early-access.yml` | `zulu` | `temurin` |
| `release.yml` | `zulu` | `temurin` |

The `build.yml` is also restructured into three jobs — **Code Style** (`spotlessCheck`), **Compile** (`assemble`), and **Tests** (matrix) — so style and compile failures surface fast without waiting for Docker.

## CI Results

**Before** (single sequential job):
<img width="1185" height="558" alt="before 2026-05-28" src="https://github.com/user-attachments/assets/0483b083-8d32-4518-a05b-b1e3dc22fe8a" />

**After** (parallel matrix, this PR):
<img width="1179" height="717" alt="after 2026-05-28 png" src="https://github.com/user-attachments/assets/bd49e053-42ce-4b16-a2fa-1d006a888b18" />

## Test plan

- [x] `./gradlew :tests:test -PtestShard=document` — `testAggregationAnnotation01` passes
- [x] `./gradlew :tests:test -PtestShard=stream` — `testFlatMapToDouble` and `DetachedEntityStreamHashTest` pass
- [x] CI: all 4 shards green, style and compile jobs green