### PR TITLE
fix: use built-in github.token for cancel-workflow-action in early-access

### DIFF
--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -3,6 +3,7 @@ name: 'Early Access'
 on:
   push:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   earlyaccess:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -3,7 +3,6 @@ name: 'Early Access'
 on:
   push:
     branches: [ main ]
-  workflow_dispatch:
 
 jobs:
   earlyaccess:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Cancel previous run
         uses: styfle/cancel-workflow-action@0.12.1
         with:
-          access_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          access_token: ${{ github.token }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The early-access workflow has been failing on every push to `main` since ~April 10th with:

\`\`\`
Error: Bad credentials
\`\`\`

The `styfle/cancel-workflow-action` step uses `secrets.GIT_ACCESS_TOKEN` which has expired or been rotated.

## Fix

Replace `secrets.GIT_ACCESS_TOKEN` with `github.token` — the built-in token GitHub provisions automatically for every workflow run. It has sufficient permissions to cancel workflows on the same repo and never expires.

## Notes

- The rest of the workflow (build, snapshot publish) still uses `secrets.GIT_ACCESS_TOKEN` via JReleaser where a PAT with broader permissions is legitimately needed
- This change only affects the cancel step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI credential swap for workflow cancellation only; no application, auth, or release logic changes.
> 
> **Overview**
> The **Early Access** workflow’s first step (`styfle/cancel-workflow-action`) now authenticates with **`github.token`** instead of **`secrets.GIT_ACCESS_TOKEN`**, so canceling in-flight runs on `main` no longer depends on a PAT that was failing with “Bad credentials.”
> 
> **JReleaser** snapshot release and related env vars in the same file are unchanged and still use **`GIT_ACCESS_TOKEN`** where broader GitHub permissions are required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1daa4d850121594ca89a27393388778fbbadf2e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->