### PR TITLE
security: harden CI for external PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code owners are automatically requested for review on all PRs.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @bsbodden @sagile
+* @sagile @foogaro

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners are automatically requested for review on all PRs.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @redis/redis-om-spring-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # Code owners are automatically requested for review on all PRs.
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @redis/redis-om-spring-maintainers
+* @bsbodden @sagile

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,6 @@
 
 ## Checklist
 
-- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md) (if present)
 - [ ] My code follows the existing code style (`./gradlew spotlessCheck`)
 - [ ] I have added or updated tests for the changes
 - [ ] All tests pass locally (`./gradlew test`)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Description
+
+<!-- What does this PR do? Why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Refactor / cleanup
+
+## How has this been tested?
+
+<!-- Describe the tests you ran and how to reproduce them. -->
+
+## Checklist
+
+- [ ] I have read the [contributing guidelines](../CONTRIBUTING.md) (if present)
+- [ ] My code follows the existing code style (`./gradlew spotlessCheck`)
+- [ ] I have added or updated tests for the changes
+- [ ] All tests pass locally (`./gradlew test`)
+- [ ] I have updated documentation where needed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   # ── 1. Format check (fast, ~30s, no Docker needed) ──────────────────────────
@@ -10,16 +13,16 @@ jobs:
     name: Code Style
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'temurin'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -27,7 +30,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -41,16 +44,16 @@ jobs:
     name: Compile
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'temurin'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -58,7 +61,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -77,16 +80,16 @@ jobs:
         shard: [document, hash, stream, other]
       fail-fast: false      # let all shards finish even if one fails
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'temurin'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -94,7 +97,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -105,7 +108,7 @@ jobs:
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test-reports-${{ matrix.shard }}
           path: tests/build/reports/tests/test/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,15 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write  # needed for jreleaser to create releases/tags
+  actions: write   # needed for styfle/cancel-workflow-action with github.token
 
 jobs:
   earlyaccess:

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -4,29 +4,32 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write  # needed for jreleaser to create releases/tags
+
 jobs:
   earlyaccess:
     name: 'Early Access'
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous run
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # 0.12.1
         with:
           access_token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'temurin'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -34,7 +37,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -46,7 +49,7 @@ jobs:
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test-report
           path: |
@@ -58,7 +61,7 @@ jobs:
         run: |
           BASE_VERSION=$(grep '^version\s*=\s*' gradle.properties | cut -d'=' -f2 | xargs)
           echo "BASE_VERSION=$BASE_VERSION" >> "$GITHUB_OUTPUT"
-          
+
           # Check if current version is already a release (RC, SNAPSHOT, or tagged release)
           if [[ "$BASE_VERSION" == *-SNAPSHOT ]] || [[ "$BASE_VERSION" == *-RC* ]]; then
             echo "SHOULD_RELEASE_SNAPSHOT=false" >> "$GITHUB_OUTPUT"
@@ -79,7 +82,7 @@ jobs:
 
       - name: Release Snapshot
         if: ${{ steps.vars.outputs.SHOULD_RELEASE_SNAPSHOT == 'true' }}
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5  # 2.5.0
         with:
           arguments: release
           version: 'latest'
@@ -97,7 +100,7 @@ jobs:
 
       - name: JReleaser output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: artifact
           path: |

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Cancel previous run
         uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # 0.12.1
         with:
-          access_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          access_token: ${{ github.token }}
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,3 +233,4 @@ See [specs/README.md](specs/README.md) for the full convention.
 
 <!-- Append a one-liner per merged spec as features land -->
 <!-- Format: - <slug>: what shipped -->
+- agentic-dev-setup: AGENTS.md, CLAUDE.md, specs workflow, speckit skills (specify/plan/tasks/implement), .java-version


### PR DESCRIPTION
## Summary

- **Pin all GitHub Actions to immutable commit SHAs** — prevents supply chain attacks where a mutable tag (e.g. `@v4`) is silently redirected to malicious code
- **Add `permissions: contents: read`** to `build.yml` — fork PRs now run with a read-only token instead of the broad default; `early-access.yml` gets `contents: write` (minimum needed for jreleaser to publish releases, and that workflow only triggers on push to `main`)
- **Add dependency-review workflow** — blocks PRs that introduce dependencies with known CVEs
- **Add `CODEOWNERS`** — maintainers are auto-requested for review on every PR; pair with branch protection "Require review from Code Owners" to enforce this
- **Add PR template** — sets contributor expectations with a checklist (tests, style check, docs)
- **Fix: use `github.token` for cancel-workflow-action** (incorporates [#736](https://github.com/redis/redis-om-spring/pull/736)) — the built-in token is sufficient and never expires
- **Docs: log agentic-dev-setup in AGENTS.md Recent Changes** (incorporates [#735](https://github.com/redis/redis-om-spring/pull/735))

## Follow-up required in GitHub Settings (cannot be done via files)

Enable on `main` branch protection:
- [ ] Require review from Code Owners
- [ ] Require status checks: `Code Style`, `Compile`, `Tests (document)`, `Tests (hash)`, `Tests (stream)`, `Tests (other)`, `Dependency Review`
- [ ] Block force pushes

## Test plan

- [ ] Verify `build.yml` triggers on a fork PR and the token has only `contents: read`
- [ ] Verify `early-access.yml` still publishes snapshots on push to `main`
- [ ] Verify `dependency-review` workflow appears in PR checks
- [ ] Close [#735](https://github.com/redis/redis-om-spring/pull/735) and [#736](https://github.com/redis/redis-om-spring/pull/736) as superseded by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI token scope and release workflow permissions; misconfiguration could block fork PR checks or break snapshot publishing on main until branch protection and settings are aligned.
> 
> **Overview**
> Hardens GitHub Actions and PR hygiene so fork PRs and CI are less exposed to supply-chain and over-privileged tokens.
> 
> **CI security:** All mutable action tags in `build.yml` and `early-access.yml` are replaced with **pinned commit SHAs**. `build.yml` and the new `dependency-review.yml` set **`permissions: contents: read`** for pull requests. `early-access.yml` declares **`contents: write`** and **`actions: write`** (minimum for JReleaser and canceling prior runs on `main` only). **`cancel-workflow-action`** now uses **`github.token`** instead of a long-lived secret.
> 
> **New automation:** **`dependency-review.yml`** runs on every PR to flag vulnerable dependency changes. **`CODEOWNERS`** auto-requests `@sagile` and `@foogaro` on all paths. A **PR template** adds description, change type, testing, and a Gradle-focused checklist.
> 
> **Docs:** `AGENTS.md` **Recent Changes** logs the merged **agentic-dev-setup** work. Branch protection still needs manual enablement for Code Owners and the new checks (not in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a064b14a28dde8801ce09e732720118818d87e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->