### PR TITLE
fix: null-safe documentToEntity for detached JSON streams

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -765,6 +765,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
       query.returnFields(returnFields.toArray(String[]::new));
     } else if (isDocument) {
+      // JSON indexes on detached indices don't always return $ unless requested explicitly
       query.returnFields("$");
     }
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -914,12 +914,20 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
     if (isDocument) {
       Object rawJson = d.get("$");
       if (rawJson == null) {
-        logger.warn("Document '" + d.getId() + "' has no '$' field; skipping entity mapping for " + entityClass
-            .getSimpleName() + ". This can happen with stale or non-JSON keys that match the index prefix.");
-        return null;
+        // "$" is absent from the FT.SEARCH result — this can happen on some Redis
+        // versions / query shapes when the root JSON projection is not returned inline.
+        // Fall back to a direct JSON.GET so the entity is never silently dropped.
+        logger.debug("Document '" + d.getId() + "' has no '$' field in FT.SEARCH result; falling back to JSON.GET.");
+        entity = json.get(d.getId(), entityClass);
+        if (entity == null) {
+          logger.warn("Document '" + d.getId() + "' not found via JSON.GET; skipping entity mapping for " + entityClass
+              .getSimpleName() + ". The key may have been deleted or is not a JSON document.");
+          return null;
+        }
+        return ObjectUtils.populateRedisKey(entity, d.getId());
       }
-      String json = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
-      entity = getGson().fromJson(json, entityClass);
+      String jsonStr = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
+      entity = getGson().fromJson(jsonStr, entityClass);
     } else {
       entity = (E) ObjectUtils.documentToObject(d, entityClass, mappingConverter);
     }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -894,8 +894,17 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
 
     // Convert aggregation results to entities
     if (isDocument) {
-      return aggResult.getResults().stream().map(d -> getGson().fromJson(d.get("$").toString(), entityClass)).collect(
-          Collectors.toList());
+      Gson g = getGson();
+      return aggResult.getResults().stream().map(d -> {
+        Object rawJson = d.get("$");
+        if (rawJson == null) {
+          logger.warn("Aggregation result has no '$' field; skipping entity mapping for " + entityClass
+              .getSimpleName());
+          return null;
+        }
+        String jsonStr = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
+        return g.fromJson(jsonStr, entityClass);
+      }).filter(Objects::nonNull).collect(Collectors.toList());
     } else {
       return aggResult.getResults().stream().map(h -> (E) ObjectUtils.mapToObject(h, entityClass, mappingConverter))
           .collect(Collectors.toList());
@@ -962,13 +971,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
   )
   private List<E> hybridDocumentsToEntities(List<redis.clients.jedis.search.Document> documents) {
     if (isDocument) {
-      Gson g = getGson();
-      return documents.stream().map(d -> {
-        Object rawJson = d.get("$");
-        String json = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
-        E entity = g.fromJson(json, entityClass);
-        return ObjectUtils.populateRedisKey(entity, d.getId());
-      }).toList();
+      return documents.stream().map(this::documentToEntity).filter(Objects::nonNull).toList();
     } else {
       return (List<E>) documents.stream().map(d -> {
         Map<String, Object> props = new HashMap<>();

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -937,7 +937,10 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
    * to a list of entity-score pairs.
    */
   private List<Pair<E, Double>> documentsToEntityScorePairs(List<redis.clients.jedis.search.Document> documents) {
-    return documents.stream().map(d -> Tuples.of(documentToEntity(d), d.getScore())).toList();
+    return documents.stream().map(d -> {
+      E entity = documentToEntity(d);
+      return entity != null ? Tuples.of(entity, d.getScore()) : null;
+    }).filter(Objects::nonNull).toList();
   }
 
   /**

--- a/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/search/stream/SearchStreamImpl.java
@@ -912,6 +912,11 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
     E entity;
     if (isDocument) {
       Object rawJson = d.get("$");
+      if (rawJson == null) {
+        logger.warn("Document '" + d.getId() + "' has no '$' field; skipping entity mapping for " + entityClass
+            .getSimpleName() + ". This can happen with stale or non-JSON keys that match the index prefix.");
+        return null;
+      }
       String json = (rawJson instanceof byte[]) ? SafeEncoder.encode((byte[]) rawJson) : rawJson.toString();
       entity = getGson().fromJson(json, entityClass);
     } else {
@@ -924,7 +929,7 @@ public class SearchStreamImpl<E> implements SearchStream<E> {
     "unchecked"
   )
   private List<E> documentsToEntities(List<redis.clients.jedis.search.Document> documents) {
-    return documents.stream().map(this::documentToEntity).toList();
+    return documents.stream().map(this::documentToEntity).filter(Objects::nonNull).toList();
   }
 
   /**

--- a/tests/src/test/java/com/redis/om/spring/search/stream/SearchStreamImplDocumentToEntityNpeTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/SearchStreamImplDocumentToEntityNpeTest.java
@@ -1,0 +1,100 @@
+package com.redis.om.spring.search.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import com.google.gson.GsonBuilder;
+import com.redis.om.spring.indexing.RediSearchIndexer;
+import com.redis.om.spring.ops.RedisModulesOperations;
+import com.redis.om.spring.ops.json.JSONOperations;
+import com.redis.om.spring.ops.search.SearchOperations;
+
+import lombok.Data;
+import redis.clients.jedis.search.Document;
+import redis.clients.jedis.search.SearchResult;
+
+/**
+ * Unit test for issue #734:
+ * SearchStreamImpl.documentToEntity() previously called rawJson.toString() without a null
+ * check. When Redis does not include "$" in the FT.SEARCH response (e.g. the
+ * index was created externally and the query specifies explicit RETURN fields
+ * that omit the root JSON projection), documentToEntity() used to throw a
+ * NullPointerException.
+ *
+ * <p>This test wires up a minimal SearchStreamImpl backed by mock
+ * SearchOperations that return a Document with no "$" field, reproducing the
+ * exact scenario described in the issue <em>without</em> requiring a running
+ * Redis instance or a specific Redis version.</p>
+ *
+ * <p>After the fix: documents with a missing "$" field are silently skipped
+ * (a warning is logged) and collect() returns an empty list instead of
+ * throwing NPE.</p>
+ */
+class SearchStreamImplDocumentToEntityNpeTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void collectSkipsDocumentWhenRootJsonFieldAbsent() throws Exception {
+    // --- mocks ---
+    SearchOperations<String> searchOps = mock(SearchOperations.class);
+    JSONOperations<String> jsonOps = mock(JSONOperations.class);
+    StringRedisTemplate template = mock(StringRedisTemplate.class);
+    RedisModulesOperations<String> modulesOps = mock(RedisModulesOperations.class);
+    RediSearchIndexer indexer = mock(RediSearchIndexer.class);
+
+    // Simulate FT.INFO: a JSON-type index
+    Map<String, Object> indexInfo = new HashMap<>();
+    indexInfo.put("index_definition", Arrays.asList("key_type", "JSON", "prefixes", Collections.emptyList()));
+    when(modulesOps.opsForSearch(anyString())).thenReturn(searchOps);
+    when(modulesOps.opsForJSON()).thenReturn(jsonOps);
+    when(modulesOps.template()).thenReturn(template);
+    when(searchOps.getInfo()).thenReturn(indexInfo);
+
+    // A document whose "$" field is absent (simulates Redis returning no root
+    // JSON payload — e.g. because of stale / non-JSON keys that share the index
+    // prefix on a reused Testcontainers instance, or externally-created indexes
+    // that omit the root projection).
+    Document docWithNullJson = new Document("bicycle:0", Collections.emptyMap());
+
+    SearchResult searchResult = mock(SearchResult.class);
+    when(searchResult.getDocuments()).thenReturn(List.of(docWithNullJson));
+    when(searchOps.search(any())).thenReturn(searchResult);
+
+    // Resolve the id field on the entity class
+    Field idField = Bicycle.class.getDeclaredField("id");
+    idField.setAccessible(true);
+
+    SearchStreamImpl<Bicycle> stream = new SearchStreamImpl<>(Bicycle.class, "idx:bicycle", idField, modulesOps,
+        new GsonBuilder(), indexer);
+
+    // After the fix: null rawJson → warning logged → entity skipped → empty result list.
+    // No NullPointerException should be thrown.
+    List<Bicycle> result = stream.collect(Collectors.toList());
+    assertThat(result).isEmpty();
+  }
+
+  // Minimal entity — intentionally has no redis-om-spring annotations so the
+  // index is treated as "externally created" (detached mode).
+  @Data
+  static class Bicycle {
+    private String id;
+    private String brand;
+    private String model;
+    private BigDecimal price;
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/search/stream/SearchStreamImplDocumentToEntityNpeTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/SearchStreamImplDocumentToEntityNpeTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -56,7 +57,7 @@ class SearchStreamImplDocumentToEntityNpeTest {
       JSONOperations<String> jsonOps) throws Exception {
     StringRedisTemplate template = mock(StringRedisTemplate.class);
     RedisModulesOperations<String> modulesOps = mock(RedisModulesOperations.class);
-    RediSearchIndexer indexer = mock(RediSearchIndexer.class);
+    RediSearchIndexer indexer = mock(RediSearchIndexer.class, RETURNS_DEEP_STUBS);
 
     Map<String, Object> indexInfo = new HashMap<>();
     indexInfo.put("index_definition", Arrays.asList("key_type", "JSON", "prefixes", Collections.emptyList()));

--- a/tests/src/test/java/com/redis/om/spring/search/stream/SearchStreamImplDocumentToEntityNpeTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/SearchStreamImplDocumentToEntityNpeTest.java
@@ -3,6 +3,7 @@ package com.redis.om.spring.search.stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -29,35 +30,34 @@ import redis.clients.jedis.search.Document;
 import redis.clients.jedis.search.SearchResult;
 
 /**
- * Unit test for issue #734:
- * SearchStreamImpl.documentToEntity() previously called rawJson.toString() without a null
- * check. When Redis does not include "$" in the FT.SEARCH response (e.g. the
- * index was created externally and the query specifies explicit RETURN fields
- * that omit the root JSON projection), documentToEntity() used to throw a
- * NullPointerException.
+ * Unit tests for the null-rawJson handling in SearchStreamImpl.documentToEntity().
  *
- * <p>This test wires up a minimal SearchStreamImpl backed by mock
- * SearchOperations that return a Document with no "$" field, reproducing the
- * exact scenario described in the issue <em>without</em> requiring a running
- * Redis instance or a specific Redis version.</p>
+ * <p>When Redis does not include "$" in the FT.SEARCH response (e.g. the index
+ * was created externally, or some Redis versions omit the root JSON projection
+ * for certain query shapes), documentToEntity() previously threw NPE at
+ * rawJson.toString().</p>
  *
- * <p>After the fix: documents with a missing "$" field are silently skipped
- * (a warning is logged) and collect() returns an empty list instead of
- * throwing NPE.</p>
+ * <p>After the fix:</p>
+ * <ul>
+ *   <li>A missing "$" triggers a fallback JSON.GET for the document key.</li>
+ *   <li>If JSON.GET succeeds the entity is returned normally.</li>
+ *   <li>If JSON.GET also returns null (key deleted / not a JSON document) the
+ *       document is silently skipped and a warning is logged.</li>
+ * </ul>
  */
 class SearchStreamImplDocumentToEntityNpeTest {
 
-  @Test
+  // -------------------------------------------------------------------------
+  // Shared mock wiring helpers
+  // -------------------------------------------------------------------------
+
   @SuppressWarnings("unchecked")
-  void collectSkipsDocumentWhenRootJsonFieldAbsent() throws Exception {
-    // --- mocks ---
-    SearchOperations<String> searchOps = mock(SearchOperations.class);
-    JSONOperations<String> jsonOps = mock(JSONOperations.class);
+  private SearchStreamImpl<Bicycle> buildStream(SearchOperations<String> searchOps,
+      JSONOperations<String> jsonOps) throws Exception {
     StringRedisTemplate template = mock(StringRedisTemplate.class);
     RedisModulesOperations<String> modulesOps = mock(RedisModulesOperations.class);
     RediSearchIndexer indexer = mock(RediSearchIndexer.class);
 
-    // Simulate FT.INFO: a JSON-type index
     Map<String, Object> indexInfo = new HashMap<>();
     indexInfo.put("index_definition", Arrays.asList("key_type", "JSON", "prefixes", Collections.emptyList()));
     when(modulesOps.opsForSearch(anyString())).thenReturn(searchOps);
@@ -65,31 +65,74 @@ class SearchStreamImplDocumentToEntityNpeTest {
     when(modulesOps.template()).thenReturn(template);
     when(searchOps.getInfo()).thenReturn(indexInfo);
 
-    // A document whose "$" field is absent (simulates Redis returning no root
-    // JSON payload — e.g. because of stale / non-JSON keys that share the index
-    // prefix on a reused Testcontainers instance, or externally-created indexes
-    // that omit the root projection).
-    Document docWithNullJson = new Document("bicycle:0", Collections.emptyMap());
+    Field idField = Bicycle.class.getDeclaredField("id");
+    idField.setAccessible(true);
 
+    return new SearchStreamImpl<>(Bicycle.class, "idx:bicycle", idField, modulesOps, new GsonBuilder(), indexer);
+  }
+
+  // -------------------------------------------------------------------------
+  // Test: fallback to JSON.GET when "$" is absent, and JSON.GET succeeds
+  // -------------------------------------------------------------------------
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void collectFallsBackToJsonGetWhenRootJsonFieldAbsent() throws Exception {
+    SearchOperations<String> searchOps = mock(SearchOperations.class);
+    JSONOperations<String> jsonOps = mock(JSONOperations.class);
+
+    // FT.SEARCH returns a document with no "$" field
+    Document docWithNullJson = new Document("bicycle:0", Collections.emptyMap());
     SearchResult searchResult = mock(SearchResult.class);
     when(searchResult.getDocuments()).thenReturn(List.of(docWithNullJson));
     when(searchOps.search(any())).thenReturn(searchResult);
 
-    // Resolve the id field on the entity class
-    Field idField = Bicycle.class.getDeclaredField("id");
-    idField.setAccessible(true);
+    // JSON.GET fallback returns the actual entity
+    Bicycle expected = new Bicycle();
+    expected.setId("bicycle:0");
+    expected.setBrand("Velorim");
+    expected.setModel("Jigger");
+    expected.setPrice(new BigDecimal("270"));
+    when(jsonOps.get(eq("bicycle:0"), eq(Bicycle.class))).thenReturn(expected);
 
-    SearchStreamImpl<Bicycle> stream = new SearchStreamImpl<>(Bicycle.class, "idx:bicycle", idField, modulesOps,
-        new GsonBuilder(), indexer);
-
-    // After the fix: null rawJson → warning logged → entity skipped → empty result list.
-    // No NullPointerException should be thrown.
+    SearchStreamImpl<Bicycle> stream = buildStream(searchOps, jsonOps);
     List<Bicycle> result = stream.collect(Collectors.toList());
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(result.get(0).getBrand()).isEqualTo("Velorim");
+  }
+
+  // -------------------------------------------------------------------------
+  // Test: document silently skipped when both "$" and JSON.GET return null
+  // -------------------------------------------------------------------------
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void collectSkipsDocumentWhenRootJsonFieldAbsentAndJsonGetReturnsNull() throws Exception {
+    SearchOperations<String> searchOps = mock(SearchOperations.class);
+    JSONOperations<String> jsonOps = mock(JSONOperations.class);
+
+    // FT.SEARCH returns a document with no "$" field
+    Document docWithNullJson = new Document("bicycle:0", Collections.emptyMap());
+    SearchResult searchResult = mock(SearchResult.class);
+    when(searchResult.getDocuments()).thenReturn(List.of(docWithNullJson));
+    when(searchOps.search(any())).thenReturn(searchResult);
+
+    // JSON.GET also returns null — key deleted or not a JSON document
+    when(jsonOps.get(eq("bicycle:0"), eq(Bicycle.class))).thenReturn(null);
+
+    SearchStreamImpl<Bicycle> stream = buildStream(searchOps, jsonOps);
+    List<Bicycle> result = stream.collect(Collectors.toList());
+
+    // No NPE; document is skipped gracefully
     assertThat(result).isEmpty();
   }
 
-  // Minimal entity — intentionally has no redis-om-spring annotations so the
-  // index is treated as "externally created" (detached mode).
+  // -------------------------------------------------------------------------
+  // Minimal entity (no redis-om-spring annotations → detached / external index)
+  // -------------------------------------------------------------------------
+
   @Data
   static class Bicycle {
     private String id;


### PR DESCRIPTION
## Problem

FT.SEARCH can return documents where the root \`\$\` JSON field is absent — this happens intermittently on detached/external indexes (e.g. reused Testcontainers instances with mixed-type keys, or certain Redis version/query-shape combinations). Previously this caused \`NullPointerException\` at \`rawJson.toString()\` inside \`documentToEntity()\`, making several \`DetachedEntityStreamDocsTest\` tests flaky.

The same unguarded \`d.get("\$").toString()\` pattern existed in three additional code paths: \`documentsToEntityScorePairs\`, \`hybridDocumentsToEntities\`, and the aggregation-to-entity loop.

## Changes

**\`SearchStreamImpl\`**
- \`documentToEntity\` — null-guard \`rawJson\`: when \`d.get("\$")\` is null, fall back to a direct \`JSON.GET\` for the document key (recovers the entity on most Redis versions). Only skip with a warning if \`JSON.GET\` also returns null (key deleted / genuinely not a JSON document)
- \`documentsToEntities\` — filter null entities via \`Objects::nonNull\`
- \`documentsToEntityScorePairs\` — same null filter so \`toListWithScores()\` callers never receive \`Pair(null, score)\` entries
- \`hybridDocumentsToEntities\` — delegate to \`documentToEntity()\` (reuses the null guard + fallback, removes duplicate deserialization code)
- Aggregation-to-entity loop — apply the same null check + \`filter(Objects::nonNull)\`
- \`prepareQuery\` — add inline comment explaining why \`returnFields("\$")\` is needed for detached JSON indexes

**\`SearchStreamImplDocumentToEntityNpeTest\`** (unit test, no Redis required)
- \`collectFallsBackToJsonGetWhenRootJsonFieldAbsent\` — verifies entity is returned when \`\$\` is absent but \`JSON.GET\` succeeds
- \`collectSkipsDocumentWhenRootJsonFieldAbsentAndJsonGetReturnsNull\` — verifies graceful empty result when both \`\$\` and \`JSON.GET\` return null

## Test plan

- [x] \`SearchStreamImplDocumentToEntityNpeTest\` — both unit tests pass locally (no Redis needed)
- [x] \`DetachedEntityStreamDocsTest\` — all 5 tests pass locally
- [ ] Full test suite on CI — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)