### PR TITLE
fix: use GIT_ACCESS_TOKEN for checkout in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Set up Java
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary
- The release workflow was failing with `Permission to redis/redis-om-spring.git denied to github-actions[bot]` when trying to push the version bump commit
- Root cause: `actions/checkout` was using the default `GITHUB_TOKEN` which lacks push rights to the `redis` org
- Fix: pass `token: ${{ secrets.GIT_ACCESS_TOKEN }}` to the checkout step so all subsequent git operations use the correct credentials

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger the Release workflow for `2.0.5`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI credential change; no application code or runtime behavior affected.
> 
> **Overview**
> The release workflow’s **Checkout** step now authenticates with **`GIT_ACCESS_TOKEN`** instead of the default **`GITHUB_TOKEN`**.
> 
> That aligns checkout with the token already used elsewhere in the job (cancel workflow, Gradle publish, JReleaser, docs dispatch). The **Bump version** step’s **`git push`** after the version commit was failing with permission denied for **`github-actions[bot]`** on the **`redis`** org repo because checkout had left git remotes on the limited default token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ed6b32e46d0c216d7bb4cd9419eefb8569b2517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->