### PR TITLE
fix: avoid full lexicographic index scans

### DIFF
--- a/demos/roms-documents/README.MD
+++ b/demos/roms-documents/README.MD
@@ -2,35 +2,145 @@
 
 This demo showcases the use of Redis OM Spring's `@Document` annotation for storing and retrieving JSON documents in Redis.
 
+## Requirements
+
+- Java 21
+- Redis Stack running on `localhost:6379`
+
+From the repository root, start the bundled Redis Stack service with:
+
+```bash
+docker compose up -d redis
+```
+
 ## Features
 
 - Demonstrates how to use the `@Document` annotation to map Java objects to Redis JSON documents
 - Shows how to create repositories that extend `RedisDocumentRepository`
-- Provides examples of querying documents using both method names and explicit queries
-- Includes REST API endpoints for CRUD operations
+- Provides examples of querying documents using method names and explicit `@Query` annotations
+- Includes REST API endpoints for document read and query operations
+- Includes an opt-in lexicographic ID range reproduction for large `@Indexed(sortable = true, lexicographic = true)` fields
 
 ## Key Components
 
-The demo includes three domain models:
+The demo includes these domain models:
+
 - Company
 - Person
 - Event
+- LexicographicIdRecord, used only by the opt-in lexicographic reproduction runner
 
-Each model is mapped as a Redis JSON document and has corresponding repository and controller classes.
-
-## Swagger Documentation
-
-The API is documented using Swagger UI, which can be accessed at:
-http://localhost:8080/swagger-ui/index.html
+Each primary model is mapped as a Redis JSON document and has corresponding repository and controller classes. The application seeds sample `Company` and `Person` data at startup.
 
 ## Running the Demo
 
-To run this demo:
+From the repository root:
 
 ```bash
 ./gradlew :demos:roms-documents:bootRun
 ```
 
+The application uses the default Spring Boot port, `8080`.
+
+## API Endpoints
+
+The demo exposes read/query endpoints under `/api`.
+
+Company endpoints:
+
+```text
+GET /api/companies/all
+GET /api/companies/all-ids
+GET /api/companies/{id}
+GET /api/companies/name/{name}
+GET /api/companies/name/starts/{prefix}
+GET /api/companies/employees/count/{count}
+GET /api/companies/employees/range/{low}/{high}
+GET /api/companies/near?lat={lat}&lon={lon}&d={distanceInMiles}
+GET /api/companies/tags?tags={tag}
+```
+
+Person endpoints:
+
+```text
+GET /api/persons/all
+GET /api/persons/all-ids
+GET /api/persons/{id}
+GET /api/persons/name/{last}/{first}
+```
+
+Event endpoints:
+
+```text
+GET /api/events/between?start={isoDateTime}&end={isoDateTime}
+```
+
+This demo does not currently configure Swagger/OpenAPI UI.
+
+## Lexicographic ID Reproduction
+
+The demo includes an opt-in runner that reproduces the large lexicographic ID range behavior for a field declared as:
+
+```java
+@Id
+@Indexed(sortable = true, lexicographic = true)
+private String id;
+```
+
+Quick run:
+
+```bash
+./gradlew :demos:roms-documents:bootRun --args='--spring.main.web-application-type=none --demo.lexicographic-repro.enabled=true --demo.lexicographic-repro.count=10000 --demo.lexicographic-repro.batch-size=1000 --demo.lexicographic-repro.update-count=100 --demo.lexicographic-repro.threshold=lex000000000'
+```
+
+Stronger signal:
+
+```bash
+./gradlew :demos:roms-documents:bootRun --args='--spring.main.web-application-type=none --demo.lexicographic-repro.enabled=true --demo.lexicographic-repro.count=50000 --demo.lexicographic-repro.batch-size=2000 --demo.lexicographic-repro.update-count=100 --demo.lexicographic-repro.threshold=lex000000000'
+```
+
+The runner has two diagnostic phases:
+
+- Clears and seeds `LexicographicIdRecord` documents
+- Rebuilds the lexicographic sorted set `lex-repro:id:lex`
+- `WRITE-SIDE CLEANUP DEMO`: updates existing records so the lexicographic indexer has to clean old ID entries
+- `MISSING QUERY FIX DEMO`: runs `LexicographicIdRecord$.ID.gt(threshold).limit(1)`
+- Logs sorted set size, query time, and heap delta
+
+What to look for in the write-side cleanup phase:
+
+```text
+WRITE-SIDE CLEANUP DEMO: older cleanup implementations used ZRANGE 0 -1 on lex-repro:id:lex once per update, materializing about 1000000 sorted-set members
+WRITE-SIDE CLEANUP DEMO: update loop completed in 51 ms
+WRITE-SIDE CLEANUP DEMO: sorted set size after updates is 10000
+```
+
+This shows why optimized write-side cleanup matters: a full-scan implementation scales with `sorted set size * update count`, while ID-field cleanup can remove exact lexicographic members directly.
+
+Then look for:
+
+```text
+MISSING QUERY FIX DEMO: ID.gt(lex000000000) has 9999 lexicographic matches in a 10000 member sorted set
+MISSING QUERY FIX DEMO: the current stream predicate still calls rangeByLex(..., Limit.unlimited()) before limit(1) is applied
+MISSING QUERY FIX DEMO: ID.gt(lex000000000) with limit(1) returned 1 record(s)
+```
+
+This shows the remaining query-side issue: `limit(1)` returns one entity, but `ID.gt(...)` still materializes all matching lexicographic IDs first.
+
+Useful properties:
+
+```text
+demo.lexicographic-repro.enabled=true
+demo.lexicographic-repro.count=50000
+demo.lexicographic-repro.batch-size=1000
+demo.lexicographic-repro.update-count=100
+demo.lexicographic-repro.threshold=lex000000000
+```
+
 ## Testing
 
 The demo includes tests demonstrating how to use Redis OM Spring in a test environment.
+
+```bash
+./gradlew :demos:roms-documents:test
+```

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/domain/LexicographicIdRecord.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/domain/LexicographicIdRecord.java
@@ -12,7 +12,9 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Document("lex-repro")
+@Document(
+  "lex-repro"
+)
 public class LexicographicIdRecord {
   @Id
   @Indexed(

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/domain/LexicographicIdRecord.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/domain/LexicographicIdRecord.java
@@ -1,0 +1,25 @@
+package com.redis.om.documents.domain;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document("lex-repro")
+public class LexicographicIdRecord {
+  @Id
+  @Indexed(
+      sortable = true, lexicographic = true
+  )
+  private String id;
+
+  @Indexed
+  private String bucket;
+}

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/repositories/LexicographicIdRecordRepository.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/repositories/LexicographicIdRecordRepository.java
@@ -1,0 +1,7 @@
+package com.redis.om.documents.repositories;
+
+import com.redis.om.documents.domain.LexicographicIdRecord;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface LexicographicIdRecordRepository extends RedisDocumentRepository<LexicographicIdRecord, String> {
+}

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/repro/LexicographicIdReproRunner.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/repro/LexicographicIdReproRunner.java
@@ -35,22 +35,22 @@ public class LexicographicIdReproRunner implements CommandLineRunner {
   private final RedisTemplate<String, String> redisTemplate;
 
   @Value(
-      "${demo.lexicographic-repro.count:50000}"
+    "${demo.lexicographic-repro.count:50000}"
   )
   private int count;
 
   @Value(
-      "${demo.lexicographic-repro.batch-size:1000}"
+    "${demo.lexicographic-repro.batch-size:1000}"
   )
   private int batchSize;
 
   @Value(
-      "${demo.lexicographic-repro.threshold:lex000000000}"
+    "${demo.lexicographic-repro.threshold:lex000000000}"
   )
   private String threshold;
 
   @Value(
-      "${demo.lexicographic-repro.update-count:100}"
+    "${demo.lexicographic-repro.update-count:100}"
   )
   private int updateCount;
 
@@ -88,8 +88,7 @@ public class LexicographicIdReproRunner implements CommandLineRunner {
     log.info("WRITE-SIDE CLEANUP DEMO: updating {} existing records whose lexicographic field is the @Id",
         actualUpdateCount);
     log.info(
-        "WRITE-SIDE CLEANUP DEMO: older cleanup implementations used ZRANGE 0 -1 on {} once per update, "
-            + "materializing about {} sorted-set members",
+        "WRITE-SIDE CLEANUP DEMO: older cleanup implementations used ZRANGE 0 -1 on {} once per update, " + "materializing about {} sorted-set members",
         LEX_SET_KEY, oldBranchMemberReads);
 
     long beforeMiB = usedHeapMiB();
@@ -104,8 +103,8 @@ public class LexicographicIdReproRunner implements CommandLineRunner {
     Long afterSize = redisTemplate.opsForZSet().size(LEX_SET_KEY);
 
     log.info("WRITE-SIDE CLEANUP DEMO: update loop completed in {} ms", elapsedMs);
-    log.info("WRITE-SIDE CLEANUP DEMO: heap before={} MiB after={} MiB delta={} MiB", beforeMiB, afterMiB, afterMiB
-        - beforeMiB);
+    log.info("WRITE-SIDE CLEANUP DEMO: heap before={} MiB after={} MiB delta={} MiB", beforeMiB, afterMiB,
+        afterMiB - beforeMiB);
     log.info("WRITE-SIDE CLEANUP DEMO: sorted set size after updates is {}", afterSize);
   }
 
@@ -114,13 +113,12 @@ public class LexicographicIdReproRunner implements CommandLineRunner {
     log.info("MISSING QUERY FIX DEMO: ID.gt({}) has {} lexicographic matches in a {} member sorted set", threshold,
         lexMatches, lexMemberCount);
     log.info(
-        "MISSING QUERY FIX DEMO: the current stream predicate still calls rangeByLex(..., Limit.unlimited()) "
-            + "before limit(1) is applied");
+        "MISSING QUERY FIX DEMO: the current stream predicate still calls rangeByLex(..., Limit.unlimited()) " + "before limit(1) is applied");
 
     long beforeMiB = usedHeapMiB();
     long startNanos = System.nanoTime();
-    List<LexicographicIdRecord> firstMatch = entityStream.of(LexicographicIdRecord.class)
-        .filter(LexicographicIdRecord$.ID.gt(threshold)) //
+    List<LexicographicIdRecord> firstMatch = entityStream.of(LexicographicIdRecord.class).filter(
+        LexicographicIdRecord$.ID.gt(threshold)) //
         .limit(1) //
         .collect(Collectors.toList());
     long elapsedMs = elapsedMs(startNanos);
@@ -128,8 +126,8 @@ public class LexicographicIdReproRunner implements CommandLineRunner {
 
     log.info("MISSING QUERY FIX DEMO: ID.gt({}) with limit(1) returned {} record(s) in {} ms", threshold, firstMatch
         .size(), elapsedMs);
-    log.info("MISSING QUERY FIX DEMO: heap before={} MiB after={} MiB delta={} MiB", beforeMiB, afterMiB, afterMiB
-        - beforeMiB);
+    log.info("MISSING QUERY FIX DEMO: heap before={} MiB after={} MiB delta={} MiB", beforeMiB, afterMiB,
+        afterMiB - beforeMiB);
   }
 
   private void seedRecords() {

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/repro/LexicographicIdReproRunner.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/repro/LexicographicIdReproRunner.java
@@ -1,0 +1,174 @@
+package com.redis.om.documents.repro;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.redis.om.documents.domain.LexicographicIdRecord;
+import com.redis.om.documents.domain.LexicographicIdRecord$;
+import com.redis.om.documents.repositories.LexicographicIdRecordRepository;
+import com.redis.om.spring.search.stream.EntityStream;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+    name = "demo.lexicographic-repro.enabled", havingValue = "true"
+)
+public class LexicographicIdReproRunner implements CommandLineRunner {
+  private static final String LEX_SET_KEY = "lex-repro:id:lex";
+
+  private final LexicographicIdRecordRepository repository;
+  private final EntityStream entityStream;
+  private final RedisTemplate<String, String> redisTemplate;
+
+  @Value(
+      "${demo.lexicographic-repro.count:50000}"
+  )
+  private int count;
+
+  @Value(
+      "${demo.lexicographic-repro.batch-size:1000}"
+  )
+  private int batchSize;
+
+  @Value(
+      "${demo.lexicographic-repro.threshold:lex000000000}"
+  )
+  private String threshold;
+
+  @Value(
+      "${demo.lexicographic-repro.update-count:100}"
+  )
+  private int updateCount;
+
+  @Override
+  public void run(String... args) {
+    log.info("LEXICOGRAPHIC REPRO: preparing {} records in batches of {}", count, batchSize);
+
+    log.info("LEXICOGRAPHIC REPRO: clearing existing records and sorted set {}", LEX_SET_KEY);
+    long cleanupStartNanos = System.nanoTime();
+    redisTemplate.delete(LEX_SET_KEY);
+    repository.deleteAll();
+    log.info("LEXICOGRAPHIC REPRO: cleanup completed in {} ms", elapsedMs(cleanupStartNanos));
+
+    long seedStartNanos = System.nanoTime();
+    seedRecords();
+    long seedElapsedMs = elapsedMs(seedStartNanos);
+
+    Long lexSetSize = redisTemplate.opsForZSet().size(LEX_SET_KEY);
+    long lexMemberCount = lexSetSize == null ? 0 : lexSetSize;
+    log.info("LEXICOGRAPHIC REPRO: seeded {} records in {} ms", count, seedElapsedMs);
+    log.info("LEXICOGRAPHIC REPRO: sorted set {} contains {} members", LEX_SET_KEY, lexMemberCount);
+
+    demonstrateWriteSideCleanup(lexMemberCount);
+    demonstrateMissingQueryFix(lexMemberCount);
+  }
+
+  private void demonstrateWriteSideCleanup(long lexMemberCount) {
+    if (count <= 0 || updateCount <= 0) {
+      log.info("WRITE-SIDE CLEANUP DEMO: skipped because count={} and update-count={}", count, updateCount);
+      return;
+    }
+
+    int actualUpdateCount = Math.min(updateCount, count);
+    long oldBranchMemberReads = lexMemberCount * actualUpdateCount;
+    log.info("WRITE-SIDE CLEANUP DEMO: updating {} existing records whose lexicographic field is the @Id",
+        actualUpdateCount);
+    log.info(
+        "WRITE-SIDE CLEANUP DEMO: older cleanup implementations used ZRANGE 0 -1 on {} once per update, "
+            + "materializing about {} sorted-set members",
+        LEX_SET_KEY, oldBranchMemberReads);
+
+    long beforeMiB = usedHeapMiB();
+    long startNanos = System.nanoTime();
+    int step = Math.max(1, count / actualUpdateCount);
+    for (int i = 0; i < actualUpdateCount; i++) {
+      int recordIndex = Math.min(count - 1, i * step);
+      repository.save(new LexicographicIdRecord(recordId(recordIndex), "updated-%02d".formatted(i % 10)));
+    }
+    long elapsedMs = elapsedMs(startNanos);
+    long afterMiB = usedHeapMiB();
+    Long afterSize = redisTemplate.opsForZSet().size(LEX_SET_KEY);
+
+    log.info("WRITE-SIDE CLEANUP DEMO: update loop completed in {} ms", elapsedMs);
+    log.info("WRITE-SIDE CLEANUP DEMO: heap before={} MiB after={} MiB delta={} MiB", beforeMiB, afterMiB, afterMiB
+        - beforeMiB);
+    log.info("WRITE-SIDE CLEANUP DEMO: sorted set size after updates is {}", afterSize);
+  }
+
+  private void demonstrateMissingQueryFix(long lexMemberCount) {
+    long lexMatches = countLexMatchesGreaterThan(threshold);
+    log.info("MISSING QUERY FIX DEMO: ID.gt({}) has {} lexicographic matches in a {} member sorted set", threshold,
+        lexMatches, lexMemberCount);
+    log.info(
+        "MISSING QUERY FIX DEMO: the current stream predicate still calls rangeByLex(..., Limit.unlimited()) "
+            + "before limit(1) is applied");
+
+    long beforeMiB = usedHeapMiB();
+    long startNanos = System.nanoTime();
+    List<LexicographicIdRecord> firstMatch = entityStream.of(LexicographicIdRecord.class)
+        .filter(LexicographicIdRecord$.ID.gt(threshold)) //
+        .limit(1) //
+        .collect(Collectors.toList());
+    long elapsedMs = elapsedMs(startNanos);
+    long afterMiB = usedHeapMiB();
+
+    log.info("MISSING QUERY FIX DEMO: ID.gt({}) with limit(1) returned {} record(s) in {} ms", threshold, firstMatch
+        .size(), elapsedMs);
+    log.info("MISSING QUERY FIX DEMO: heap before={} MiB after={} MiB delta={} MiB", beforeMiB, afterMiB, afterMiB
+        - beforeMiB);
+  }
+
+  private void seedRecords() {
+    List<LexicographicIdRecord> batch = new ArrayList<>(batchSize);
+    for (int i = 0; i < count; i++) {
+      batch.add(new LexicographicIdRecord(recordId(i), "bucket-%02d".formatted(i % 10)));
+      if (batch.size() == batchSize) {
+        repository.saveAll(batch);
+        batch.clear();
+      }
+    }
+    if (!batch.isEmpty()) {
+      repository.saveAll(batch);
+    }
+  }
+
+  private String recordId(int index) {
+    return "lex%09d".formatted(index);
+  }
+
+  private long countLexMatchesGreaterThan(String value) {
+    Object result = redisTemplate.execute((RedisCallback<Object>) connection -> connection.execute("ZLEXCOUNT",
+        LEX_SET_KEY.getBytes(UTF_8), ("(" + value + "\uffff").getBytes(UTF_8), "+".getBytes(UTF_8)));
+
+    if (result instanceof Number number) {
+      return number.longValue();
+    }
+    if (result instanceof byte[] bytes) {
+      return Long.parseLong(new String(bytes, UTF_8));
+    }
+    return -1;
+  }
+
+  private long elapsedMs(long startNanos) {
+    return (System.nanoTime() - startNanos) / 1_000_000;
+  }
+
+  private long usedHeapMiB() {
+    Runtime runtime = Runtime.getRuntime();
+    return (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024);
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/LexicographicIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/LexicographicIndexer.java
@@ -1,12 +1,19 @@
 package com.redis.om.spring.indexing;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.util.ReflectionUtils;
+
+import com.redis.om.spring.util.ObjectUtils;
 
 /**
  * Handles maintenance of lexicographic sorted sets for fields marked with lexicographic=true.
@@ -46,6 +53,7 @@ public class LexicographicIndexer {
   public void processEntity(Object entity, String entityId, boolean isNew, String entityPrefix) {
     Class<?> entityClass = entity.getClass();
     Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+    List<Field> idFields = ObjectUtils.getIdFieldsForEntityClass(entityClass);
 
     logger.debug(String.format("Processing entity %s with ID %s, isNew=%s, entityPrefix=%s", entityClass
         .getSimpleName(), entityId, isNew, entityPrefix));
@@ -73,9 +81,9 @@ public class LexicographicIndexer {
         logger.debug(String.format("Processing field %s, value=%s, member=%s, isNew=%s", fieldName, fieldValue, member,
             isNew));
 
-        // If updating, remove the old entry (we don't know the old value, so we need to find and remove it)
+        // If updating, remove the previous member before adding the current one.
         if (!isNew) {
-          removeOldEntry(sortedSetKey, entityId);
+          removeOldEntry(sortedSetKey, entityId, field, fieldValue, idFields);
         }
 
         // Add the new entry with score 0 (all entries have same score for lexicographic ordering)
@@ -95,6 +103,7 @@ public class LexicographicIndexer {
   public void processEntityDeletion(Object entity, String entityId, String entityPrefix) {
     Class<?> entityClass = entity.getClass();
     Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+    List<Field> idFields = ObjectUtils.getIdFieldsForEntityClass(entityClass);
 
     if (lexicographicFields == null || lexicographicFields.isEmpty()) {
       return;
@@ -102,7 +111,20 @@ public class LexicographicIndexer {
 
     for (String fieldName : lexicographicFields) {
       String sortedSetKey = entityPrefix + fieldName + ":lex";
-      removeOldEntry(sortedSetKey, entityId);
+      Field field = ReflectionUtils.findField(entityClass, fieldName);
+      if (field == null) {
+        logger.warn(String.format("Lexicographic field %s not found on class %s", fieldName, entityClass.getName()));
+        removeOldEntryByScan(sortedSetKey, entityId);
+        continue;
+      }
+
+      field.setAccessible(true);
+      Object fieldValue = ReflectionUtils.getField(field, entity);
+      if (isIdField(field, idFields) && fieldValue != null) {
+        removeExactEntry(sortedSetKey, member(fieldValue, entityId));
+      } else {
+        removeOldEntryByScan(sortedSetKey, entityId);
+      }
     }
   }
 
@@ -115,6 +137,7 @@ public class LexicographicIndexer {
    */
   public void processEntityDeletionById(Class<?> entityClass, String entityId, String entityPrefix) {
     Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+    Optional<Field> singleIdField = getSingleIdField(entityClass);
 
     if (lexicographicFields == null || lexicographicFields.isEmpty()) {
       return;
@@ -122,32 +145,87 @@ public class LexicographicIndexer {
 
     for (String fieldName : lexicographicFields) {
       String sortedSetKey = entityPrefix + fieldName + ":lex";
-      removeOldEntry(sortedSetKey, entityId);
+      if (singleIdField.map(idField -> idField.getName().equals(fieldName)).orElse(false)) {
+        removeExactEntry(sortedSetKey, member(entityId, entityId));
+      } else {
+        removeOldEntryByScan(sortedSetKey, entityId);
+      }
     }
   }
 
   /**
-   * Removes entries ending with the given entity ID from the sorted set.
+   * Removes the old lexicographic member for an update.
+   * <p>
+   * For ID fields the old member is deterministic, because the ID value is stable for
+   * the entity being updated. For other mutable lexicographic fields, the previous
+   * value may be unknown, so the fallback uses a cursor scan to avoid materializing the
+   * entire sorted set in JVM heap.
+   *
+   * @param sortedSetKey the sorted set key
+   * @param entityId     the entity ID to remove
+   * @param field        the lexicographic field
+   * @param fieldValue   the current field value
+   * @param idFields     ID fields declared by the entity
+   */
+  private void removeOldEntry(String sortedSetKey, String entityId, Field field, Object fieldValue,
+      List<Field> idFields) {
+    if (isIdField(field, idFields) && fieldValue != null) {
+      removeExactEntry(sortedSetKey, member(fieldValue, entityId));
+    } else {
+      removeOldEntryByScan(sortedSetKey, entityId);
+    }
+  }
+
+  /**
+   * Removes entries ending with the given entity ID from the sorted set using a cursor scan.
    * This is needed because we may not know the old field value during updates.
    *
    * @param sortedSetKey the sorted set key
    * @param entityId     the entity ID to remove
    */
-  private void removeOldEntry(String sortedSetKey, String entityId) {
-    // Get all members and remove those ending with #entityId
-    Set<String> members = redisTemplate.opsForZSet().range(sortedSetKey, 0, -1);
+  private void removeOldEntryByScan(String sortedSetKey, String entityId) {
     logger.debug(String.format("Removing old entries for entityId %s from %s", entityId, sortedSetKey));
-    logger.debug(String.format("Current members: %s", members));
-    if (members != null) {
-      String suffix = "#" + entityId;
-      logger.debug(String.format("Looking for entries ending with: %s", suffix));
-      for (String member : members) {
-        if (member.endsWith(suffix)) {
-          Long removed = redisTemplate.opsForZSet().remove(sortedSetKey, member);
-          logger.debug(String.format("Removed entry %s from sorted set %s (result: %s)", member, sortedSetKey,
-              removed));
+    String suffix = "#" + entityId;
+    logger.debug(String.format("Looking for entries ending with: %s", suffix));
+
+    ScanOptions options = ScanOptions.scanOptions().match("*" + escapeRedisGlob(suffix)).count(1000).build();
+    try (Cursor<ZSetOperations.TypedTuple<String>> cursor = redisTemplate.opsForZSet().scan(sortedSetKey, options)) {
+      while (cursor.hasNext()) {
+        String member = cursor.next().getValue();
+        if (member != null && member.endsWith(suffix)) {
+          removeExactEntry(sortedSetKey, member);
         }
       }
     }
+  }
+
+  private void removeExactEntry(String sortedSetKey, String member) {
+    Long removed = redisTemplate.opsForZSet().remove(sortedSetKey, member);
+    logger.debug(String.format("Removed entry %s from sorted set %s (result: %s)", member, sortedSetKey, removed));
+  }
+
+  private String member(Object fieldValue, String entityId) {
+    return fieldValue + "#" + entityId;
+  }
+
+  private boolean isIdField(Field field, List<Field> idFields) {
+    return idFields.stream().anyMatch(idField -> idField.getName().equals(field.getName()));
+  }
+
+  private Optional<Field> getSingleIdField(Class<?> entityClass) {
+    List<Field> idFields = ObjectUtils.getIdFieldsForEntityClass(entityClass);
+    return idFields.size() == 1 ? Optional.of(idFields.get(0)) : Optional.empty();
+  }
+
+  private String escapeRedisGlob(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == '*' || c == '?' || c == '[' || c == ']' || c == '\\') {
+        escaped.append('\\');
+      }
+      escaped.append(c);
+    }
+    return escaped.toString();
   }
 }

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/ReferenceTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/ReferenceTest.java
@@ -20,6 +20,9 @@ import com.redis.om.spring.search.stream.EntityStream;
     properties = { "spring.config.location=classpath:application.yaml" }
 )
 class ReferenceTest extends AbstractBaseDocumentTest {
+  private static final int EXTREME_REFERENCE_COUNT = 10000;
+  private static final int EXTREME_REFERENCE_BATCH_SIZE = 500;
+
   @Autowired
   CityRepository cityRepository;
 
@@ -72,36 +75,45 @@ class ReferenceTest extends AbstractBaseDocumentTest {
         City.of("Savannah", ga), City.of("Augusta", ga) //
     );
     cityRepository.saveAll(cities);
+  }
 
-    if (refRepository.count() == 0) {
-      Set<Ref> refs = new HashSet<>();
-      for (int i = 0; i < 100; i++) {
-        refs.add(Ref.of("ref" + i));
+  private void prepareExtremeReferences() {
+    tooManyReferencesRepository.deleteAll();
+    refRepository.deleteAll();
+
+    Set<Ref> refs = new HashSet<>();
+    for (int i = 0; i < 100; i++) {
+      refs.add(Ref.of("ref" + i));
+    }
+    refRepository.saveAll(refs);
+
+    List<Ref> refList = new ArrayList<>(refs);
+    Random random = new Random();
+    List<TooManyReferences> batch = new ArrayList<>(EXTREME_REFERENCE_BATCH_SIZE);
+
+    for (int i = 0; i < EXTREME_REFERENCE_COUNT; i++) {
+      TooManyReferences tmr = TooManyReferences.of("ref" + i);
+
+      tmr.setRef1(refList.get(random.nextInt(refList.size())));
+      tmr.setRef2(refList.get(random.nextInt(refList.size())));
+      tmr.setRef3(refList.get(random.nextInt(refList.size())));
+      tmr.setRef4(refList.get(random.nextInt(refList.size())));
+      tmr.setRef5(refList.get(random.nextInt(refList.size())));
+      tmr.setRef6(refList.get(random.nextInt(refList.size())));
+      tmr.setRef7(refList.get(random.nextInt(refList.size())));
+      tmr.setRef8(refList.get(random.nextInt(refList.size())));
+      tmr.setRef9(refList.get(random.nextInt(refList.size())));
+      tmr.setRef10(refList.get(random.nextInt(refList.size())));
+
+      batch.add(tmr);
+      if (batch.size() == EXTREME_REFERENCE_BATCH_SIZE) {
+        tooManyReferencesRepository.saveAll(batch);
+        batch.clear();
       }
-      refRepository.saveAll(refs);
+    }
 
-      Set<TooManyReferences> tmrs = new HashSet<>();
-      List<Ref> refList = new ArrayList<>(refs);
-      Random random = new Random();
-
-      for (int i = 0; i < 10000; i++) {
-        TooManyReferences tmr = TooManyReferences.of("ref" + i);
-
-        tmr.setRef1(refList.get(random.nextInt(refList.size())));
-        tmr.setRef2(refList.get(random.nextInt(refList.size())));
-        tmr.setRef3(refList.get(random.nextInt(refList.size())));
-        tmr.setRef4(refList.get(random.nextInt(refList.size())));
-        tmr.setRef5(refList.get(random.nextInt(refList.size())));
-        tmr.setRef6(refList.get(random.nextInt(refList.size())));
-        tmr.setRef7(refList.get(random.nextInt(refList.size())));
-        tmr.setRef8(refList.get(random.nextInt(refList.size())));
-        tmr.setRef9(refList.get(random.nextInt(refList.size())));
-        tmr.setRef10(refList.get(random.nextInt(refList.size())));
-
-        tmrs.add(tmr);
-      }
-
-      tooManyReferencesRepository.saveAll(tmrs);
+    if (!batch.isEmpty()) {
+      tooManyReferencesRepository.saveAll(batch);
     }
   }
 
@@ -270,6 +282,8 @@ class ReferenceTest extends AbstractBaseDocumentTest {
 
   @Test
   void testExtremeReferencesWithFindAll() {
+    prepareExtremeReferences();
+
     List<TooManyReferences> allReferences = tooManyReferencesRepository.findAll();
 
     assertThat(allReferences).isNotEmpty();

--- a/tests/src/test/java/com/redis/om/spring/indexing/LexicographicIndexerTest.java
+++ b/tests/src/test/java/com/redis/om/spring/indexing/LexicographicIndexerTest.java
@@ -1,0 +1,108 @@
+package com.redis.om.spring.indexing;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import com.redis.om.spring.annotations.Indexed;
+
+@ExtendWith(
+  MockitoExtension.class
+)
+class LexicographicIndexerTest {
+  @Mock
+  RedisTemplate<String, String> redisTemplate;
+
+  @Mock
+  RediSearchIndexer rediSearchIndexer;
+
+  @Mock
+  ZSetOperations<String, String> zSetOperations;
+
+  @Mock
+  Cursor<ZSetOperations.TypedTuple<String>> cursor;
+
+  @Mock
+  ZSetOperations.TypedTuple<String> tuple;
+
+  private LexicographicIndexer lexicographicIndexer;
+
+  @BeforeEach
+  void setUp() {
+    when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+    lexicographicIndexer = new LexicographicIndexer(redisTemplate, rediSearchIndexer);
+  }
+
+  @Test
+  void processEntityRemovesLexicographicIdByExactMemberWithoutFullRangeScan() {
+    when(rediSearchIndexer.getLexicographicFields(LexicographicIdEntity.class)).thenReturn(Set.of("id"));
+
+    LexicographicIdEntity entity = new LexicographicIdEntity("session-42");
+
+    lexicographicIndexer.processEntity(entity, "session-42", false, "sessions:");
+
+    verify(zSetOperations).remove("sessions:id:lex", "session-42#session-42");
+    verify(zSetOperations).add("sessions:id:lex", "session-42#session-42", 0.0);
+    verify(zSetOperations, never()).range(anyString(), anyLong(), anyLong());
+    verify(zSetOperations, never()).scan(anyString(), any(ScanOptions.class));
+  }
+
+  @Test
+  void processEntityUsesCursorScanForMutableLexicographicFieldWithoutFullRangeScan() {
+    when(rediSearchIndexer.getLexicographicFields(MutableLexicographicEntity.class)).thenReturn(Set.of("sku"));
+    when(zSetOperations.scan(eq("products:sku:lex"), any(ScanOptions.class))).thenReturn(cursor);
+    when(cursor.hasNext()).thenReturn(true, false);
+    when(cursor.next()).thenReturn(tuple);
+    when(tuple.getValue()).thenReturn("old-sku#product-1");
+
+    MutableLexicographicEntity entity = new MutableLexicographicEntity("product-1", "new-sku");
+
+    lexicographicIndexer.processEntity(entity, "product-1", false, "products:");
+
+    verify(zSetOperations).scan(eq("products:sku:lex"), any(ScanOptions.class));
+    verify(zSetOperations).remove("products:sku:lex", "old-sku#product-1");
+    verify(zSetOperations).add("products:sku:lex", "new-sku#product-1", 0.0);
+    verify(zSetOperations, never()).range(anyString(), anyLong(), anyLong());
+    verify(cursor).close();
+  }
+
+  @Test
+  void processEntityDeletionRemovesLexicographicIdByExactMemberWithoutFullRangeScan() {
+    when(rediSearchIndexer.getLexicographicFields(LexicographicIdEntity.class)).thenReturn(Set.of("id"));
+
+    LexicographicIdEntity entity = new LexicographicIdEntity("session-42");
+
+    lexicographicIndexer.processEntityDeletion(entity, "session-42", "sessions:");
+
+    verify(zSetOperations).remove("sessions:id:lex", "session-42#session-42");
+    verify(zSetOperations, never()).range(anyString(), anyLong(), anyLong());
+    verify(zSetOperations, never()).scan(anyString(), any(ScanOptions.class));
+  }
+
+  private record LexicographicIdEntity(@Id @Indexed(
+      lexicographic = true
+  ) String id) {
+  }
+
+  private record MutableLexicographicEntity(@Id String id, @Indexed(
+      lexicographic = true
+  ) String sku) {
+  }
+}


### PR DESCRIPTION
## Summary
- avoid full `ZRANGE 0 -1` materialization when cleaning up lexicographic sorted set entries
- remove lexicographic ID entries directly with `ZREM` because the member is deterministic
- use cursor-based `ZSCAN` with `MATCH` fallback for mutable non-ID lexicographic fields
- add regression tests covering ID update/delete and mutable-field cleanup without full range scans

## Verification
- `./gradlew :tests:test -S`
- `./gradlew spotlessApply`
- `./gradlew spotlessCheck build aggregateTestReport -S`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core entity save/update/delete indexing for lexicographic fields; behavior should be equivalent but mistakes could leave stale or duplicate sorted-set members at scale.
> 
> **Overview**
> **Write-side lexicographic index maintenance** no longer loads entire sorted sets on every update or delete. `LexicographicIndexer` now removes members with a direct `ZREM` when the lexicographic field is the entity `@Id` (member is `id#entityId`), and uses cursor-based `ZSCAN` with a `MATCH` on `#entityId` for other mutable lexicographic fields instead of `ZRANGE 0 -1`.
> 
> **Tests and demo** back the change: new `LexicographicIndexerTest` asserts ID paths never call `range`/`scan` inappropriately and mutable fields use scan without full range reads. The roms-documents demo adds an opt-in `LexicographicIdReproRunner` and README material to stress write-side cleanup and to document a separate **query-side** issue where `ID.gt(...).limit(1)` still materializes all lex matches (not fixed here).
> 
> `ReferenceTest` defers seeding 10k `TooManyReferences` documents until `testExtremeReferencesWithFindAll`, using batched `saveAll` so other reference tests stay lighter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 993df17f04ecaab437db566a591001609517c14a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->