### PR TITLE
ci: backport release/CI improvements from main to 1.1.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners are automatically requested for review on all PRs.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @sagile @foogaro

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Description
+
+<!-- What does this PR do? Why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Refactor / cleanup
+
+## How has this been tested?
+
+<!-- Describe the tests you ran and how to reproduce them. -->
+
+## Checklist
+
+- [ ] My code follows the existing code style (`./gradlew spotlessCheck`)
+- [ ] I have added or updated tests for the changes
+- [ ] All tests pass locally (`./gradlew test`)
+- [ ] I have updated documentation where needed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'zulu'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test-reports
           path: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,14 @@ name: Build
 on:
   pull_request:
 
+permissions:
+  contents: read
+  actions: write  # required for actions/upload-artifact
+
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
 
+  # ── 1. Format check (fast, ~30s, no Docker needed) ──────────────────────────
+  style:
+    name: Code Style
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
@@ -23,7 +24,7 @@ jobs:
         uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: Cache Gradle
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
@@ -40,18 +41,79 @@ jobs:
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
           restore-keys: ${{ runner.os }}-gradlew-
 
-      - name: Code Style Check
-        run: |
-          ./gradlew spotlessCheck -S
+      - name: Spotless check
+        run: ./gradlew spotlessCheck -S
 
-      - name: Build
-        run: |
-          ./gradlew build aggregateTestReport -S
+  # ── 2. Compile (fast, ~1–2 min, no tests, no Docker) ────────────────────────
+  compile:
+    name: Compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Compile (no tests)
+        run: ./gradlew assemble -S
+
+  # ── 3. Integration tests — 4 shards run in parallel on separate runners ───────
+  test:
+    name: Tests (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    needs: compile          # only run if compile passes
+    strategy:
+      matrix:
+        shard: [document, hash, stream, other]
+      fail-fast: false      # let all shards finish even if one fails
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Run tests (${{ matrix.shard }})
+        run: ./gradlew :tests:test -PtestShard=${{ matrix.shard }} -S
 
       - name: Upload test reports
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: test-reports
-          path: |
-            build/reports/tests/aggregate/
+          name: test-reports-${{ matrix.shard }}
+          path: tests/build/reports/tests/test/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,15 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: main  # Always checkout main branch for docs builds
           fetch-depth: 0  # Fetch all history for all branches and tags
@@ -33,18 +33,18 @@ jobs:
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'zulu'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -52,7 +52,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -141,13 +141,13 @@ jobs:
         run: touch docs/build/site/.nojekyll
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d  # v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: 'docs/build/site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -4,29 +4,33 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write  # needed for jreleaser to create releases/tags
+  actions: write   # needed for styfle/cancel-workflow-action with github.token
+
 jobs:
   earlyaccess:
     name: 'Early Access'
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous run
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # 0.12.1
         with:
-          access_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'zulu'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -34,7 +38,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -46,7 +50,7 @@ jobs:
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test-report
           path: |
@@ -58,7 +62,7 @@ jobs:
         run: |
           BASE_VERSION=$(grep '^version\s*=\s*' gradle.properties | cut -d'=' -f2 | xargs)
           echo "BASE_VERSION=$BASE_VERSION" >> "$GITHUB_OUTPUT"
-          
+
           # Check if current version is already a release (RC, SNAPSHOT, or tagged release)
           if [[ "$BASE_VERSION" == *-SNAPSHOT ]] || [[ "$BASE_VERSION" == *-RC* ]]; then
             echo "SHOULD_RELEASE_SNAPSHOT=false" >> "$GITHUB_OUTPUT"
@@ -79,7 +83,7 @@ jobs:
 
       - name: Release Snapshot
         if: ${{ steps.vars.outputs.SHOULD_RELEASE_SNAPSHOT == 'true' }}
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5  # 2.5.0
         with:
           arguments: release
           version: 'latest'
@@ -97,7 +101,7 @@ jobs:
 
       - name: JReleaser output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: artifact
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,29 +8,33 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  actions: write  # required for actions/upload-artifact
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous run
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ secrets.GIT_ACCESS_TOKEN }}
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'zulu'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -38,7 +42,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -66,21 +70,21 @@ jobs:
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test-reports
           path: |
             build/reports/tests/aggregate/
 
       - name: Assemble
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5  # 2.5.0
         with:
           arguments: assemble
         env:
           JRELEASER_PROJECT_VERSION: ${{ inputs.version }}
 
       - name: Release
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5  # 2.5.0
         with:
           arguments: full-release
         env:
@@ -97,15 +101,15 @@ jobs:
 
       - name: JReleaser output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: artifact
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties
-            
+
       - name: Trigger documentation build
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570  # v2
         with:
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
           event-type: build-docs

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -58,7 +58,8 @@ release:
 
 signing:
   active: ALWAYS
-  armored: true
+  pgp:
+    armored: true
 
 deploy:
   maven:

--- a/redis-om-spring-ai/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
+++ b/redis-om-spring-ai/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
@@ -303,10 +303,6 @@ public class DefaultEmbedder implements Embedder {
    */
   @Override
   public void processEntity(Object item) {
-    if (!isReady()) {
-      return;
-    }
-
     List<Field> fields = ObjectUtils.getFieldsWithAnnotation(item.getClass(), Vectorize.class);
     if (!fields.isEmpty()) {
       PropertyAccessor accessor = PropertyAccessorFactory.forBeanPropertyAccess(item);
@@ -338,10 +334,6 @@ public class DefaultEmbedder implements Embedder {
    */
   @Override
   public <S> void processEntities(Iterable<S> items) {
-    if (!isReady()) {
-      return;
-    }
-
     int batchSize = properties.getEmbeddingBatchSize();
     List<FieldData> batch = new ArrayList<>(batchSize);
 
@@ -694,13 +686,44 @@ public class DefaultEmbedder implements Embedder {
 
   /**
    * {@inheritDoc}
-   * 
-   * @return Always returns true as models are created on demand
+   *
+   * Always returns true — the embedder bean is available and all provider-specific
+   * checks are handled lazily inside each embedding call. Use
+   * {@link #isTransformersReady()} when you specifically need the DJL + ONNX/Transformers
+   * stack to be available (e.g. to gate tests via {@code @EnabledIf}).
    */
   @Override
   public boolean isReady() {
-    //return this.faceEmbeddingModel != null && this.transformersEmbeddingModel != null;
     return true;
+  }
+
+  /**
+   * Returns true when both DJL image models loaded and the ONNX Runtime native
+   * library is loadable in this JVM, meaning the Transformers embedding provider
+   * can be used. The ONNX check is cached after the first probe so repeated calls
+   * are cheap.
+   */
+  @Override
+  public boolean isTransformersReady() {
+    return imageEmbeddingModel != null && faceEmbeddingModel != null && isOnnxRuntimeAvailable();
+  }
+
+  private static volatile Boolean onnxRuntimeAvailable;
+
+  private static boolean isOnnxRuntimeAvailable() {
+    if (onnxRuntimeAvailable != null) {
+      return onnxRuntimeAvailable;
+    }
+    try {
+      // initialize=true forces the static initializer, which triggers the native lib load.
+      // On a second call after a failed init the JVM throws NoClassDefFoundError, so catch that too.
+      Class.forName("ai.onnxruntime.OrtEnvironment", true, Thread.currentThread().getContextClassLoader());
+      onnxRuntimeAvailable = true;
+    } catch (ClassNotFoundException | NoClassDefFoundError | UnsatisfiedLinkError | ExceptionInInitializerError e) {
+      logger.warn("ONNX Runtime not available, Transformers-backed embeddings will be skipped: " + e.getMessage());
+      onnxRuntimeAvailable = false;
+    }
+    return onnxRuntimeAvailable;
   }
 
   /**

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/Embedder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/Embedder.java
@@ -27,10 +27,22 @@ public interface Embedder {
 
   /**
    * Check if embedder is ready for use.
-   * 
+   *
    * @return true if ready
    */
   boolean isReady();
+
+  /**
+   * Check if the Transformers (ONNX) embedding provider is available.
+   * The default implementation returns false; concrete embedders that support
+   * Transformers (e.g. {@code DefaultEmbedder}) override this to probe DJL model
+   * availability and ONNX Runtime native library loadability.
+   *
+   * @return true if both DJL models and ONNX Runtime are available; false by default
+   */
+  default boolean isTransformersReady() {
+    return false;
+  }
 
   /**
    * Get text embeddings as byte arrays.

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -120,6 +120,28 @@ jacocoTestReport {
 
 test.finalizedBy jacocoTestReport
 
+// Test-shard definitions — used by CI to run tests in parallel.
+// Each shard runs on its own runner with its own Testcontainers Redis instance,
+// so there are no shared-state conflicts.
+//
+// Usage:  ./gradlew :tests:test -PtestShard=document   (or hash | stream | other)
+// Omit -PtestShard to run the full suite (local dev / single-job CI).
+//
+// The 'other' shard is a catch-all: it includes everything under
+// com.redis.om.spring.** and excludes the patterns claimed by the named shards.
+// This means any new test package is automatically picked up without having to
+// add it here explicitly.
+ext.namedShards = [
+	document: [
+		'com.redis.om.spring.annotations.document.**',
+	],
+	hash: [
+		'com.redis.om.spring.annotations.hash.**',
+	],
+	stream: [
+		'com.redis.om.spring.search.stream.**',
+	],
+]
 
 test {
 	useJUnitPlatform()
@@ -128,5 +150,24 @@ test {
 	testLogging {
 		events "passed", "skipped", "failed"
 		exceptionFormat = 'full'
+	}
+
+	// Apply shard filter when -PtestShard=<name> is supplied.
+	if (project.hasProperty('testShard')) {
+		def shard = project.property('testShard') as String
+		def validShards = namedShards.keySet() + ['other']
+		if (!validShards.contains(shard)) {
+			throw new GradleException("Unknown testShard '${shard}'. Valid values: ${validShards.join(', ')}")
+		}
+		filter {
+			if (shard == 'other') {
+				// Catch-all: everything not claimed by a named shard.
+				// New test packages are automatically included here.
+				includeTestsMatching 'com.redis.om.spring.**'
+				namedShards.values().flatten().each { excludeTestsMatching it }
+			} else {
+				namedShards[shard].each { includeTestsMatching it }
+			}
+		}
 	}
 }

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 }
 
 apply plugin: 'org.springframework.boot'
@@ -94,6 +95,31 @@ compileTestJava {
 	options.annotationProcessorPath = configurations.testAnnotationProcessor
 	options.generatedSourceOutputDirectory = file("${buildDir}/generated/sources/annotationProcessor/java/test")
 }
+
+// JaCoCo configuration
+jacoco {
+	toolVersion = "0.8.12"
+}
+
+jacocoTestReport {
+	dependsOn test
+	classDirectories.setFrom(files(
+			project(':redis-om-spring').sourceSets.main.output.classesDirs,
+			project(':redis-om-spring-ai').sourceSets.main.output.classesDirs
+			))
+	sourceDirectories.setFrom(files(
+			project(':redis-om-spring').sourceSets.main.allSource.srcDirs,
+			project(':redis-om-spring-ai').sourceSets.main.allSource.srcDirs
+			))
+	reports {
+		html.required = true
+		xml.required = true
+		csv.required = false
+	}
+}
+
+test.finalizedBy jacocoTestReport
+
 
 test {
 	useJUnitPlatform()

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
@@ -50,7 +50,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testImageIsVectorized() {
@@ -63,7 +63,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testSentenceIsVectorized() {
@@ -76,7 +76,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnImageSimilaritySearch() {
@@ -98,7 +98,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnSentenceSimilaritySearch() {
@@ -120,7 +120,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnHybridSentenceSimilaritySearch() {
@@ -143,7 +143,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnSentenceSimilaritySearchWithScores() {
@@ -167,7 +167,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testEmbedderCanVectorizeSentence() {
@@ -183,7 +183,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testBulkEmbedMapEmbeddingsCorrectly() {

--- a/tests/src/test/java/com/redis/om/spring/annotations/hash/vectorize/VectorizeHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/hash/vectorize/VectorizeHashTest.java
@@ -50,7 +50,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testImageIsVectorized() {
@@ -63,7 +63,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testSentenceIsVectorized() {
@@ -76,7 +76,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnImageSimilaritySearch() {
@@ -98,7 +98,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnSentenceSimilaritySearch() {
@@ -120,7 +120,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnHybridSentenceSimilaritySearch() {
@@ -143,7 +143,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnSentenceSimilaritySearchWithScores() {
@@ -167,7 +167,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testEmbedderCanVectorizeSentence() {
@@ -183,7 +183,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testBulkEmbedMapEmbeddingsCorrectly() {

--- a/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamDocsTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamDocsTest.java
@@ -101,8 +101,8 @@ public class DetachedEntityStreamDocsTest extends AbstractBaseDocumentTest {
     SearchStream<Bicycle> stream = entityStream.of(Bicycle.class, "idx:bicycle", "id");
     List<Bicycle> bicycles = stream.filter(MODEL.eq("Jigger")).collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model").containsOnly("Jigger");
   }
 
   @Test
@@ -111,8 +111,8 @@ public class DetachedEntityStreamDocsTest extends AbstractBaseDocumentTest {
     SearchStream<Bicycle> stream = entityStream.of(Bicycle.class, "idx:bicycle", "id");
     List<Bicycle> bicycles = stream.filter(MODEL.eq("Jigger")).collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model").containsOnly("Jigger");
   }
 
   @Test
@@ -124,10 +124,9 @@ public class DetachedEntityStreamDocsTest extends AbstractBaseDocumentTest {
         .filter(PRICE.between(BigDecimal.valueOf(815), BigDecimal.valueOf(815))) //
         .collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("BikeShind");
-    assertThat(bicycles.get(0).getBrand()).isEqualTo("ThrillCycle");
-    assertThat(bicycles.get(0).getPrice()).isEqualTo(BigDecimal.valueOf(815));
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model", "brand", "price")
+        .containsOnly(org.assertj.core.groups.Tuple.tuple("BikeShind", "ThrillCycle", BigDecimal.valueOf(815)));
   }
 
   @Test
@@ -138,10 +137,8 @@ public class DetachedEntityStreamDocsTest extends AbstractBaseDocumentTest {
         .collect(Collectors.toList());
 
     assertThat(bicycles).hasSize(2);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Chook air 5");
-    assertThat(bicycles.get(1).getModel()).isEqualTo("BikeShind");
-    assertThat(bicycles.get(0).getPrice()).isEqualTo(BigDecimal.valueOf(815));
-    assertThat(bicycles.get(1).getPrice()).isEqualTo(BigDecimal.valueOf(815));
+    assertThat(bicycles).extracting("model").containsExactlyInAnyOrder("Chook air 5", "BikeShind");
+    assertThat(bicycles).extracting("price").containsOnly(BigDecimal.valueOf(815));
   }
 
   @Data

--- a/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamHashTest.java
@@ -108,8 +108,8 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
     SearchStream<Bicycle> stream = entityStream.of(Bicycle.class, "idx:hashbikes", "id");
     List<Bicycle> bicycles = stream.filter(MODEL.eq("Jigger")).collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model").containsOnly("Jigger");
   }
 
   @Test
@@ -118,8 +118,8 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
     SearchStream<Bicycle> stream = entityStream.of(Bicycle.class, "idx:hashbikes", "id");
     List<Bicycle> bicycles = stream.filter(MODEL.eq("Jigger")).collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model").containsOnly("Jigger");
   }
 
   @Test
@@ -131,10 +131,9 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
         .filter(PRICE.between(815.0, 815.0)) //
         .collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("BikeShind");
-    assertThat(bicycles.get(0).getBrand()).isEqualTo("ThrillCycle");
-    assertThat(bicycles.get(0).getPrice()).isEqualTo(815.0);
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model", "brand", "price")
+        .containsOnly(org.assertj.core.groups.Tuple.tuple("BikeShind", "ThrillCycle", 815.0));
   }
 
   @Test
@@ -145,10 +144,8 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
         .collect(Collectors.toList());
 
     assertThat(bicycles).hasSize(2);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Chook air 5");
-    assertThat(bicycles.get(1).getModel()).isEqualTo("BikeShind");
-    assertThat(bicycles.get(0).getPrice()).isEqualTo(815.0);
-    assertThat(bicycles.get(1).getPrice()).isEqualTo(815.0);
+    assertThat(bicycles).extracting("model").containsExactlyInAnyOrder("Chook air 5", "BikeShind");
+    assertThat(bicycles).extracting("price").containsOnly(815.0);
   }
 
   public static Map<String, String> convertBicycleToStringMap(Bicycle bicycle) {


### PR DESCRIPTION
## Summary

Backports CI/release improvements from `main` (up to v2.0.5) to the `1.1.x-spring-boot-3.5` branch.

### Release workflow fix
- **fix push permission** (`f9c31eb6`): pass `GIT_ACCESS_TOKEN` to `actions/checkout` so `git push origin HEAD` in the release workflow uses the correct credentials — the default `GITHUB_TOKEN` lacks push rights to the redis org

### CI hardening (`514c9275`, `c3da3cbb`)
- SHA-pin all GitHub Actions to immutable commit SHAs (supply chain protection)
- Least-privilege `permissions` blocks on `build.yml`, `release.yml`, `early-access.yml`
- Native `concurrency` groups replace `styfle/cancel-workflow-action`
- Add `dependency-review` workflow to block PRs introducing known-vulnerable deps
- Add `CODEOWNERS` and PR template

### JReleaser fix (`a1a29c83`)
- Replace deprecated `signing.armored` with `signing.pgp.armored` for JReleaser ≥1.22 compatibility

### JaCoCo coverage reporting (`cd55fe04`)
- Wire JaCoCo into `tests/build.gradle` — `./gradlew :tests:test` now auto-produces HTML + XML coverage reports

### Test stability (`48f9a94e`)
- `VectorizeDocumentTest` / `VectorizeHashTest`: gate on `isTransformersReady()` (ONNX Runtime probe) so tests are skipped rather than failing on CI runners without the native lib
- `DetachedEntityStreamDocsTest` / `DetachedEntityStreamHashTest`: order-independent assertions and null-safe entity handling to prevent flaky failures on shared Testcontainers instances

## Test plan
- [ ] CI passes on this branch
- [ ] Merge, then trigger the Release workflow on `1.1.x-spring-boot-3.5` with `version = 1.1.4` (or next patch) — `git push origin HEAD` should succeed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI and release workflow changes affect how every PR is built and how releases run; embedder behavior no longer no-ops batch processing on `isReady()`, which could surface runtime errors where ONNX/DJL is missing instead of silent skips.
> 
> **Overview**
> Backports **CI, release, and test stability** improvements from `main` onto the `1.1.x` line.
> 
> **CI** splits PR builds into Spotless, `assemble`, and four parallel test shards (`document`, `hash`, `stream`, `other`) via `-PtestShard`, with concurrency groups, least-privilege permissions, SHA-pinned Actions, per-shard failure artifacts, and a new **Dependency Review** workflow. **CODEOWNERS** and a **PR template** are added. Other workflows (`docs`, `early-access`, `release`) pin action SHAs; **release** drops `styfle/cancel-workflow-action` in favor of native concurrency and keeps checkout on `GIT_ACCESS_TOKEN` for org pushes.
> 
> **Release tooling**: JReleaser signing moves from deprecated `signing.armored` to `signing.pgp.armored`.
> 
> **Embeddings**: `DefaultEmbedder` no longer skips `processEntity` / `processEntities` when `isReady()` was false; `isReady()` is always true. New **`isTransformersReady()`** (DJL models + cached ONNX Runtime probe) gates Transformers-specific tests; vectorize tests switch `@EnabledIf` from `isReady()` to `isTransformersReady()`.
> 
> **Tests / build**: `tests` adds JaCoCo reports over main module sources and Gradle test sharding. Detached entity-stream tests use null-safe, order-independent AssertJ checks to reduce flakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0039c6be70ce90322270a737ab67cfb7380f8e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->