### PR TITLE
ci: backport release/CI improvements and fixes from main to 1.0.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Code owners are automatically requested for review on all PRs.
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @sagile @foogaro

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Description
+
+<!-- What does this PR do? Why? -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+- [ ] Refactor / cleanup
+
+## How has this been tested?
+
+<!-- Describe the tests you ran and how to reproduce them. -->
+
+## Checklist
+
+- [ ] My code follows the existing code style (`./gradlew spotlessCheck`)
+- [ ] I have added or updated tests for the changes
+- [ ] All tests pass locally (`./gradlew test`)
+- [ ] I have updated documentation where needed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,20 +148,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradlew-
 
       - name: Build and test demos
-        run: |
-          ./gradlew \
-            :demos:roms-documents:build \
-            :demos:roms-hashes:build \
-            :demos:roms-modeling:build \
-            :demos:roms-multi-acl-account:build \
-            :demos:roms-permits:build \
-            :demos:roms-vectorizers:build \
-            :demos:roms-vss-movies:build \
-            :demos:roms-vss:build \
-            :demos:roms-multitenant:build \
-            :demos:roms-hybrid:build \
-            :demos:roms-amr-entraid:build \
-            -S
+        run: ./gradlew :demos:build -S
 
       - name: Upload demo test reports
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,20 @@ jobs:
           restore-keys: ${{ runner.os }}-gradlew-
 
       - name: Build and test demos
-        run: ./gradlew :demos:build -S
+        run: |
+          ./gradlew \
+            :demos:roms-documents:build \
+            :demos:roms-hashes:build \
+            :demos:roms-modeling:build \
+            :demos:roms-multi-acl-account:build \
+            :demos:roms-permits:build \
+            :demos:roms-vectorizers:build \
+            :demos:roms-vss-movies:build \
+            :demos:roms-vss:build \
+            :demos:roms-multitenant:build \
+            :demos:roms-hybrid:build \
+            :demos:roms-amr-entraid:build \
+            -S
 
       - name: Upload demo test reports
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,22 +3,31 @@ name: Build
 on:
   pull_request:
 
-jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
+  actions: write  # required for actions/upload-artifact
 
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  # ── 1. Format check (fast, ~30s, no Docker needed) ──────────────────────────
+  style:
+    name: Code Style
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -26,24 +35,85 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
           restore-keys: ${{ runner.os }}-gradlew-
 
-      - name: Code Style Check
-        run: |
-          ./gradlew spotlessCheck -S
+      - name: Spotless check
+        run: ./gradlew spotlessCheck -S
 
-      - name: Build
-        run: |
-          ./gradlew build aggregateTestReport -S
+  # ── 2. Compile (fast, ~1–2 min, no tests, no Docker) ────────────────────────
+  compile:
+    name: Compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Compile (no tests)
+        run: ./gradlew assemble -S
+
+  # ── 3. Integration tests — 4 shards run in parallel on separate runners ───────
+  test:
+    name: Tests (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    needs: compile          # only run if compile passes
+    strategy:
+      matrix:
+        shard: [document, hash, stream, other]
+      fail-fast: false      # let all shards finish even if one fails
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Run tests (${{ matrix.shard }})
+        run: ./gradlew :tests:test -PtestShard=${{ matrix.shard }} -S
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: test-reports
-          path: |
-            build/reports/tests/aggregate/
+          name: test-reports-${{ matrix.shard }}
+          path: tests/build/reports/tests/test/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,3 +117,42 @@ jobs:
         with:
           name: test-reports-${{ matrix.shard }}
           path: tests/build/reports/tests/test/
+
+  # ── 4. Demo module tests ─────────────────────────────────────────────────────
+  demos:
+    name: Demo Tests
+    runs-on: ubuntu-latest
+    needs: compile
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Build and test demos
+        run: ./gradlew :demos:build -S
+
+      - name: Upload demo test reports
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: test-reports-demos
+          path: demos/*/build/reports/tests/test/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,15 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48  # v4.9.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           ref: main  # Always checkout main branch for docs builds
           fetch-depth: 0  # Fetch all history for all branches and tags
@@ -33,18 +33,18 @@ jobs:
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'zulu'
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
         with:
           node-version: 20
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -52,7 +52,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -141,13 +141,13 @@ jobs:
         run: touch docs/build/site/.nojekyll
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d  # v4
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3
         with:
           path: 'docs/build/site'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4

--- a/.github/workflows/early-access.yml
+++ b/.github/workflows/early-access.yml
@@ -4,29 +4,33 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write  # needed for jreleaser to create releases/tags
+  actions: write   # needed for styfle/cancel-workflow-action with github.token
+
 jobs:
   earlyaccess:
     name: 'Early Access'
     runs-on: ubuntu-latest
     steps:
       - name: Cancel previous run
-        uses: styfle/cancel-workflow-action@0.12.1
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # 0.12.1
         with:
-          access_token: ${{ secrets.GIT_ACCESS_TOKEN }}
+          access_token: ${{ github.token }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'zulu'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -34,7 +38,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -46,7 +50,7 @@ jobs:
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test-report
           path: |
@@ -58,7 +62,7 @@ jobs:
         run: |
           BASE_VERSION=$(grep '^version\s*=\s*' gradle.properties | cut -d'=' -f2 | xargs)
           echo "BASE_VERSION=$BASE_VERSION" >> "$GITHUB_OUTPUT"
-          
+
           # Check if current version is already a release (RC, SNAPSHOT, or tagged release)
           if [[ "$BASE_VERSION" == *-SNAPSHOT ]] || [[ "$BASE_VERSION" == *-RC* ]]; then
             echo "SHOULD_RELEASE_SNAPSHOT=false" >> "$GITHUB_OUTPUT"
@@ -79,7 +83,7 @@ jobs:
 
       - name: Release Snapshot
         if: ${{ steps.vars.outputs.SHOULD_RELEASE_SNAPSHOT == 'true' }}
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5  # 2.5.0
         with:
           arguments: release
           version: 'latest'
@@ -97,7 +101,7 @@ jobs:
 
       - name: JReleaser output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: artifact
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,29 +8,33 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+  actions: write  # required for actions/upload-artifact
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel previous run
-        uses: styfle/cancel-workflow-action@0.12.1
-        with:
-          access_token: ${{ secrets.GIT_ACCESS_TOKEN }}
-
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GIT_ACCESS_TOKEN }}
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
           distribution: 'zulu'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -38,7 +42,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
@@ -66,21 +70,21 @@ jobs:
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: test-reports
           path: |
             build/reports/tests/aggregate/
 
       - name: Assemble
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5  # 2.5.0
         with:
           arguments: assemble
         env:
           JRELEASER_PROJECT_VERSION: ${{ inputs.version }}
 
       - name: Release
-        uses: jreleaser/release-action@v2
+        uses: jreleaser/release-action@90ac653bb9c79d11179e65d81499f3f34527dcd5  # 2.5.0
         with:
           arguments: full-release
         env:
@@ -97,15 +101,15 @@ jobs:
 
       - name: JReleaser output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: artifact
           path: |
             out/jreleaser/trace.log
             out/jreleaser/output.properties
-            
+
       - name: Trigger documentation build
-        uses: peter-evans/repository-dispatch@v2
+        uses: peter-evans/repository-dispatch@bf47d102fdb849e755b0b0023ea3e81a44b6f570  # v2
         with:
           token: ${{ secrets.GIT_ACCESS_TOKEN }}
           event-type: build-docs

--- a/demos/build.gradle
+++ b/demos/build.gradle
@@ -110,3 +110,9 @@ test {
 		exceptionFormat = 'full'
 	}
 }
+
+// Make :demos:build cascade to all demo subprojects so that
+// ./gradlew :demos:build covers all demo tests on CI.
+tasks.named('build') {
+	dependsOn subprojects.collect { "${it.path}:build" }
+}

--- a/demos/roms-documents/README.MD
+++ b/demos/roms-documents/README.MD
@@ -2,35 +2,145 @@
 
 This demo showcases the use of Redis OM Spring's `@Document` annotation for storing and retrieving JSON documents in Redis.
 
+## Requirements
+
+- Java 21
+- Redis Stack running on `localhost:6379`
+
+From the repository root, start the bundled Redis Stack service with:
+
+```bash
+docker compose up -d redis
+```
+
 ## Features
 
 - Demonstrates how to use the `@Document` annotation to map Java objects to Redis JSON documents
 - Shows how to create repositories that extend `RedisDocumentRepository`
-- Provides examples of querying documents using both method names and explicit queries
-- Includes REST API endpoints for CRUD operations
+- Provides examples of querying documents using method names and explicit `@Query` annotations
+- Includes REST API endpoints for document read and query operations
+- Includes an opt-in lexicographic ID range reproduction for large `@Indexed(sortable = true, lexicographic = true)` fields
 
 ## Key Components
 
-The demo includes three domain models:
+The demo includes these domain models:
+
 - Company
 - Person
 - Event
+- LexicographicIdRecord, used only by the opt-in lexicographic reproduction runner
 
-Each model is mapped as a Redis JSON document and has corresponding repository and controller classes.
-
-## Swagger Documentation
-
-The API is documented using Swagger UI, which can be accessed at:
-http://localhost:8080/swagger-ui/index.html
+Each primary model is mapped as a Redis JSON document and has corresponding repository and controller classes. The application seeds sample `Company` and `Person` data at startup.
 
 ## Running the Demo
 
-To run this demo:
+From the repository root:
 
 ```bash
 ./gradlew :demos:roms-documents:bootRun
 ```
 
+The application uses the default Spring Boot port, `8080`.
+
+## API Endpoints
+
+The demo exposes read/query endpoints under `/api`.
+
+Company endpoints:
+
+```text
+GET /api/companies/all
+GET /api/companies/all-ids
+GET /api/companies/{id}
+GET /api/companies/name/{name}
+GET /api/companies/name/starts/{prefix}
+GET /api/companies/employees/count/{count}
+GET /api/companies/employees/range/{low}/{high}
+GET /api/companies/near?lat={lat}&lon={lon}&d={distanceInMiles}
+GET /api/companies/tags?tags={tag}
+```
+
+Person endpoints:
+
+```text
+GET /api/persons/all
+GET /api/persons/all-ids
+GET /api/persons/{id}
+GET /api/persons/name/{last}/{first}
+```
+
+Event endpoints:
+
+```text
+GET /api/events/between?start={isoDateTime}&end={isoDateTime}
+```
+
+This demo does not currently configure Swagger/OpenAPI UI.
+
+## Lexicographic ID Reproduction
+
+The demo includes an opt-in runner that reproduces the large lexicographic ID range behavior for a field declared as:
+
+```java
+@Id
+@Indexed(sortable = true, lexicographic = true)
+private String id;
+```
+
+Quick run:
+
+```bash
+./gradlew :demos:roms-documents:bootRun --args='--spring.main.web-application-type=none --demo.lexicographic-repro.enabled=true --demo.lexicographic-repro.count=10000 --demo.lexicographic-repro.batch-size=1000 --demo.lexicographic-repro.update-count=100 --demo.lexicographic-repro.threshold=lex000000000'
+```
+
+Stronger signal:
+
+```bash
+./gradlew :demos:roms-documents:bootRun --args='--spring.main.web-application-type=none --demo.lexicographic-repro.enabled=true --demo.lexicographic-repro.count=50000 --demo.lexicographic-repro.batch-size=2000 --demo.lexicographic-repro.update-count=100 --demo.lexicographic-repro.threshold=lex000000000'
+```
+
+The runner has two diagnostic phases:
+
+- Clears and seeds `LexicographicIdRecord` documents
+- Rebuilds the lexicographic sorted set `lex-repro:id:lex`
+- `WRITE-SIDE CLEANUP DEMO`: updates existing records so the lexicographic indexer has to clean old ID entries
+- `MISSING QUERY FIX DEMO`: runs `LexicographicIdRecord$.ID.gt(threshold).limit(1)`
+- Logs sorted set size, query time, and heap delta
+
+What to look for in the write-side cleanup phase:
+
+```text
+WRITE-SIDE CLEANUP DEMO: older cleanup implementations used ZRANGE 0 -1 on lex-repro:id:lex once per update, materializing about 1000000 sorted-set members
+WRITE-SIDE CLEANUP DEMO: update loop completed in 51 ms
+WRITE-SIDE CLEANUP DEMO: sorted set size after updates is 10000
+```
+
+This shows why optimized write-side cleanup matters: a full-scan implementation scales with `sorted set size * update count`, while ID-field cleanup can remove exact lexicographic members directly.
+
+Then look for:
+
+```text
+MISSING QUERY FIX DEMO: ID.gt(lex000000000) has 9999 lexicographic matches in a 10000 member sorted set
+MISSING QUERY FIX DEMO: the current stream predicate still calls rangeByLex(..., Limit.unlimited()) before limit(1) is applied
+MISSING QUERY FIX DEMO: ID.gt(lex000000000) with limit(1) returned 1 record(s)
+```
+
+This shows the remaining query-side issue: `limit(1)` returns one entity, but `ID.gt(...)` still materializes all matching lexicographic IDs first.
+
+Useful properties:
+
+```text
+demo.lexicographic-repro.enabled=true
+demo.lexicographic-repro.count=50000
+demo.lexicographic-repro.batch-size=1000
+demo.lexicographic-repro.update-count=100
+demo.lexicographic-repro.threshold=lex000000000
+```
+
 ## Testing
 
 The demo includes tests demonstrating how to use Redis OM Spring in a test environment.
+
+```bash
+./gradlew :demos:roms-documents:test
+```

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/domain/LexicographicIdRecord.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/domain/LexicographicIdRecord.java
@@ -1,0 +1,27 @@
+package com.redis.om.documents.domain;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(
+  "lex-repro"
+)
+public class LexicographicIdRecord {
+  @Id
+  @Indexed(
+      sortable = true, lexicographic = true
+  )
+  private String id;
+
+  @Indexed
+  private String bucket;
+}

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/repositories/LexicographicIdRecordRepository.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/repositories/LexicographicIdRecordRepository.java
@@ -1,0 +1,7 @@
+package com.redis.om.documents.repositories;
+
+import com.redis.om.documents.domain.LexicographicIdRecord;
+import com.redis.om.spring.repository.RedisDocumentRepository;
+
+public interface LexicographicIdRecordRepository extends RedisDocumentRepository<LexicographicIdRecord, String> {
+}

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/repro/LexicographicIdReproRunner.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/repro/LexicographicIdReproRunner.java
@@ -1,0 +1,172 @@
+package com.redis.om.documents.repro;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.redis.om.documents.domain.LexicographicIdRecord;
+import com.redis.om.documents.domain.LexicographicIdRecord$;
+import com.redis.om.documents.repositories.LexicographicIdRecordRepository;
+import com.redis.om.spring.search.stream.EntityStream;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+    name = "demo.lexicographic-repro.enabled", havingValue = "true"
+)
+public class LexicographicIdReproRunner implements CommandLineRunner {
+  private static final String LEX_SET_KEY = "lex-repro:id:lex";
+
+  private final LexicographicIdRecordRepository repository;
+  private final EntityStream entityStream;
+  private final RedisTemplate<String, String> redisTemplate;
+
+  @Value(
+    "${demo.lexicographic-repro.count:50000}"
+  )
+  private int count;
+
+  @Value(
+    "${demo.lexicographic-repro.batch-size:1000}"
+  )
+  private int batchSize;
+
+  @Value(
+    "${demo.lexicographic-repro.threshold:lex000000000}"
+  )
+  private String threshold;
+
+  @Value(
+    "${demo.lexicographic-repro.update-count:100}"
+  )
+  private int updateCount;
+
+  @Override
+  public void run(String... args) {
+    log.info("LEXICOGRAPHIC REPRO: preparing {} records in batches of {}", count, batchSize);
+
+    log.info("LEXICOGRAPHIC REPRO: clearing existing records and sorted set {}", LEX_SET_KEY);
+    long cleanupStartNanos = System.nanoTime();
+    redisTemplate.delete(LEX_SET_KEY);
+    repository.deleteAll();
+    log.info("LEXICOGRAPHIC REPRO: cleanup completed in {} ms", elapsedMs(cleanupStartNanos));
+
+    long seedStartNanos = System.nanoTime();
+    seedRecords();
+    long seedElapsedMs = elapsedMs(seedStartNanos);
+
+    Long lexSetSize = redisTemplate.opsForZSet().size(LEX_SET_KEY);
+    long lexMemberCount = lexSetSize == null ? 0 : lexSetSize;
+    log.info("LEXICOGRAPHIC REPRO: seeded {} records in {} ms", count, seedElapsedMs);
+    log.info("LEXICOGRAPHIC REPRO: sorted set {} contains {} members", LEX_SET_KEY, lexMemberCount);
+
+    demonstrateWriteSideCleanup(lexMemberCount);
+    demonstrateMissingQueryFix(lexMemberCount);
+  }
+
+  private void demonstrateWriteSideCleanup(long lexMemberCount) {
+    if (count <= 0 || updateCount <= 0) {
+      log.info("WRITE-SIDE CLEANUP DEMO: skipped because count={} and update-count={}", count, updateCount);
+      return;
+    }
+
+    int actualUpdateCount = Math.min(updateCount, count);
+    long oldBranchMemberReads = lexMemberCount * actualUpdateCount;
+    log.info("WRITE-SIDE CLEANUP DEMO: updating {} existing records whose lexicographic field is the @Id",
+        actualUpdateCount);
+    log.info(
+        "WRITE-SIDE CLEANUP DEMO: older cleanup implementations used ZRANGE 0 -1 on {} once per update, " + "materializing about {} sorted-set members",
+        LEX_SET_KEY, oldBranchMemberReads);
+
+    long beforeMiB = usedHeapMiB();
+    long startNanos = System.nanoTime();
+    int step = Math.max(1, count / actualUpdateCount);
+    for (int i = 0; i < actualUpdateCount; i++) {
+      int recordIndex = Math.min(count - 1, i * step);
+      repository.save(new LexicographicIdRecord(recordId(recordIndex), "updated-%02d".formatted(i % 10)));
+    }
+    long elapsedMs = elapsedMs(startNanos);
+    long afterMiB = usedHeapMiB();
+    Long afterSize = redisTemplate.opsForZSet().size(LEX_SET_KEY);
+
+    log.info("WRITE-SIDE CLEANUP DEMO: update loop completed in {} ms", elapsedMs);
+    log.info("WRITE-SIDE CLEANUP DEMO: heap before={} MiB after={} MiB delta={} MiB", beforeMiB, afterMiB,
+        afterMiB - beforeMiB);
+    log.info("WRITE-SIDE CLEANUP DEMO: sorted set size after updates is {}", afterSize);
+  }
+
+  private void demonstrateMissingQueryFix(long lexMemberCount) {
+    long lexMatches = countLexMatchesGreaterThan(threshold);
+    log.info("MISSING QUERY FIX DEMO: ID.gt({}) has {} lexicographic matches in a {} member sorted set", threshold,
+        lexMatches, lexMemberCount);
+    log.info(
+        "MISSING QUERY FIX DEMO: the current stream predicate still calls rangeByLex(..., Limit.unlimited()) " + "before limit(1) is applied");
+
+    long beforeMiB = usedHeapMiB();
+    long startNanos = System.nanoTime();
+    List<LexicographicIdRecord> firstMatch = entityStream.of(LexicographicIdRecord.class).filter(
+        LexicographicIdRecord$.ID.gt(threshold)) //
+        .limit(1) //
+        .collect(Collectors.toList());
+    long elapsedMs = elapsedMs(startNanos);
+    long afterMiB = usedHeapMiB();
+
+    log.info("MISSING QUERY FIX DEMO: ID.gt({}) with limit(1) returned {} record(s) in {} ms", threshold, firstMatch
+        .size(), elapsedMs);
+    log.info("MISSING QUERY FIX DEMO: heap before={} MiB after={} MiB delta={} MiB", beforeMiB, afterMiB,
+        afterMiB - beforeMiB);
+  }
+
+  private void seedRecords() {
+    List<LexicographicIdRecord> batch = new ArrayList<>(batchSize);
+    for (int i = 0; i < count; i++) {
+      batch.add(new LexicographicIdRecord(recordId(i), "bucket-%02d".formatted(i % 10)));
+      if (batch.size() == batchSize) {
+        repository.saveAll(batch);
+        batch.clear();
+      }
+    }
+    if (!batch.isEmpty()) {
+      repository.saveAll(batch);
+    }
+  }
+
+  private String recordId(int index) {
+    return "lex%09d".formatted(index);
+  }
+
+  private long countLexMatchesGreaterThan(String value) {
+    Object result = redisTemplate.execute((RedisCallback<Object>) connection -> connection.execute("ZLEXCOUNT",
+        LEX_SET_KEY.getBytes(UTF_8), ("(" + value + "\uffff").getBytes(UTF_8), "+".getBytes(UTF_8)));
+
+    if (result instanceof Number number) {
+      return number.longValue();
+    }
+    if (result instanceof byte[] bytes) {
+      return Long.parseLong(new String(bytes, UTF_8));
+    }
+    return -1;
+  }
+
+  private long elapsedMs(long startNanos) {
+    return (System.nanoTime() - startNanos) / 1_000_000;
+  }
+
+  private long usedHeapMiB() {
+    Runtime runtime = Runtime.getRuntime();
+    return (runtime.totalMemory() - runtime.freeMemory()) / (1024 * 1024);
+  }
+}

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -58,7 +58,8 @@ release:
 
 signing:
   active: ALWAYS
-  armored: true
+  pgp:
+    armored: true
 
 deploy:
   maven:

--- a/redis-om-spring-ai/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
+++ b/redis-om-spring-ai/src/main/java/com/redis/om/spring/vectorize/DefaultEmbedder.java
@@ -303,10 +303,6 @@ public class DefaultEmbedder implements Embedder {
    */
   @Override
   public void processEntity(Object item) {
-    if (!isReady()) {
-      return;
-    }
-
     List<Field> fields = ObjectUtils.getFieldsWithAnnotation(item.getClass(), Vectorize.class);
     if (!fields.isEmpty()) {
       PropertyAccessor accessor = PropertyAccessorFactory.forBeanPropertyAccess(item);
@@ -338,10 +334,6 @@ public class DefaultEmbedder implements Embedder {
    */
   @Override
   public <S> void processEntities(Iterable<S> items) {
-    if (!isReady()) {
-      return;
-    }
-
     int batchSize = properties.getEmbeddingBatchSize();
     List<FieldData> batch = new ArrayList<>(batchSize);
 
@@ -694,13 +686,44 @@ public class DefaultEmbedder implements Embedder {
 
   /**
    * {@inheritDoc}
-   * 
-   * @return Always returns true as models are created on demand
+   *
+   * Always returns true — the embedder bean is available and all provider-specific
+   * checks are handled lazily inside each embedding call. Use
+   * {@link #isTransformersReady()} when you specifically need the DJL + ONNX/Transformers
+   * stack to be available (e.g. to gate tests via {@code @EnabledIf}).
    */
   @Override
   public boolean isReady() {
-    //return this.faceEmbeddingModel != null && this.transformersEmbeddingModel != null;
     return true;
+  }
+
+  /**
+   * Returns true when both DJL image models loaded and the ONNX Runtime native
+   * library is loadable in this JVM, meaning the Transformers embedding provider
+   * can be used. The ONNX check is cached after the first probe so repeated calls
+   * are cheap.
+   */
+  @Override
+  public boolean isTransformersReady() {
+    return imageEmbeddingModel != null && faceEmbeddingModel != null && isOnnxRuntimeAvailable();
+  }
+
+  private static volatile Boolean onnxRuntimeAvailable;
+
+  private static boolean isOnnxRuntimeAvailable() {
+    if (onnxRuntimeAvailable != null) {
+      return onnxRuntimeAvailable;
+    }
+    try {
+      // initialize=true forces the static initializer, which triggers the native lib load.
+      // On a second call after a failed init the JVM throws NoClassDefFoundError, so catch that too.
+      Class.forName("ai.onnxruntime.OrtEnvironment", true, Thread.currentThread().getContextClassLoader());
+      onnxRuntimeAvailable = true;
+    } catch (ClassNotFoundException | NoClassDefFoundError | UnsatisfiedLinkError | ExceptionInInitializerError e) {
+      logger.warn("ONNX Runtime not available, Transformers-backed embeddings will be skipped: " + e.getMessage());
+      onnxRuntimeAvailable = false;
+    }
+    return onnxRuntimeAvailable;
   }
 
   /**

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/LexicographicIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/LexicographicIndexer.java
@@ -1,12 +1,19 @@
 package com.redis.om.spring.indexing;
 
 import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.util.ReflectionUtils;
+
+import com.redis.om.spring.util.ObjectUtils;
 
 /**
  * Handles maintenance of lexicographic sorted sets for fields marked with lexicographic=true.
@@ -46,6 +53,7 @@ public class LexicographicIndexer {
   public void processEntity(Object entity, String entityId, boolean isNew, String entityPrefix) {
     Class<?> entityClass = entity.getClass();
     Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+    List<Field> idFields = ObjectUtils.getIdFieldsForEntityClass(entityClass);
 
     logger.debug(String.format("Processing entity %s with ID %s, isNew=%s, entityPrefix=%s", entityClass
         .getSimpleName(), entityId, isNew, entityPrefix));
@@ -73,9 +81,9 @@ public class LexicographicIndexer {
         logger.debug(String.format("Processing field %s, value=%s, member=%s, isNew=%s", fieldName, fieldValue, member,
             isNew));
 
-        // If updating, remove the old entry (we don't know the old value, so we need to find and remove it)
+        // If updating, remove the previous member before adding the current one.
         if (!isNew) {
-          removeOldEntry(sortedSetKey, entityId);
+          removeOldEntry(sortedSetKey, entityId, field, fieldValue, idFields);
         }
 
         // Add the new entry with score 0 (all entries have same score for lexicographic ordering)
@@ -95,6 +103,7 @@ public class LexicographicIndexer {
   public void processEntityDeletion(Object entity, String entityId, String entityPrefix) {
     Class<?> entityClass = entity.getClass();
     Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+    List<Field> idFields = ObjectUtils.getIdFieldsForEntityClass(entityClass);
 
     if (lexicographicFields == null || lexicographicFields.isEmpty()) {
       return;
@@ -102,7 +111,20 @@ public class LexicographicIndexer {
 
     for (String fieldName : lexicographicFields) {
       String sortedSetKey = entityPrefix + fieldName + ":lex";
-      removeOldEntry(sortedSetKey, entityId);
+      Field field = ReflectionUtils.findField(entityClass, fieldName);
+      if (field == null) {
+        logger.warn(String.format("Lexicographic field %s not found on class %s", fieldName, entityClass.getName()));
+        removeOldEntryByScan(sortedSetKey, entityId);
+        continue;
+      }
+
+      field.setAccessible(true);
+      Object fieldValue = ReflectionUtils.getField(field, entity);
+      if (isIdField(field, idFields) && fieldValue != null) {
+        removeExactEntry(sortedSetKey, member(fieldValue, entityId));
+      } else {
+        removeOldEntryByScan(sortedSetKey, entityId);
+      }
     }
   }
 
@@ -115,6 +137,7 @@ public class LexicographicIndexer {
    */
   public void processEntityDeletionById(Class<?> entityClass, String entityId, String entityPrefix) {
     Set<String> lexicographicFields = indexer.getLexicographicFields(entityClass);
+    Optional<Field> singleIdField = getSingleIdField(entityClass);
 
     if (lexicographicFields == null || lexicographicFields.isEmpty()) {
       return;
@@ -122,32 +145,87 @@ public class LexicographicIndexer {
 
     for (String fieldName : lexicographicFields) {
       String sortedSetKey = entityPrefix + fieldName + ":lex";
-      removeOldEntry(sortedSetKey, entityId);
+      if (singleIdField.map(idField -> idField.getName().equals(fieldName)).orElse(false)) {
+        removeExactEntry(sortedSetKey, member(entityId, entityId));
+      } else {
+        removeOldEntryByScan(sortedSetKey, entityId);
+      }
     }
   }
 
   /**
-   * Removes entries ending with the given entity ID from the sorted set.
+   * Removes the old lexicographic member for an update.
+   * <p>
+   * For ID fields the old member is deterministic, because the ID value is stable for
+   * the entity being updated. For other mutable lexicographic fields, the previous
+   * value may be unknown, so the fallback uses a cursor scan to avoid materializing the
+   * entire sorted set in JVM heap.
+   *
+   * @param sortedSetKey the sorted set key
+   * @param entityId     the entity ID to remove
+   * @param field        the lexicographic field
+   * @param fieldValue   the current field value
+   * @param idFields     ID fields declared by the entity
+   */
+  private void removeOldEntry(String sortedSetKey, String entityId, Field field, Object fieldValue,
+      List<Field> idFields) {
+    if (isIdField(field, idFields) && fieldValue != null) {
+      removeExactEntry(sortedSetKey, member(fieldValue, entityId));
+    } else {
+      removeOldEntryByScan(sortedSetKey, entityId);
+    }
+  }
+
+  /**
+   * Removes entries ending with the given entity ID from the sorted set using a cursor scan.
    * This is needed because we may not know the old field value during updates.
    *
    * @param sortedSetKey the sorted set key
    * @param entityId     the entity ID to remove
    */
-  private void removeOldEntry(String sortedSetKey, String entityId) {
-    // Get all members and remove those ending with #entityId
-    Set<String> members = redisTemplate.opsForZSet().range(sortedSetKey, 0, -1);
+  private void removeOldEntryByScan(String sortedSetKey, String entityId) {
     logger.debug(String.format("Removing old entries for entityId %s from %s", entityId, sortedSetKey));
-    logger.debug(String.format("Current members: %s", members));
-    if (members != null) {
-      String suffix = "#" + entityId;
-      logger.debug(String.format("Looking for entries ending with: %s", suffix));
-      for (String member : members) {
-        if (member.endsWith(suffix)) {
-          Long removed = redisTemplate.opsForZSet().remove(sortedSetKey, member);
-          logger.debug(String.format("Removed entry %s from sorted set %s (result: %s)", member, sortedSetKey,
-              removed));
+    String suffix = "#" + entityId;
+    logger.debug(String.format("Looking for entries ending with: %s", suffix));
+
+    ScanOptions options = ScanOptions.scanOptions().match("*" + escapeRedisGlob(suffix)).count(1000).build();
+    try (Cursor<ZSetOperations.TypedTuple<String>> cursor = redisTemplate.opsForZSet().scan(sortedSetKey, options)) {
+      while (cursor.hasNext()) {
+        String member = cursor.next().getValue();
+        if (member != null && member.endsWith(suffix)) {
+          removeExactEntry(sortedSetKey, member);
         }
       }
     }
+  }
+
+  private void removeExactEntry(String sortedSetKey, String member) {
+    Long removed = redisTemplate.opsForZSet().remove(sortedSetKey, member);
+    logger.debug(String.format("Removed entry %s from sorted set %s (result: %s)", member, sortedSetKey, removed));
+  }
+
+  private String member(Object fieldValue, String entityId) {
+    return fieldValue + "#" + entityId;
+  }
+
+  private boolean isIdField(Field field, List<Field> idFields) {
+    return idFields.stream().anyMatch(idField -> idField.getName().equals(field.getName()));
+  }
+
+  private Optional<Field> getSingleIdField(Class<?> entityClass) {
+    List<Field> idFields = ObjectUtils.getIdFieldsForEntityClass(entityClass);
+    return idFields.size() == 1 ? Optional.of(idFields.get(0)) : Optional.empty();
+  }
+
+  private String escapeRedisGlob(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == '*' || c == '?' || c == '[' || c == ']' || c == '\\') {
+        escaped.append('\\');
+      }
+      escaped.append(c);
+    }
+    return escaped.toString();
   }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/Embedder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/vectorize/Embedder.java
@@ -27,10 +27,22 @@ public interface Embedder {
 
   /**
    * Check if embedder is ready for use.
-   * 
+   *
    * @return true if ready
    */
   boolean isReady();
+
+  /**
+   * Check if the Transformers (ONNX) embedding provider is available.
+   * The default implementation returns false; concrete embedders that support
+   * Transformers (e.g. {@code DefaultEmbedder}) override this to probe DJL model
+   * availability and ONNX Runtime native library loadability.
+   *
+   * @return true if both DJL models and ONNX Runtime are available; false by default
+   */
+  default boolean isTransformersReady() {
+    return false;
+  }
 
   /**
    * Get text embeddings as byte arrays.

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -1,5 +1,6 @@
 plugins {
 	id 'java'
+	id 'jacoco'
 }
 
 apply plugin: 'org.springframework.boot'
@@ -95,6 +96,53 @@ compileTestJava {
 	options.generatedSourceOutputDirectory = file("${buildDir}/generated/sources/annotationProcessor/java/test")
 }
 
+// JaCoCo configuration
+jacoco {
+	toolVersion = "0.8.12"
+}
+
+jacocoTestReport {
+	dependsOn test
+	classDirectories.setFrom(files(
+			project(':redis-om-spring').sourceSets.main.output.classesDirs,
+			project(':redis-om-spring-ai').sourceSets.main.output.classesDirs
+			))
+	sourceDirectories.setFrom(files(
+			project(':redis-om-spring').sourceSets.main.allSource.srcDirs,
+			project(':redis-om-spring-ai').sourceSets.main.allSource.srcDirs
+			))
+	reports {
+		html.required = true
+		xml.required = true
+		csv.required = false
+	}
+}
+
+test.finalizedBy jacocoTestReport
+
+// Test-shard definitions — used by CI to run tests in parallel.
+// Each shard runs on its own runner with its own Testcontainers Redis instance,
+// so there are no shared-state conflicts.
+//
+// Usage:  ./gradlew :tests:test -PtestShard=document   (or hash | stream | other)
+// Omit -PtestShard to run the full suite (local dev / single-job CI).
+//
+// The 'other' shard is a catch-all: it includes everything under
+// com.redis.om.spring.** and excludes the patterns claimed by the named shards.
+// This means any new test package is automatically picked up without having to
+// add it here explicitly.
+ext.namedShards = [
+	document: [
+		'com.redis.om.spring.annotations.document.**',
+	],
+	hash: [
+		'com.redis.om.spring.annotations.hash.**',
+	],
+	stream: [
+		'com.redis.om.spring.search.stream.**',
+	],
+]
+
 test {
 	useJUnitPlatform()
 	maxHeapSize = "1g"
@@ -102,5 +150,24 @@ test {
 	testLogging {
 		events "passed", "skipped", "failed"
 		exceptionFormat = 'full'
+	}
+
+	// Apply shard filter when -PtestShard=<name> is supplied.
+	if (project.hasProperty('testShard')) {
+		def shard = project.property('testShard') as String
+		def validShards = namedShards.keySet() + ['other']
+		if (!validShards.contains(shard)) {
+			throw new GradleException("Unknown testShard '${shard}'. Valid values: ${validShards.join(', ')}")
+		}
+		filter {
+			if (shard == 'other') {
+				// Catch-all: everything not claimed by a named shard.
+				// New test packages are automatically included here.
+				includeTestsMatching 'com.redis.om.spring.**'
+				namedShards.values().flatten().each { excludeTestsMatching it }
+			} else {
+				namedShards[shard].each { includeTestsMatching it }
+			}
+		}
 	}
 }

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/ReferenceTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/ReferenceTest.java
@@ -20,6 +20,9 @@ import com.redis.om.spring.search.stream.EntityStream;
     properties = { "spring.config.location=classpath:application.yaml" }
 )
 class ReferenceTest extends AbstractBaseDocumentTest {
+  private static final int EXTREME_REFERENCE_COUNT = 10000;
+  private static final int EXTREME_REFERENCE_BATCH_SIZE = 500;
+
   @Autowired
   CityRepository cityRepository;
 
@@ -72,36 +75,45 @@ class ReferenceTest extends AbstractBaseDocumentTest {
         City.of("Savannah", ga), City.of("Augusta", ga) //
     );
     cityRepository.saveAll(cities);
+  }
 
-    if (refRepository.count() == 0) {
-      Set<Ref> refs = new HashSet<>();
-      for (int i = 0; i < 100; i++) {
-        refs.add(Ref.of("ref" + i));
+  private void prepareExtremeReferences() {
+    tooManyReferencesRepository.deleteAll();
+    refRepository.deleteAll();
+
+    Set<Ref> refs = new HashSet<>();
+    for (int i = 0; i < 100; i++) {
+      refs.add(Ref.of("ref" + i));
+    }
+    refRepository.saveAll(refs);
+
+    List<Ref> refList = new ArrayList<>(refs);
+    Random random = new Random();
+    List<TooManyReferences> batch = new ArrayList<>(EXTREME_REFERENCE_BATCH_SIZE);
+
+    for (int i = 0; i < EXTREME_REFERENCE_COUNT; i++) {
+      TooManyReferences tmr = TooManyReferences.of("ref" + i);
+
+      tmr.setRef1(refList.get(random.nextInt(refList.size())));
+      tmr.setRef2(refList.get(random.nextInt(refList.size())));
+      tmr.setRef3(refList.get(random.nextInt(refList.size())));
+      tmr.setRef4(refList.get(random.nextInt(refList.size())));
+      tmr.setRef5(refList.get(random.nextInt(refList.size())));
+      tmr.setRef6(refList.get(random.nextInt(refList.size())));
+      tmr.setRef7(refList.get(random.nextInt(refList.size())));
+      tmr.setRef8(refList.get(random.nextInt(refList.size())));
+      tmr.setRef9(refList.get(random.nextInt(refList.size())));
+      tmr.setRef10(refList.get(random.nextInt(refList.size())));
+
+      batch.add(tmr);
+      if (batch.size() == EXTREME_REFERENCE_BATCH_SIZE) {
+        tooManyReferencesRepository.saveAll(batch);
+        batch.clear();
       }
-      refRepository.saveAll(refs);
+    }
 
-      Set<TooManyReferences> tmrs = new HashSet<>();
-      List<Ref> refList = new ArrayList<>(refs);
-      Random random = new Random();
-
-      for (int i = 0; i < 10000; i++) {
-        TooManyReferences tmr = TooManyReferences.of("ref" + i);
-
-        tmr.setRef1(refList.get(random.nextInt(refList.size())));
-        tmr.setRef2(refList.get(random.nextInt(refList.size())));
-        tmr.setRef3(refList.get(random.nextInt(refList.size())));
-        tmr.setRef4(refList.get(random.nextInt(refList.size())));
-        tmr.setRef5(refList.get(random.nextInt(refList.size())));
-        tmr.setRef6(refList.get(random.nextInt(refList.size())));
-        tmr.setRef7(refList.get(random.nextInt(refList.size())));
-        tmr.setRef8(refList.get(random.nextInt(refList.size())));
-        tmr.setRef9(refList.get(random.nextInt(refList.size())));
-        tmr.setRef10(refList.get(random.nextInt(refList.size())));
-
-        tmrs.add(tmr);
-      }
-
-      tooManyReferencesRepository.saveAll(tmrs);
+    if (!batch.isEmpty()) {
+      tooManyReferencesRepository.saveAll(batch);
     }
   }
 
@@ -270,6 +282,8 @@ class ReferenceTest extends AbstractBaseDocumentTest {
 
   @Test
   void testExtremeReferencesWithFindAll() {
+    prepareExtremeReferences();
+
     List<TooManyReferences> allReferences = tooManyReferencesRepository.findAll();
 
     assertThat(allReferences).isNotEmpty();

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/vectorize/VectorizeDocumentTest.java
@@ -50,7 +50,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testImageIsVectorized() {
@@ -63,7 +63,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testSentenceIsVectorized() {
@@ -76,7 +76,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnImageSimilaritySearch() {
@@ -98,7 +98,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnSentenceSimilaritySearch() {
@@ -120,7 +120,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnHybridSentenceSimilaritySearch() {
@@ -143,7 +143,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnSentenceSimilaritySearchWithScores() {
@@ -167,7 +167,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testEmbedderCanVectorizeSentence() {
@@ -183,7 +183,7 @@ class VectorizeDocumentTest extends AbstractBaseDocumentTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testBulkEmbedMapEmbeddingsCorrectly() {

--- a/tests/src/test/java/com/redis/om/spring/annotations/hash/vectorize/VectorizeHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/hash/vectorize/VectorizeHashTest.java
@@ -50,7 +50,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testImageIsVectorized() {
@@ -63,7 +63,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testSentenceIsVectorized() {
@@ -76,7 +76,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnImageSimilaritySearch() {
@@ -98,7 +98,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnSentenceSimilaritySearch() {
@@ -120,7 +120,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnHybridSentenceSimilaritySearch() {
@@ -143,7 +143,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testKnnSentenceSimilaritySearchWithScores() {
@@ -167,7 +167,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testEmbedderCanVectorizeSentence() {
@@ -183,7 +183,7 @@ class VectorizeHashTest extends AbstractBaseEnhancedRedisTest {
 
   @Test
   @EnabledIf(
-      expression = "#{@featureExtractor.isReady()}", //
+      expression = "#{@featureExtractor.isTransformersReady()}", //
       loadContext = true //
   )
   void testBulkEmbedMapEmbeddingsCorrectly() {

--- a/tests/src/test/java/com/redis/om/spring/indexing/LexicographicIndexerTest.java
+++ b/tests/src/test/java/com/redis/om/spring/indexing/LexicographicIndexerTest.java
@@ -1,0 +1,108 @@
+package com.redis.om.spring.indexing;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import com.redis.om.spring.annotations.Indexed;
+
+@ExtendWith(
+  MockitoExtension.class
+)
+class LexicographicIndexerTest {
+  @Mock
+  RedisTemplate<String, String> redisTemplate;
+
+  @Mock
+  RediSearchIndexer rediSearchIndexer;
+
+  @Mock
+  ZSetOperations<String, String> zSetOperations;
+
+  @Mock
+  Cursor<ZSetOperations.TypedTuple<String>> cursor;
+
+  @Mock
+  ZSetOperations.TypedTuple<String> tuple;
+
+  private LexicographicIndexer lexicographicIndexer;
+
+  @BeforeEach
+  void setUp() {
+    when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+    lexicographicIndexer = new LexicographicIndexer(redisTemplate, rediSearchIndexer);
+  }
+
+  @Test
+  void processEntityRemovesLexicographicIdByExactMemberWithoutFullRangeScan() {
+    when(rediSearchIndexer.getLexicographicFields(LexicographicIdEntity.class)).thenReturn(Set.of("id"));
+
+    LexicographicIdEntity entity = new LexicographicIdEntity("session-42");
+
+    lexicographicIndexer.processEntity(entity, "session-42", false, "sessions:");
+
+    verify(zSetOperations).remove("sessions:id:lex", "session-42#session-42");
+    verify(zSetOperations).add("sessions:id:lex", "session-42#session-42", 0.0);
+    verify(zSetOperations, never()).range(anyString(), anyLong(), anyLong());
+    verify(zSetOperations, never()).scan(anyString(), any(ScanOptions.class));
+  }
+
+  @Test
+  void processEntityUsesCursorScanForMutableLexicographicFieldWithoutFullRangeScan() {
+    when(rediSearchIndexer.getLexicographicFields(MutableLexicographicEntity.class)).thenReturn(Set.of("sku"));
+    when(zSetOperations.scan(eq("products:sku:lex"), any(ScanOptions.class))).thenReturn(cursor);
+    when(cursor.hasNext()).thenReturn(true, false);
+    when(cursor.next()).thenReturn(tuple);
+    when(tuple.getValue()).thenReturn("old-sku#product-1");
+
+    MutableLexicographicEntity entity = new MutableLexicographicEntity("product-1", "new-sku");
+
+    lexicographicIndexer.processEntity(entity, "product-1", false, "products:");
+
+    verify(zSetOperations).scan(eq("products:sku:lex"), any(ScanOptions.class));
+    verify(zSetOperations).remove("products:sku:lex", "old-sku#product-1");
+    verify(zSetOperations).add("products:sku:lex", "new-sku#product-1", 0.0);
+    verify(zSetOperations, never()).range(anyString(), anyLong(), anyLong());
+    verify(cursor).close();
+  }
+
+  @Test
+  void processEntityDeletionRemovesLexicographicIdByExactMemberWithoutFullRangeScan() {
+    when(rediSearchIndexer.getLexicographicFields(LexicographicIdEntity.class)).thenReturn(Set.of("id"));
+
+    LexicographicIdEntity entity = new LexicographicIdEntity("session-42");
+
+    lexicographicIndexer.processEntityDeletion(entity, "session-42", "sessions:");
+
+    verify(zSetOperations).remove("sessions:id:lex", "session-42#session-42");
+    verify(zSetOperations, never()).range(anyString(), anyLong(), anyLong());
+    verify(zSetOperations, never()).scan(anyString(), any(ScanOptions.class));
+  }
+
+  private record LexicographicIdEntity(@Id @Indexed(
+      lexicographic = true
+  ) String id) {
+  }
+
+  private record MutableLexicographicEntity(@Id String id, @Indexed(
+      lexicographic = true
+  ) String sku) {
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamDocsTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamDocsTest.java
@@ -101,8 +101,8 @@ public class DetachedEntityStreamDocsTest extends AbstractBaseDocumentTest {
     SearchStream<Bicycle> stream = entityStream.of(Bicycle.class, "idx:bicycle", "id");
     List<Bicycle> bicycles = stream.filter(MODEL.eq("Jigger")).collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model").containsOnly("Jigger");
   }
 
   @Test
@@ -111,8 +111,8 @@ public class DetachedEntityStreamDocsTest extends AbstractBaseDocumentTest {
     SearchStream<Bicycle> stream = entityStream.of(Bicycle.class, "idx:bicycle", "id");
     List<Bicycle> bicycles = stream.filter(MODEL.eq("Jigger")).collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model").containsOnly("Jigger");
   }
 
   @Test
@@ -124,10 +124,9 @@ public class DetachedEntityStreamDocsTest extends AbstractBaseDocumentTest {
         .filter(PRICE.between(BigDecimal.valueOf(815), BigDecimal.valueOf(815))) //
         .collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("BikeShind");
-    assertThat(bicycles.get(0).getBrand()).isEqualTo("ThrillCycle");
-    assertThat(bicycles.get(0).getPrice()).isEqualTo(BigDecimal.valueOf(815));
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model", "brand", "price")
+        .containsOnly(org.assertj.core.groups.Tuple.tuple("BikeShind", "ThrillCycle", BigDecimal.valueOf(815)));
   }
 
   @Test
@@ -138,10 +137,8 @@ public class DetachedEntityStreamDocsTest extends AbstractBaseDocumentTest {
         .collect(Collectors.toList());
 
     assertThat(bicycles).hasSize(2);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Chook air 5");
-    assertThat(bicycles.get(1).getModel()).isEqualTo("BikeShind");
-    assertThat(bicycles.get(0).getPrice()).isEqualTo(BigDecimal.valueOf(815));
-    assertThat(bicycles.get(1).getPrice()).isEqualTo(BigDecimal.valueOf(815));
+    assertThat(bicycles).extracting("model").containsExactlyInAnyOrder("Chook air 5", "BikeShind");
+    assertThat(bicycles).extracting("price").containsOnly(BigDecimal.valueOf(815));
   }
 
   @Data

--- a/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamHashTest.java
+++ b/tests/src/test/java/com/redis/om/spring/search/stream/DetachedEntityStreamHashTest.java
@@ -108,8 +108,8 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
     SearchStream<Bicycle> stream = entityStream.of(Bicycle.class, "idx:hashbikes", "id");
     List<Bicycle> bicycles = stream.filter(MODEL.eq("Jigger")).collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model").containsOnly("Jigger");
   }
 
   @Test
@@ -118,8 +118,8 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
     SearchStream<Bicycle> stream = entityStream.of(Bicycle.class, "idx:hashbikes", "id");
     List<Bicycle> bicycles = stream.filter(MODEL.eq("Jigger")).collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Jigger");
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model").containsOnly("Jigger");
   }
 
   @Test
@@ -131,10 +131,9 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
         .filter(PRICE.between(815.0, 815.0)) //
         .collect(Collectors.toList());
 
-    assertThat(bicycles).hasSize(1);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("BikeShind");
-    assertThat(bicycles.get(0).getBrand()).isEqualTo("ThrillCycle");
-    assertThat(bicycles.get(0).getPrice()).isEqualTo(815.0);
+    assertThat(bicycles).filteredOn(Objects::nonNull).hasSize(1)
+        .extracting("model", "brand", "price")
+        .containsOnly(org.assertj.core.groups.Tuple.tuple("BikeShind", "ThrillCycle", 815.0));
   }
 
   @Test
@@ -145,10 +144,8 @@ public class DetachedEntityStreamHashTest extends AbstractBaseEnhancedRedisTest 
         .collect(Collectors.toList());
 
     assertThat(bicycles).hasSize(2);
-    assertThat(bicycles.get(0).getModel()).isEqualTo("Chook air 5");
-    assertThat(bicycles.get(1).getModel()).isEqualTo("BikeShind");
-    assertThat(bicycles.get(0).getPrice()).isEqualTo(815.0);
-    assertThat(bicycles.get(1).getPrice()).isEqualTo(815.0);
+    assertThat(bicycles).extracting("model").containsExactlyInAnyOrder("Chook air 5", "BikeShind");
+    assertThat(bicycles).extracting("price").containsOnly(815.0);
   }
 
   public static Map<String, String> convertBicycleToStringMap(Bicycle bicycle) {


### PR DESCRIPTION
## Summary

Backports CI/release improvements from `main` (up to v2.0.5) and the lexicographic index scan fix to the `1.0.x-spring-boot-3.4` branch.

### Bug fix
- **fix: avoid full lexicographic index scans** (`14f947d0` / #749)

### Release workflow / CI hardening
- SHA-pin all GitHub Actions to immutable commit SHAs (supply chain protection)
- Least-privilege `permissions` blocks on `build.yml`, `release.yml`, `early-access.yml`
- Native `concurrency` groups replace `styfle/cancel-workflow-action`
- Add `dependency-review` workflow, `CODEOWNERS`, and PR template
- Fix JReleaser signing deprecation (`signing.armored` → `signing.pgp.armored`)
- Switch JDK distribution from zulu to temurin (Azul CDN is flaky)

### Build pipeline
- Split single-job build into `style → compile → test (4 shards)` pipeline — matching `main`
- Add JaCoCo test coverage reporting

### Test stability
- `VectorizeDocumentTest` / `VectorizeHashTest`: gate on `isTransformersReady()` so tests skip on CI runners without ONNX Runtime native lib
- `DetachedEntityStreamDocsTest` / `DetachedEntityStreamHashTest`: order-independent assertions and null-safe entity handling

## Test plan
- [ ] CI passes on this branch
- [ ] Merge, then trigger the Release workflow on `1.0.x-spring-boot-3.4` with `version = 1.0.8`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> LexicographicIndexer changes affect save/update/delete indexing paths at scale; release/CI workflow edits can block merges or releases if misconfigured, but core auth/data paths are untouched.
> 
> **Overview**
> Backports **main** CI/release hardening and a **lexicographic indexing** performance fix onto the 1.0.x line.
> 
> **Runtime fix:** `LexicographicIndexer` no longer loads entire lex sorted sets via `ZRANGE 0 -1` on updates/deletes. Lexicographic **@Id** fields get **exact** `ZREM` of `value#entityId`; other lex fields use **ZSCAN** with a glob on `#entityId`. New unit tests and an opt-in `roms-documents` repro runner document write-side vs query-side behavior.
> 
> **CI/build:** PR `build` is split into **style → compile → four parallel test shards** (`-PtestShard`) plus **demos**; JaCoCo reports core modules. Workflows get **SHA-pinned** actions, tighter **permissions**, **concurrency** groups (release drops `cancel-workflow-action`), **dependency-review**, **CODEOWNERS**, and PR template. JReleaser signing moves to `signing.pgp.armored`.
> 
> **Test/embedder stability:** Vectorize tests gate on **`isTransformersReady()`** (DJL + ONNX probe) instead of broad `isReady()`; embedder no longer no-ops batch/single processing when “not ready.” Reference extreme-data seeding is on-demand; detached entity-stream tests use order-independent, null-safe assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1bfb16e03aa0c437d3d2135b8e060b067315af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->