### PR TITLE
ci: restore demo module test coverage in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,20 +148,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradlew-
 
       - name: Build and test demos
-        run: |
-          ./gradlew \
-            :demos:roms-documents:build \
-            :demos:roms-hashes:build \
-            :demos:roms-modeling:build \
-            :demos:roms-multi-acl-account:build \
-            :demos:roms-permits:build \
-            :demos:roms-vectorizers:build \
-            :demos:roms-vss-movies:build \
-            :demos:roms-vss:build \
-            :demos:roms-multitenant:build \
-            :demos:roms-hybrid:build \
-            :demos:roms-amr-entraid:build \
-            -S
+        run: ./gradlew :demos:build -S
 
       - name: Upload demo test reports
         if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,22 +3,31 @@ name: Build
 on:
   pull_request:
 
-jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+permissions:
+  contents: read
+  actions: write  # required for actions/upload-artifact
 
+concurrency:
+  group: build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  # ── 1. Format check (fast, ~30s, no Docker needed) ──────────────────────────
+  style:
+    name: Code Style
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
         with:
           java-version: 21
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
@@ -26,24 +35,124 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Gradle wrapper
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
           restore-keys: ${{ runner.os }}-gradlew-
 
-      - name: Code Style Check
-        run: |
-          ./gradlew spotlessCheck -S
+      - name: Spotless check
+        run: ./gradlew spotlessCheck -S
 
-      - name: Build
-        run: |
-          ./gradlew build aggregateTestReport -S
+  # ── 2. Compile (fast, ~1–2 min, no tests, no Docker) ────────────────────────
+  compile:
+    name: Compile
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Compile (no tests)
+        run: ./gradlew assemble -S
+
+  # ── 3. Integration tests — 4 shards run in parallel on separate runners ───────
+  test:
+    name: Tests (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    needs: compile          # only run if compile passes
+    strategy:
+      matrix:
+        shard: [document, hash, stream, other]
+      fail-fast: false      # let all shards finish even if one fails
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Run tests (${{ matrix.shard }})
+        run: ./gradlew :tests:test -PtestShard=${{ matrix.shard }} -S
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: test-reports
-          path: |
-            build/reports/tests/aggregate/
+          name: test-reports-${{ matrix.shard }}
+          path: tests/build/reports/tests/test/
+
+  # ── 4. Demo module tests ─────────────────────────────────────────────────────
+  demos:
+    name: Demo Tests
+    runs-on: ubuntu-latest
+    needs: compile
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9  # v4
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}-${{ hashFiles('**/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Cache Gradle wrapper
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradlew-${{ hashFiles('**/gradlew') }}
+          restore-keys: ${{ runner.os }}-gradlew-
+
+      - name: Build and test demos
+        run: ./gradlew :demos:build -S
+
+      - name: Upload demo test reports
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: test-reports-demos
+          path: demos/*/build/reports/tests/test/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,20 @@ jobs:
           restore-keys: ${{ runner.os }}-gradlew-
 
       - name: Build and test demos
-        run: ./gradlew :demos:build -S
+        run: |
+          ./gradlew \
+            :demos:roms-documents:build \
+            :demos:roms-hashes:build \
+            :demos:roms-modeling:build \
+            :demos:roms-multi-acl-account:build \
+            :demos:roms-permits:build \
+            :demos:roms-vectorizers:build \
+            :demos:roms-vss-movies:build \
+            :demos:roms-vss:build \
+            :demos:roms-multitenant:build \
+            :demos:roms-hybrid:build \
+            :demos:roms-amr-entraid:build \
+            -S
 
       - name: Upload demo test reports
         if: failure()

--- a/demos/build.gradle
+++ b/demos/build.gradle
@@ -110,3 +110,9 @@ test {
 		exceptionFormat = 'full'
 	}
 }
+
+// Make :demos:build cascade to all demo subprojects so that
+// ./gradlew :demos:build covers all demo tests on CI.
+tasks.named('build') {
+	dependsOn subprojects.collect { "${it.path}:build" }
+}


### PR DESCRIPTION
## Summary

Restores demo test coverage lost when the single-job build was split into shards in #751. Also brings the full sharded pipeline to 1.1.x since the linter reverted build.yml before #751 was pushed.

### Changes
- Add \`demos\` job: runs \`./gradlew :demos:build\` after \`compile\`, covering all demo subproject tests on every PR
- Restore sharded test structure (\`style\`, \`compile\`, \`test\` matrix, \`demos\`) with SHA-pinned actions and temurin JDK

## Test plan
- [ ] CI shows 4 test shards + demo job running in parallel

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflow and Gradle build orchestration for demo modules; no production runtime or library behavior is modified.
> 
> **Overview**
> Restores **demo module test coverage** in CI after sharded tests stopped exercising demos.
> 
> Adds a **`demos` GitHub Actions job** (after `compile`, parallel with the test matrix) that runs `./gradlew :demos:build` and uploads `demos/*/build/reports/tests/test/` on failure, mirroring the existing shard jobs’ Java/cache setup.
> 
> Updates **`demos/build.gradle`** so `:demos:build` **depends on every demo subproject’s `:build`**, ensuring one root Gradle invocation runs all demo builds/tests. Also fixes the **`test { }` block** so it closes correctly before the new `build` task configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c6b9a89c656c5a1e675d59777bc4af43865595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->