### PR TITLE
fix: preserve phonetic text matching after tag fields

### DIFF
--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
@@ -80,6 +80,14 @@ class IndexDefinitionBuilder {
         field -> (isDocument ? "$." : "") + field.getName());
   }
 
+  private boolean hasPhonetic(Searchable searchable) {
+    return searchable.phonetic() != null && !searchable.phonetic().isEmpty();
+  }
+
+  private boolean hasPhonetic(TextIndexed textIndexed) {
+    return textIndexed.phonetic() != null && !textIndexed.phonetic().isEmpty();
+  }
+
   // ---------------------------------------------------------------------------
   // Field processing pipeline
   // ---------------------------------------------------------------------------
@@ -326,10 +334,11 @@ class IndexDefinitionBuilder {
         logger.info(String.format("Tracked lexicographic field %s on class %s", field.getName(), entityClass
             .getName()));
       }
-      fields.add(SearchField.of(field, factory.indexAsTextFieldFor(field, isDocument, prefix, searchable)));
+      fields.add(SearchField.of(field, factory.indexAsTextFieldFor(field, isDocument, prefix, searchable), hasPhonetic(
+          searchable)));
     } else if (field.isAnnotationPresent(TextIndexed.class)) {
       TextIndexed ti = field.getAnnotation(TextIndexed.class);
-      fields.add(SearchField.of(field, factory.indexAsTextFieldFor(field, isDocument, prefix, ti)));
+      fields.add(SearchField.of(field, factory.indexAsTextFieldFor(field, isDocument, prefix, ti), hasPhonetic(ti)));
     } else if (field.isAnnotationPresent(TagIndexed.class)) {
       TagIndexed ti = field.getAnnotation(TagIndexed.class);
       fields.add(SearchField.of(field, factory.indexAsTagFieldFor(field, isDocument, prefix, ti)));
@@ -486,7 +495,7 @@ class IndexDefinitionBuilder {
           textField.indexMissing();
         if (searchable.indexEmpty())
           textField.indexEmpty();
-        fields.add(SearchField.of(subField, textField));
+        fields.add(SearchField.of(subField, textField, hasPhonetic(searchable)));
         continue;
       }
 
@@ -508,7 +517,7 @@ class IndexDefinitionBuilder {
           textField.indexMissing();
         if (textIndexed.indexEmpty())
           textField.indexEmpty();
-        fields.add(SearchField.of(subField, textField));
+        fields.add(SearchField.of(subField, textField, hasPhonetic(textIndexed)));
         continue;
       }
 
@@ -706,7 +715,7 @@ class IndexDefinitionBuilder {
 
           fieldList.add(SearchField.of(field, factory.getTextField(fieldName, searchable.weight(), searchable
               .sortable(), searchable.nostem(), searchable.noindex(), phonetic, searchable.indexMissing(), searchable
-                  .indexEmpty())));
+                  .indexEmpty()), phonetic != null));
 
           continue;
         }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/RediSearchIndexer.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/RediSearchIndexer.java
@@ -251,6 +251,23 @@ public class RediSearchIndexer {
     return searchFields;
   }
 
+  private List<SchemaField> schemaFieldsForCreateIndex(List<SearchField> searchFields) {
+    List<SearchField> orderedFields = new ArrayList<>();
+    int firstTagFieldIndex = -1;
+    for (SearchField searchField : searchFields) {
+      if (searchField.isPhoneticTextField() && firstTagFieldIndex != -1) {
+        orderedFields.add(firstTagFieldIndex, searchField);
+        firstTagFieldIndex++;
+      } else {
+        if (firstTagFieldIndex == -1 && searchField.getSchemaField() instanceof TagField) {
+          firstTagFieldIndex = orderedFields.size();
+        }
+        orderedFields.add(searchField);
+      }
+    }
+    return orderedFields.stream().map(SearchField::getSchemaField).toList();
+  }
+
   /**
    * Evaluates any SpEL templates in each raw prefix and normalizes the result with a
    * trailing colon via {@link #getKeyspace(String)}. Used when an
@@ -406,7 +423,7 @@ public class RediSearchIndexer {
       }
 
       updateTTLSettings(cl, entityPrefix, isDocument, document, allClassFields);
-      List<SchemaField> fields = searchFields.stream().map(SearchField::getSchemaField).toList();
+      List<SchemaField> fields = schemaFieldsForCreateIndex(searchFields);
       entityClassToSchema.put(cl, searchFields);
       entityClassToIndexName.put(cl, indexName);
 
@@ -1025,7 +1042,7 @@ public class RediSearchIndexer {
           Optional.empty();
       updateTTLSettings(entityClass, entityPrefix, isDocument, document, allClassFields);
 
-      List<SchemaField> fields = searchFields.stream().map(SearchField::getSchemaField).toList();
+      List<SchemaField> fields = schemaFieldsForCreateIndex(searchFields);
 
       // Note: We don't update entityClassToSchema or entityClassToIndexName here
       // because this method is for creating indexes with custom names/prefixes.
@@ -1105,7 +1122,7 @@ public class RediSearchIndexer {
         registerSecondaryKeyspace(entityPrefix, entityClass);
       }
 
-      List<SchemaField> fields = searchFields.stream().map(SearchField::getSchemaField).toList();
+      List<SchemaField> fields = schemaFieldsForCreateIndex(searchFields);
 
       applyCreationMode(opsForSearch, params, fields, repoIndexingOptions.creationMode(), indexName, entityClass,
           () -> indexExistsFor(entityClass, indexName), () -> {

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/SearchField.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/SearchField.java
@@ -19,6 +19,7 @@ import redis.clients.jedis.search.schemafields.SchemaField;
 public class SearchField {
   private final Field field;
   private final SchemaField schemaField;
+  private final boolean phoneticTextField;
 
   /**
    * Creates a new SearchField with the specified Java field and schema field.
@@ -27,8 +28,13 @@ public class SearchField {
    * @param schemaField the corresponding RediSearch schema field
    */
   public SearchField(Field field, SchemaField schemaField) {
+    this(field, schemaField, false);
+  }
+
+  public SearchField(Field field, SchemaField schemaField, boolean phoneticTextField) {
     this.field = field;
     this.schemaField = schemaField;
+    this.phoneticTextField = phoneticTextField;
   }
 
   /**
@@ -40,6 +46,10 @@ public class SearchField {
    */
   public static SearchField of(Field field, SchemaField schemaField) {
     return new SearchField(field, schemaField);
+  }
+
+  public static SearchField of(Field field, SchemaField schemaField, boolean phoneticTextField) {
+    return new SearchField(field, schemaField, phoneticTextField);
   }
 
   /**
@@ -58,5 +68,9 @@ public class SearchField {
    */
   public Field getField() {
     return field;
+  }
+
+  public boolean isPhoneticTextField() {
+    return phoneticTextField;
   }
 }

--- a/tests/src/test/java/com/redis/om/spring/annotations/document/SearchablePhoneticTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/document/SearchablePhoneticTest.java
@@ -1,0 +1,238 @@
+package com.redis.om.spring.annotations.document;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.annotation.DirtiesContext;
+
+import com.redis.om.spring.AbstractBaseOMTest;
+import com.redis.om.spring.TestConfig;
+import com.redis.om.spring.annotations.EnableRedisDocumentRepositories;
+import com.redis.om.spring.fixtures.document.model.PhoneticChunkDoc;
+import com.redis.om.spring.fixtures.document.model.PhoneticDoc;
+import com.redis.om.spring.fixtures.document.model.PhoneticMultiFieldDoc;
+import com.redis.om.spring.fixtures.document.model.PhoneticReferenceDoc;
+import com.redis.om.spring.fixtures.document.model.PhoneticTextIndexedDoc;
+import com.redis.om.spring.fixtures.hash.model.PhoneticHash;
+import com.redis.om.spring.ops.search.SearchOperations;
+
+import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.search.FTCreateParams;
+import redis.clients.jedis.search.FieldName;
+import redis.clients.jedis.search.IndexDataType;
+import redis.clients.jedis.search.Query;
+import redis.clients.jedis.search.SearchResult;
+import redis.clients.jedis.search.schemafields.SchemaField;
+import redis.clients.jedis.search.schemafields.TagField;
+import redis.clients.jedis.search.schemafields.TextField;
+
+@DirtiesContext
+@SpringBootTest(
+    classes = SearchablePhoneticTest.Config.class,
+    properties = { "spring.main.allow-bean-definition-overriding=true" }
+)
+class SearchablePhoneticTest extends AbstractBaseOMTest {
+  private static final String INDEX_NAME = "searchable_phonetic_test_idx";
+  private static final String PREFIX = "searchable_phonetic_test:";
+  private static final String KEY = PREFIX + "1";
+  private static final String CHUNK_INDEX_NAME = "searchable_phonetic_chunk_test_idx";
+  private static final String CHUNK_PREFIX = "searchable_phonetic_chunk_test:";
+  private static final String CHUNK_KEY = CHUNK_PREFIX + "1";
+  private static final String TEXT_INDEXED_INDEX_NAME = "searchable_phonetic_text_indexed_test_idx";
+  private static final String TEXT_INDEXED_PREFIX = "searchable_phonetic_text_indexed_test:";
+  private static final String TEXT_INDEXED_KEY = TEXT_INDEXED_PREFIX + "1";
+  private static final String MULTI_FIELD_INDEX_NAME = "searchable_phonetic_multi_field_test_idx";
+  private static final String MULTI_FIELD_PREFIX = "searchable_phonetic_multi_field_test:";
+  private static final String MULTI_FIELD_KEY = MULTI_FIELD_PREFIX + "1";
+  private static final String REFERENCE_INDEX_NAME = "searchable_phonetic_reference_test_idx";
+  private static final String REFERENCE_PREFIX = "searchable_phonetic_reference_test:";
+  private static final String REFERENCE_KEY = REFERENCE_PREFIX + "1";
+  private static final String HASH_INDEX_NAME = "searchable_phonetic_hash_test_idx";
+  private static final String HASH_PREFIX = "searchable_phonetic_hash_test:";
+  private static final String HASH_KEY = HASH_PREFIX + "1";
+  private static final String TEXT_FIRST_INDEX_NAME = "searchable_phonetic_text_first_test_idx";
+  private static final String TEXT_FIRST_PREFIX = "searchable_phonetic_text_first_test:";
+  private static final String TEXT_FIRST_KEY = TEXT_FIRST_PREFIX + "1";
+  private static final String TAG_FIRST_INDEX_NAME = "searchable_phonetic_tag_first_test_idx";
+  private static final String TAG_FIRST_PREFIX = "searchable_phonetic_tag_first_test:";
+  private static final String TAG_FIRST_KEY = TAG_FIRST_PREFIX + "1";
+
+  @BeforeEach
+  void setUp() {
+    cleanRedis();
+  }
+
+  @AfterEach
+  void cleanUp() {
+    cleanRedis();
+  }
+
+  @Test
+  void searchablePhoneticCreatesRedisPhoneticSchemaAndMatchesSoundAlikeTerms() {
+    assertTrue(indexer.createIndexFor(PhoneticDoc.class, INDEX_NAME, PREFIX));
+
+    modulesOperations.opsForJSON().set(KEY, Map.of("phoneticName", "John", "plainName", "John"));
+
+    SearchOperations<String> ops = modulesOperations.opsForSearch(INDEX_NAME);
+    SearchResult phoneticResult = ops.search(new Query("@phoneticName:Jon"));
+    SearchResult plainResult = ops.search(new Query("@plainName:Jon"));
+
+    assertThat(phoneticResult.getTotalResults()).isEqualTo(1);
+    assertThat(plainResult.getTotalResults()).isZero();
+  }
+
+  @Test
+  void searchablePhoneticFieldAfterIndexedTagFieldMatchesSoundAlikeTerms() {
+    assertTrue(indexer.createIndexFor(PhoneticChunkDoc.class, CHUNK_INDEX_NAME, CHUNK_PREFIX));
+
+    modulesOperations.opsForJSON().set(CHUNK_KEY, Map.of("chunkText", "cash", "filingDate", "2026-06-15"));
+
+    SearchResult result = modulesOperations.opsForSearch(CHUNK_INDEX_NAME).search(new Query("@chunkText:kash"));
+
+    assertThat(result.getTotalResults()).isEqualTo(1);
+  }
+
+  @Test
+  void textIndexedPhoneticFieldAfterIndexedTagFieldMatchesSoundAlikeTerms() {
+    assertTrue(indexer.createIndexFor(PhoneticTextIndexedDoc.class, TEXT_INDEXED_INDEX_NAME, TEXT_INDEXED_PREFIX));
+
+    modulesOperations.opsForJSON().set(TEXT_INDEXED_KEY, Map.of("chunkText", "cash", "filingDate", "2026-06-15"));
+
+    SearchResult result = modulesOperations.opsForSearch(TEXT_INDEXED_INDEX_NAME).search(new Query("@chunkText:kash"));
+
+    assertThat(result.getTotalResults()).isEqualTo(1);
+  }
+
+  @Test
+  void multipleSearchablePhoneticFieldsAfterIndexedTagFieldsMatchSoundAlikeTerms() {
+    assertTrue(indexer.createIndexFor(PhoneticMultiFieldDoc.class, MULTI_FIELD_INDEX_NAME, MULTI_FIELD_PREFIX));
+
+    modulesOperations.opsForJSON().set(MULTI_FIELD_KEY, Map.of(
+        "chunkText", "cash",
+        "customerName", "John",
+        "filingDate", "2026-06-15",
+        "category", "contract"
+    ));
+
+    SearchOperations<String> ops = modulesOperations.opsForSearch(MULTI_FIELD_INDEX_NAME);
+
+    assertThat(ops.search(new Query("@chunkText:kash")).getTotalResults()).isEqualTo(1);
+    assertThat(ops.search(new Query("@customerName:Jon")).getTotalResults()).isEqualTo(1);
+  }
+
+  @Test
+  void referencedSearchablePhoneticFieldIsCreatedBeforeReferenceTagField() {
+    assertTrue(indexer.createIndexFor(PhoneticReferenceDoc.class, REFERENCE_INDEX_NAME, REFERENCE_PREFIX));
+
+    List<String> attributes = attributeNames(REFERENCE_INDEX_NAME);
+
+    assertThat(attributes).contains("owner_name", "owner");
+    assertThat(attributes.indexOf("owner_name")).isLessThan(attributes.indexOf("owner"));
+  }
+
+  @Test
+  void searchablePhoneticHashFieldAfterIndexedTagFieldMatchesSoundAlikeTerms() {
+    assertTrue(indexer.createIndexFor(PhoneticHash.class, HASH_INDEX_NAME, HASH_PREFIX));
+
+    template.opsForHash().putAll(HASH_KEY, Map.of("chunkText", "cash", "filingDate", "2026-06-15"));
+
+    SearchResult result = modulesOperations.opsForSearch(HASH_INDEX_NAME).search(new Query("@chunkText:kash"));
+
+    assertThat(result.getTotalResults()).isEqualTo(1);
+  }
+
+  @Test
+  void textPhoneticFieldBeforeTagFieldMatchesSoundAlikeTerms() {
+    createIndex(TEXT_FIRST_INDEX_NAME, TEXT_FIRST_PREFIX, List.of(
+        TextField.of(FieldName.of("$.chunkText").as("chunkText")).phonetic("dm:en"),
+        TagField.of(FieldName.of("$.filingDate").as("filingDate"))
+    ));
+    modulesOperations.opsForJSON().set(TEXT_FIRST_KEY, Map.of("chunkText", "cash", "filingDate", "2026-06-15"));
+
+    SearchResult result = modulesOperations.opsForSearch(TEXT_FIRST_INDEX_NAME).search(new Query("@chunkText:kash"));
+
+    assertThat(result.getTotalResults()).isEqualTo(1);
+  }
+
+  @Test
+  void tagFieldBeforeTextPhoneticFieldDoesNotMatchSoundAlikeTerms() {
+    createIndex(TAG_FIRST_INDEX_NAME, TAG_FIRST_PREFIX, List.of(
+        TagField.of(FieldName.of("$.filingDate").as("filingDate")),
+        TextField.of(FieldName.of("$.chunkText").as("chunkText")).phonetic("dm:en")
+    ));
+    modulesOperations.opsForJSON().set(TAG_FIRST_KEY, Map.of("chunkText", "cash", "filingDate", "2026-06-15"));
+
+    SearchResult result = modulesOperations.opsForSearch(TAG_FIRST_INDEX_NAME).search(new Query("@chunkText:kash"));
+
+    assertThat(result.getTotalResults()).isZero();
+  }
+
+  private void createIndex(String indexName, String prefix, List<SchemaField> fields) {
+    FTCreateParams params = FTCreateParams.createParams().on(IndexDataType.JSON).prefix(prefix);
+    modulesOperations.opsForSearch(indexName).createIndex(params, fields);
+  }
+
+  private List<String> attributeNames(String indexName) {
+    Object rawAttributes = modulesOperations.opsForSearch(indexName).getInfo().get("attributes");
+    assertThat(rawAttributes).isInstanceOf(List.class);
+
+    List<String> names = new ArrayList<>();
+    for (Object rawAttribute : (List<?>) rawAttributes) {
+      assertThat(rawAttribute).isInstanceOf(List.class);
+      List<?> attribute = (List<?>) rawAttribute;
+      int attributeNameIndex = attribute.indexOf("attribute");
+      assertThat(attributeNameIndex).isGreaterThanOrEqualTo(0);
+      names.add(attribute.get(attributeNameIndex + 1).toString());
+    }
+    return names;
+  }
+
+  private void cleanRedis() {
+    dropIndex(INDEX_NAME);
+    dropIndex(CHUNK_INDEX_NAME);
+    dropIndex(TEXT_INDEXED_INDEX_NAME);
+    dropIndex(MULTI_FIELD_INDEX_NAME);
+    dropIndex(REFERENCE_INDEX_NAME);
+    dropIndex(HASH_INDEX_NAME);
+    dropIndex(TEXT_FIRST_INDEX_NAME);
+    dropIndex(TAG_FIRST_INDEX_NAME);
+    template.delete(KEY);
+    template.delete(CHUNK_KEY);
+    template.delete(TEXT_INDEXED_KEY);
+    template.delete(MULTI_FIELD_KEY);
+    template.delete(REFERENCE_KEY);
+    template.delete(HASH_KEY);
+    template.delete(TEXT_FIRST_KEY);
+    template.delete(TAG_FIRST_KEY);
+  }
+
+  private void dropIndex(String indexName) {
+    try {
+      modulesOperations.opsForSearch(indexName).dropIndexAndDocuments();
+    } catch (JedisDataException e) {
+      String message = e.getMessage() == null ? "" : e.getMessage().toLowerCase();
+      if (!message.contains("unknown index") && !message.contains("unknown index name") && !message.contains(
+          "no such index")) {
+        throw e;
+      }
+    }
+  }
+
+  @SpringBootApplication
+  @Configuration
+  @EnableRedisDocumentRepositories(
+      basePackageClasses = SearchablePhoneticTest.class
+  )
+  static class Config extends TestConfig {
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticChunkDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticChunkDoc.java
@@ -1,0 +1,32 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+
+@Document
+public class PhoneticChunkDoc {
+  @Indexed
+  private String filingDate;
+
+  @Searchable(
+      phonetic = "dm:en"
+  )
+  private String chunkText;
+
+  public String getFilingDate() {
+    return filingDate;
+  }
+
+  public void setFilingDate(String filingDate) {
+    this.filingDate = filingDate;
+  }
+
+  public String getChunkText() {
+    return chunkText;
+  }
+
+  public void setChunkText(String chunkText) {
+    this.chunkText = chunkText;
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticDoc.java
@@ -1,0 +1,31 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Searchable;
+
+@Document
+public class PhoneticDoc {
+  @Searchable(
+      phonetic = "dm:en"
+  )
+  private String phoneticName;
+
+  @Searchable
+  private String plainName;
+
+  public String getPhoneticName() {
+    return phoneticName;
+  }
+
+  public void setPhoneticName(String phoneticName) {
+    this.phoneticName = phoneticName;
+  }
+
+  public String getPlainName() {
+    return plainName;
+  }
+
+  public void setPlainName(String plainName) {
+    this.plainName = plainName;
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticMultiFieldDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticMultiFieldDoc.java
@@ -1,0 +1,56 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+
+@Document
+public class PhoneticMultiFieldDoc {
+  @Indexed
+  private String filingDate;
+
+  @Indexed
+  private String category;
+
+  @Searchable(
+      phonetic = "dm:en"
+  )
+  private String chunkText;
+
+  @Searchable(
+      phonetic = "dm:en"
+  )
+  private String customerName;
+
+  public String getFilingDate() {
+    return filingDate;
+  }
+
+  public void setFilingDate(String filingDate) {
+    this.filingDate = filingDate;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public void setCategory(String category) {
+    this.category = category;
+  }
+
+  public String getChunkText() {
+    return chunkText;
+  }
+
+  public void setChunkText(String chunkText) {
+    this.chunkText = chunkText;
+  }
+
+  public String getCustomerName() {
+    return customerName;
+  }
+
+  public void setCustomerName(String customerName) {
+    this.customerName = customerName;
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticOwnerDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticOwnerDoc.java
@@ -1,0 +1,20 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Searchable;
+
+@Document
+public class PhoneticOwnerDoc {
+  @Searchable(
+      phonetic = "dm:en"
+  )
+  private String name;
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticReferenceDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticReferenceDoc.java
@@ -1,0 +1,32 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import org.springframework.data.annotation.Reference;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+
+@Document
+public class PhoneticReferenceDoc {
+  @Indexed
+  private String filingDate;
+
+  @Reference
+  @Indexed
+  private PhoneticOwnerDoc owner;
+
+  public String getFilingDate() {
+    return filingDate;
+  }
+
+  public void setFilingDate(String filingDate) {
+    this.filingDate = filingDate;
+  }
+
+  public PhoneticOwnerDoc getOwner() {
+    return owner;
+  }
+
+  public void setOwner(PhoneticOwnerDoc owner) {
+    this.owner = owner;
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticTextIndexedDoc.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/PhoneticTextIndexedDoc.java
@@ -1,0 +1,32 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.TextIndexed;
+
+@Document
+public class PhoneticTextIndexedDoc {
+  @Indexed
+  private String filingDate;
+
+  @TextIndexed(
+      phonetic = "dm:en"
+  )
+  private String chunkText;
+
+  public String getFilingDate() {
+    return filingDate;
+  }
+
+  public void setFilingDate(String filingDate) {
+    this.filingDate = filingDate;
+  }
+
+  public String getChunkText() {
+    return chunkText;
+  }
+
+  public void setChunkText(String chunkText) {
+    this.chunkText = chunkText;
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/PhoneticHash.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/PhoneticHash.java
@@ -1,0 +1,33 @@
+package com.redis.om.spring.fixtures.hash.model;
+
+import org.springframework.data.redis.core.RedisHash;
+
+import com.redis.om.spring.annotations.Indexed;
+import com.redis.om.spring.annotations.Searchable;
+
+@RedisHash
+public class PhoneticHash {
+  @Indexed
+  private String filingDate;
+
+  @Searchable(
+      phonetic = "dm:en"
+  )
+  private String chunkText;
+
+  public String getFilingDate() {
+    return filingDate;
+  }
+
+  public void setFilingDate(String filingDate) {
+    this.filingDate = filingDate;
+  }
+
+  public String getChunkText() {
+    return chunkText;
+  }
+
+  public void setChunkText(String chunkText) {
+    this.chunkText = chunkText;
+  }
+}


### PR DESCRIPTION
## Summary

This appears to be a Redis Search schema field ordering problem. We reproduced the behavior directly with Redis CLI against Redis 8.8, without Redis OM Spring involved. Currently waiting for confirmation on their side: https://github.com/RediSearch/RediSearch/issues/10140

Fixes phonetic text indexing when Redis Search receives a schema where TAG fields are declared before later TEXT PHONETIC fields.

## Identified Problem

Redis OM Spring correctly sends `PHONETIC dm:en` for `@Searchable(phonetic = "dm:en")` and `@TextIndexed(phonetic = "dm:en")`.

The issue appears when Redis Search receives a mixed schema where a TAG field is declared before a later TEXT PHONETIC field. Redis accepts the schema, but the later phonetic text field does not behave phonetically. Queries like `@chunkText:kash` do not match stored text like `cash`.

This appears to be a Redis Search schema field ordering problem. We reproduced the behavior directly with Redis CLI against Redis 8.8, without Redis OM Spring involved. Currently waiting for confirmation on their side.

## Changes

- Mark phonetic `@Searchable` and `@TextIndexed` fields during schema generation
- Reorder only the FT.CREATE schema field list so phonetic text fields are emitted before tag fields
- Keep Redis OM Spring’s stored schema metadata order unchanged
- Add regression coverage for document, hash, text indexed, multiple phonetic fields, reference fields, and direct Redis schema behavior

## Verification

- Focused phonetic test suite passes
- Full test suite was run on the feature branch
- The only full suite failure also reproduces on clean `main`:
  `RedisDocumentSearchTest.testAggregationAnnotation01`