### PR TITLE
feat: support WITHSUFFIXTRIE in indexed fields

### DIFF
--- a/demos/roms-documents/README.MD
+++ b/demos/roms-documents/README.MD
@@ -20,6 +20,7 @@ docker compose up -d redis
 - Provides examples of querying documents using method names and explicit `@Query` annotations
 - Includes REST API endpoints for document read and query operations
 - Includes an opt-in lexicographic ID range reproduction for large `@Indexed(sortable = true, lexicographic = true)` fields
+- Shows `withSuffixTrie` and phonetic indexing on a `Company` text field
 
 ## Key Components
 
@@ -53,6 +54,7 @@ GET /api/companies/all
 GET /api/companies/all-ids
 GET /api/companies/{id}
 GET /api/companies/name/{name}
+GET /api/companies/description/{description}
 GET /api/companies/name/starts/{prefix}
 GET /api/companies/employees/count/{count}
 GET /api/companies/employees/range/{low}/{high}
@@ -135,6 +137,56 @@ demo.lexicographic-repro.count=50000
 demo.lexicographic-repro.batch-size=1000
 demo.lexicographic-repro.update-count=100
 demo.lexicographic-repro.threshold=lex000000000
+```
+
+## WITHSUFFIXTRIE and Phonetic Example
+
+The `Company` model includes a searchable description field with suffix trie and phonetic indexing enabled:
+
+```java
+@Searchable(phonetic = "dm:en", withSuffixTrie = true)
+private String description;
+```
+
+Run the demo and inspect the generated company index:
+
+```bash
+./gradlew :demos:roms-documents:bootRun
+docker exec redis-om-spring-redis-1 redis-cli FT.INFO com.redis.om.documents.domain.CompanyIdx
+```
+
+The `description` attribute should include `WITHSUFFIXTRIE`:
+
+```text
+identifier
+$.description
+attribute
+description
+type
+TEXT
+WITHSUFFIXTRIE
+```
+
+Redis Search may not echo `PHONETIC` in `FT.INFO`. Check phonetic expansion with `FT.EXPLAINCLI`:
+
+```bash
+docker exec redis-om-spring-redis-1 redis-cli FT.EXPLAINCLI com.redis.om.documents.domain.CompanyIdx '@description:kash'
+```
+
+Expected plan shape:
+
+```text
+@description:UNION {
+  @description:kash
+  @description:<KX(expanded)
+  @description:+kash(expanded)
+}
+```
+
+You can also query the seeded `Company` data through the existing REST API:
+
+```bash
+curl http://localhost:8080/api/companies/description/kash
 ```
 
 ## Testing

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/RomsDocumentsApplication.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/RomsDocumentsApplication.java
@@ -36,10 +36,12 @@ public class RomsDocumentsApplication {
       companyRepo.deleteAll();
       Company redis = Company.of("Redis", "https://redis.com", new Point(-122.066540, 37.377690), 526, 2011, Set.of(
           CompanyMeta.of("Redis", 100, Set.of("RedisTag"))));
+      redis.setDescription("Fast cache and real-time data platform");
       redis.setTags(Set.of("fast", "scalable", "reliable"));
 
       Company microsoft = Company.of("Microsoft", "https://microsoft.com", new Point(-122.124500, 47.640160), 182268,
           1975, Set.of(CompanyMeta.of("MS", 50, Set.of("MsTag"))));
+      microsoft.setDescription("Cloud software and productivity platform");
       microsoft.setTags(Set.of("innovative", "reliable"));
 
       companyRepo.save(redis);

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/controllers/CompanyController.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/controllers/CompanyController.java
@@ -91,6 +91,15 @@ public class CompanyController {
   }
 
   @GetMapping(
+    "description/{description}"
+  )
+  Iterable<Company> byDescription(@PathVariable(
+    "description"
+  ) String description) {
+    return repository.findByDescription(description);
+  }
+
+  @GetMapping(
     "tags"
   )
   Iterable<Company> byTags(@RequestParam(

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/domain/Company.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/domain/Company.java
@@ -32,6 +32,11 @@ public class Company {
   @Searchable
   private String name;
 
+  @Searchable(
+      phonetic = "dm:en", withSuffixTrie = true
+  )
+  private String description;
+
   @Indexed
   private Set<String> tags = new HashSet<>();
 

--- a/demos/roms-documents/src/main/java/com/redis/om/documents/repositories/CompanyRepository.java
+++ b/demos/roms-documents/src/main/java/com/redis/om/documents/repositories/CompanyRepository.java
@@ -15,6 +15,9 @@ public interface CompanyRepository extends RedisDocumentRepository<Company, Stri
   // find one by property
   Optional<Company> findOneByName(String name);
 
+  // phonetic and suffix trie text field
+  Iterable<Company> findByDescription(String description);
+
   // geospatial query
   Iterable<Company> findByLocationNear(Point point, Distance distance);
 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Indexed.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Indexed.java
@@ -95,6 +95,14 @@ public @interface Indexed {
   String phonetic() default "";
 
   /**
+   * Indicates whether suffix trie indexing should be enabled for supported fields.
+   * Redis supports this option on TEXT and TAG schema fields.
+   *
+   * @return {@code true} if suffix trie indexing should be enabled, {@code false} otherwise
+   */
+  boolean withSuffixTrie() default false;
+
+  /**
    * Specifies the separator character for tag fields.
    * 
    * @return the separator character

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Searchable.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/Searchable.java
@@ -89,6 +89,14 @@ public @interface Searchable {
   String phonetic() default "";
 
   /**
+   * Whether to enable suffix trie indexing for this text field.
+   * When enabled, Redis can optimize suffix and contains queries on this field.
+   *
+   * @return true if suffix trie indexing should be enabled, false otherwise
+   */
+  boolean withSuffixTrie() default false;
+
+  /**
    * Whether to index missing (null) values for this field.
    * When enabled, allows searching for documents where this field is null.
    * 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/TagIndexed.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/TagIndexed.java
@@ -106,6 +106,16 @@ public @interface TagIndexed {
   String separator() default "|";
 
   /**
+   * Whether to enable suffix trie indexing for this tag field.
+   * <p>
+   * When enabled, Redis can optimize suffix and contains queries on this field.
+   * </p>
+   *
+   * @return true to enable suffix trie indexing, false otherwise
+   */
+  boolean withSuffixTrie() default false;
+
+  /**
    * Whether to index documents where this field is missing (null).
    * <p>
    * When true, documents with null values for this field will be included

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/TextIndexed.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/TextIndexed.java
@@ -108,7 +108,7 @@ public @interface TextIndexed {
    */
   String phonetic() default "";
 
-   /**
+  /**
    * Whether to enable suffix trie indexing for this text field.
    *
    * <p>When true, Redis can optimize suffix and contains queries on this field.</p>

--- a/redis-om-spring/src/main/java/com/redis/om/spring/annotations/TextIndexed.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/annotations/TextIndexed.java
@@ -108,6 +108,15 @@ public @interface TextIndexed {
    */
   String phonetic() default "";
 
+   /**
+   * Whether to enable suffix trie indexing for this text field.
+   *
+   * <p>When true, Redis can optimize suffix and contains queries on this field.</p>
+   *
+   * @return true if suffix trie indexing should be enabled, defaults to false
+   */
+  boolean withSuffixTrie() default false;
+
   /**
    * Whether to index documents where this field is missing.
    * 

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
@@ -726,6 +726,26 @@ class IndexDefinitionBuilder {
                   .indexEmpty(), searchable.withSuffixTrie())));
 
           continue;
+        } else if (subField.isAnnotationPresent(TextIndexed.class)) {
+          TextIndexed textIndexed = subField.getAnnotation(TextIndexed.class);
+          tempPrefix = field.getName() + "[0:].";
+
+          FieldName fieldName = FieldName.of(fieldPrefix + tempPrefix + subField.getName() + suffix);
+          String alias = QueryUtils.searchIndexFieldAliasFor(subField, prefix);
+          fieldName = fieldName.as(alias);
+
+          logger.info(String.format("Creating TEXT nested relationships: %s -> %s", field.getName(), subField
+              .getName()));
+
+          String phonetic = org.apache.commons.lang3.ObjectUtils.isEmpty(textIndexed.phonetic()) ?
+              null :
+              textIndexed.phonetic();
+
+          fieldList.add(SearchField.of(field, factory.getTextField(fieldName, textIndexed.weight(), textIndexed
+              .sortable(), textIndexed.nostem(), textIndexed.noindex(), phonetic, textIndexed.indexMissing(),
+              textIndexed.indexEmpty(), textIndexed.withSuffixTrie())));
+
+          continue;
         }
         if (subField.isAnnotationPresent(Indexed.class)) {
           getNestedField(fieldPrefix + tempPrefix, subField, prefix, fieldList);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
@@ -747,15 +747,33 @@ class IndexDefinitionBuilder {
 
     logger.info(String.format("Creating automatic nested field index: %s -> %s", arrayField.getName(), fullFieldPath));
 
-    FieldTypeMapper fieldTypeMapper = FieldTypeMapper.getFieldType(nestedFieldType);
+    FieldName fieldName = nestedFieldName(fullFieldPath, nestedField, prefix);
 
+    Searchable searchable = nestedField.getAnnotation(Searchable.class);
+    if (searchable != null) {
+      String phonetic = org.apache.commons.lang3.ObjectUtils.isEmpty(searchable.phonetic()) ?
+          null :
+          searchable.phonetic();
+      fields.add(SearchField.of(arrayField, factory.getTextField(fieldName, searchable.weight(), searchable.sortable(),
+          searchable.nostem(), searchable.noindex(), phonetic, searchable.indexMissing(), searchable.indexEmpty(),
+          searchable.withSuffixTrie())));
+      return fields;
+    }
+
+    TextIndexed textIndexed = nestedField.getAnnotation(TextIndexed.class);
+    if (textIndexed != null) {
+      String phonetic = org.apache.commons.lang3.ObjectUtils.isEmpty(textIndexed.phonetic()) ?
+          null :
+          textIndexed.phonetic();
+      fields.add(SearchField.of(arrayField, factory.getTextField(fieldName, textIndexed.weight(), textIndexed
+          .sortable(), textIndexed.nostem(), textIndexed.noindex(), phonetic, textIndexed.indexMissing(), textIndexed
+              .indexEmpty(), textIndexed.withSuffixTrie())));
+      return fields;
+    }
+
+    FieldTypeMapper fieldTypeMapper = FieldTypeMapper.getFieldType(nestedFieldType);
     switch (fieldTypeMapper) {
       case TAG -> {
-        FieldName fieldName = FieldName.of(fullFieldPath);
-        String alias = QueryUtils.searchIndexFieldAliasFor(nestedField, prefix);
-        if (alias != null && !alias.isEmpty()) {
-          fieldName = fieldName.as(alias);
-        }
         Indexed indexed = nestedField.getAnnotation(Indexed.class);
         TagIndexed tagIndexed = nestedField.getAnnotation(TagIndexed.class);
         boolean withSuffixTrie = (indexed != null && indexed.withSuffixTrie()) || (tagIndexed != null && tagIndexed
@@ -763,27 +781,22 @@ class IndexDefinitionBuilder {
         fields.add(SearchField.of(arrayField, factory.getTagField(fieldName, "|", false, false, false,
             withSuffixTrie)));
       }
-      case NUMERIC -> {
-        FieldName fieldName = FieldName.of(fullFieldPath);
-        String alias = QueryUtils.searchIndexFieldAliasFor(nestedField, prefix);
-        if (alias != null && !alias.isEmpty()) {
-          fieldName = fieldName.as(alias);
-        }
-        fields.add(SearchField.of(arrayField, NumericField.of(fieldName)));
-      }
-      case GEO -> {
-        FieldName fieldName = FieldName.of(fullFieldPath);
-        String alias = QueryUtils.searchIndexFieldAliasFor(nestedField, prefix);
-        if (alias != null && !alias.isEmpty()) {
-          fieldName = fieldName.as(alias);
-        }
-        fields.add(SearchField.of(arrayField, GeoField.of(fieldName)));
-      }
+      case NUMERIC -> fields.add(SearchField.of(arrayField, NumericField.of(fieldName)));
+      case GEO -> fields.add(SearchField.of(arrayField, GeoField.of(fieldName)));
       case UNSUPPORTED -> logger.debug(String.format("Skipping nested field %s of unsupported type %s", nestedField
           .getName(), nestedFieldType.getSimpleName()));
     }
 
     return fields;
+  }
+
+  private FieldName nestedFieldName(String fullFieldPath, java.lang.reflect.Field nestedField, String prefix) {
+    FieldName fieldName = FieldName.of(fullFieldPath);
+    String alias = QueryUtils.searchIndexFieldAliasFor(nestedField, prefix);
+    if (alias != null && !alias.isEmpty()) {
+      fieldName = fieldName.as(alias);
+    }
+    return fieldName;
   }
 
   // ---------------------------------------------------------------------------

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
@@ -118,8 +118,8 @@ class IndexDefinitionBuilder {
         if (CharSequence.class.isAssignableFrom(fieldType) || //
             (fieldType == Boolean.class) || (fieldType == UUID.class) || (fieldType == Ulid.class)) {
           fields.add(SearchField.of(field, factory.indexAsTagFieldFor(field, isDocument, prefix, indexed.sortable(),
-              indexed.separator(), indexed.arrayIndex(), indexed.alias(), indexed.indexMissing(), indexed
-                  .indexEmpty(), indexed.withSuffixTrie())));
+              indexed.separator(), indexed.arrayIndex(), indexed.alias(), indexed.indexMissing(), indexed.indexEmpty(),
+              indexed.withSuffixTrie())));
         } else if (fieldType.isEnum()) {
           if (Objects.requireNonNull(indexed.serializationHint()) == SerializationHint.ORDINAL) {
             fields.add(SearchField.of(field, factory.indexAsNumericFieldFor(field, isDocument, prefix, indexed
@@ -692,8 +692,8 @@ class IndexDefinitionBuilder {
             fieldName = fieldName.as(alias);
 
             logger.info(String.format("Creating nested relationships: %s -> %s", field.getName(), subField.getName()));
-            fieldList.add(SearchField.of(field, factory.getTagField(fieldName, indexed.separator(), false, false,
-                false, indexed.withSuffixTrie())));
+            fieldList.add(SearchField.of(field, factory.getTagField(fieldName, indexed.separator(), false, false, false,
+                indexed.withSuffixTrie())));
             continue;
           } else if (Number.class.isAssignableFrom(subField.getType()) || (subField
               .getType() == LocalDateTime.class) || (subField.getType() == LocalDate.class) || (subField

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/IndexDefinitionBuilder.java
@@ -119,7 +119,7 @@ class IndexDefinitionBuilder {
             (fieldType == Boolean.class) || (fieldType == UUID.class) || (fieldType == Ulid.class)) {
           fields.add(SearchField.of(field, factory.indexAsTagFieldFor(field, isDocument, prefix, indexed.sortable(),
               indexed.separator(), indexed.arrayIndex(), indexed.alias(), indexed.indexMissing(), indexed
-                  .indexEmpty())));
+                  .indexEmpty(), indexed.withSuffixTrie())));
         } else if (fieldType.isEnum()) {
           if (Objects.requireNonNull(indexed.serializationHint()) == SerializationHint.ORDINAL) {
             fields.add(SearchField.of(field, factory.indexAsNumericFieldFor(field, isDocument, prefix, indexed
@@ -128,7 +128,7 @@ class IndexDefinitionBuilder {
           } else {
             fields.add(SearchField.of(field, factory.indexAsTagFieldFor(field, isDocument, prefix, indexed.sortable(),
                 indexed.separator(), indexed.arrayIndex(), indexed.alias(), indexed.indexMissing(), indexed
-                    .indexEmpty())));
+                    .indexEmpty(), indexed.withSuffixTrie())));
           }
         } else if ( //
         Number.class.isAssignableFrom(fieldType) || //
@@ -149,7 +149,7 @@ class IndexDefinitionBuilder {
             if (CharSequence.class.isAssignableFrom(collectionType) || (collectionType == Boolean.class)) {
               fields.add(SearchField.of(field, factory.indexAsTagFieldFor(field, isDocument, prefix, indexed.sortable(),
                   indexed.separator(), indexed.arrayIndex(), indexed.alias(), indexed.indexMissing(), indexed
-                      .indexEmpty())));
+                      .indexEmpty(), indexed.withSuffixTrie())));
             } else if (isDocument) {
               if (Number.class.isAssignableFrom(collectionType)) {
                 fields.add(SearchField.of(field, factory.indexAsNumericFieldFor(field, true, prefix, indexed.sortable(),
@@ -158,7 +158,8 @@ class IndexDefinitionBuilder {
                 fields.add(SearchField.of(field, factory.indexAsGeoFieldFor(field, true, prefix, indexed.alias())));
               } else if (collectionType == UUID.class || collectionType == Ulid.class) {
                 fields.add(SearchField.of(field, factory.indexAsTagFieldFor(field, true, prefix, indexed.sortable(),
-                    indexed.separator(), 0, indexed.alias(), indexed.indexMissing(), indexed.indexEmpty())));
+                    indexed.separator(), 0, indexed.alias(), indexed.indexMissing(), indexed.indexEmpty(), indexed
+                        .withSuffixTrie())));
               } else {
                 logger.debug(String.format("Found nested field on field of type: %s", field.getType()));
                 fields.addAll(indexAsNestedFieldFor(field, prefix));
@@ -193,6 +194,8 @@ class IndexDefinitionBuilder {
                 tagField.indexMissing();
               if (indexed.indexEmpty())
                 tagField.indexEmpty();
+              if (indexed.withSuffixTrie())
+                tagField.withSuffixTrie();
               if (!indexed.separator().isEmpty()) {
                 tagField.separator(indexed.separator().charAt(0));
               }
@@ -244,6 +247,8 @@ class IndexDefinitionBuilder {
                       tagField.indexMissing();
                     if (subfieldIndexed.indexEmpty())
                       tagField.indexEmpty();
+                    if (subfieldIndexed.withSuffixTrie())
+                      tagField.withSuffixTrie();
                     if (!subfieldIndexed.separator().isEmpty()) {
                       tagField.separator(subfieldIndexed.separator().charAt(0));
                     }
@@ -283,7 +288,7 @@ class IndexDefinitionBuilder {
         switch (indexed.schemaFieldType()) {
           case TAG -> fields.add(SearchField.of(field, factory.indexAsTagFieldFor(field, isDocument, prefix, indexed
               .sortable(), indexed.separator(), indexed.arrayIndex(), indexed.alias(), indexed.indexMissing(), indexed
-                  .indexEmpty())));
+                  .indexEmpty(), indexed.withSuffixTrie())));
           case NUMERIC -> fields.add(SearchField.of(field, factory.indexAsNumericFieldFor(field, isDocument, prefix,
               indexed.sortable(), indexed.noindex(), indexed.alias(), indexed.indexMissing(), indexed.indexEmpty())));
           case GEO -> fields.add(SearchField.of(field, factory.indexAsGeoFieldFor(field, true, prefix, indexed
@@ -486,6 +491,8 @@ class IndexDefinitionBuilder {
           textField.indexMissing();
         if (searchable.indexEmpty())
           textField.indexEmpty();
+        if (searchable.withSuffixTrie())
+          textField.withSuffixTrie();
         fields.add(SearchField.of(subField, textField));
         continue;
       }
@@ -508,6 +515,8 @@ class IndexDefinitionBuilder {
           textField.indexMissing();
         if (textIndexed.indexEmpty())
           textField.indexEmpty();
+        if (textIndexed.withSuffixTrie())
+          textField.withSuffixTrie();
         fields.add(SearchField.of(subField, textField));
         continue;
       }
@@ -536,6 +545,8 @@ class IndexDefinitionBuilder {
         } else if (indexed != null && indexed.indexEmpty()) {
           tagField.indexEmpty();
         }
+        if ((tagIndexed != null && tagIndexed.withSuffixTrie()) || (indexed != null && indexed.withSuffixTrie()))
+          tagField.withSuffixTrie();
         fields.add(SearchField.of(subField, tagField));
       } else if (numericIndexed != null || (indexed != null && (Number.class.isAssignableFrom(
           subFieldType) || subFieldType == java.time.LocalDateTime.class || subFieldType == java.time.LocalDate.class || subFieldType == java.util.Date.class || subFieldType == java.time.Instant.class || subFieldType == java.time.OffsetDateTime.class))) {
@@ -559,6 +570,8 @@ class IndexDefinitionBuilder {
           tagField.indexMissing();
         if (indexed.indexEmpty())
           tagField.indexEmpty();
+        if (indexed.withSuffixTrie())
+          tagField.withSuffixTrie();
         fields.add(SearchField.of(subField, tagField));
       } else if (indexed != null && (subFieldType == Boolean.class || subFieldType == boolean.class)) {
         TagField tagField = TagField.of(fieldName);
@@ -568,6 +581,8 @@ class IndexDefinitionBuilder {
           tagField.indexMissing();
         if (indexed.indexEmpty())
           tagField.indexEmpty();
+        if (indexed.withSuffixTrie())
+          tagField.withSuffixTrie();
         fields.add(SearchField.of(subField, tagField));
       }
 
@@ -652,7 +667,8 @@ class IndexDefinitionBuilder {
           fieldName = fieldName.as(QueryUtils.searchIndexFieldAliasFor(subField, prefix));
 
           logger.info(String.format("Creating nested relationships: %s -> %s", field.getName(), subField.getName()));
-          fieldList.add(SearchField.of(field, factory.getTagField(fieldName, ti.separator(), false)));
+          fieldList.add(SearchField.of(field, factory.getTagField(fieldName, ti.separator(), false, false, false, ti
+              .withSuffixTrie())));
           continue;
         } else if (subField.isAnnotationPresent(Indexed.class)) {
           boolean subFieldIsTagField = (subField.isAnnotationPresent(Indexed.class) && ( //
@@ -676,7 +692,8 @@ class IndexDefinitionBuilder {
             fieldName = fieldName.as(alias);
 
             logger.info(String.format("Creating nested relationships: %s -> %s", field.getName(), subField.getName()));
-            fieldList.add(SearchField.of(field, factory.getTagField(fieldName, indexed.separator(), false)));
+            fieldList.add(SearchField.of(field, factory.getTagField(fieldName, indexed.separator(), false, false,
+                false, indexed.withSuffixTrie())));
             continue;
           } else if (Number.class.isAssignableFrom(subField.getType()) || (subField
               .getType() == LocalDateTime.class) || (subField.getType() == LocalDate.class) || (subField
@@ -706,7 +723,7 @@ class IndexDefinitionBuilder {
 
           fieldList.add(SearchField.of(field, factory.getTextField(fieldName, searchable.weight(), searchable
               .sortable(), searchable.nostem(), searchable.noindex(), phonetic, searchable.indexMissing(), searchable
-                  .indexEmpty())));
+                  .indexEmpty(), searchable.withSuffixTrie())));
 
           continue;
         }
@@ -739,7 +756,12 @@ class IndexDefinitionBuilder {
         if (alias != null && !alias.isEmpty()) {
           fieldName = fieldName.as(alias);
         }
-        fields.add(SearchField.of(arrayField, factory.getTagField(fieldName, "|", false)));
+        Indexed indexed = nestedField.getAnnotation(Indexed.class);
+        TagIndexed tagIndexed = nestedField.getAnnotation(TagIndexed.class);
+        boolean withSuffixTrie = (indexed != null && indexed.withSuffixTrie()) || (tagIndexed != null && tagIndexed
+            .withSuffixTrie());
+        fields.add(SearchField.of(arrayField, factory.getTagField(fieldName, "|", false, false, false,
+            withSuffixTrie)));
       }
       case NUMERIC -> {
         FieldName fieldName = FieldName.of(fullFieldPath);

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/SchemaFieldFactory.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/SchemaFieldFactory.java
@@ -96,8 +96,8 @@ class SchemaFieldFactory {
 
   SchemaField indexAsTagFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, boolean sortable,
       String separator, int arrayIndex, String annotationAlias) {
-    return indexAsTagFieldFor(field, isDocument, prefix, sortable, separator, arrayIndex, annotationAlias, false,
-        false, false);
+    return indexAsTagFieldFor(field, isDocument, prefix, sortable, separator, arrayIndex, annotationAlias, false, false,
+        false);
   }
 
   SchemaField indexAsTagFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, boolean sortable,

--- a/redis-om-spring/src/main/java/com/redis/om/spring/indexing/SchemaFieldFactory.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/indexing/SchemaFieldFactory.java
@@ -31,7 +31,7 @@ class SchemaFieldFactory {
 
   TagField indexAsTagFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, TagIndexed ti) {
     FieldName fieldName = buildFieldName(field, prefix, isDocument, Optional.ofNullable(ti.alias()), Optional.empty());
-    return getTagField(fieldName, ti.separator(), false);
+    return getTagField(fieldName, ti.separator(), false, false, false, ti.withSuffixTrie());
   }
 
   VectorField indexAsVectorFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, Indexed indexed) {
@@ -97,28 +97,35 @@ class SchemaFieldFactory {
   SchemaField indexAsTagFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, boolean sortable,
       String separator, int arrayIndex, String annotationAlias) {
     return indexAsTagFieldFor(field, isDocument, prefix, sortable, separator, arrayIndex, annotationAlias, false,
-        false);
+        false, false);
   }
 
   SchemaField indexAsTagFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, boolean sortable,
       String separator, int arrayIndex, String annotationAlias, boolean indexMissing, boolean indexEmpty) {
+    return indexAsTagFieldFor(field, isDocument, prefix, sortable, separator, arrayIndex, annotationAlias, indexMissing,
+        indexEmpty, false);
+  }
+
+  SchemaField indexAsTagFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, boolean sortable,
+      String separator, int arrayIndex, String annotationAlias, boolean indexMissing, boolean indexEmpty,
+      boolean withSuffixTrie) {
     FieldName fieldName = buildFieldName(field, prefix, isDocument, Optional.ofNullable(annotationAlias), Optional.of(
         arrayIndex));
-    return getTagField(fieldName, separator, sortable, indexMissing, indexEmpty);
+    return getTagField(fieldName, separator, sortable, indexMissing, indexEmpty, withSuffixTrie);
   }
 
   TextField indexAsTextFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, TextIndexed ti) {
     var fieldName = buildFieldName(field, prefix, isDocument, Optional.ofNullable(ti.alias()), Optional.empty());
     String phonetic = ObjectUtils.isEmpty(ti.phonetic()) ? null : ti.phonetic();
     return getTextField(fieldName, ti.weight(), ti.sortable(), ti.nostem(), ti.noindex(), phonetic, ti.indexMissing(),
-        ti.indexEmpty());
+        ti.indexEmpty(), ti.withSuffixTrie());
   }
 
   TextField indexAsTextFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, Searchable ti) {
     var fieldName = buildFieldName(field, prefix, isDocument, Optional.ofNullable(ti.alias()), Optional.empty());
     String phonetic = ObjectUtils.isEmpty(ti.phonetic()) ? null : ti.phonetic();
     return getTextField(fieldName, ti.weight(), ti.sortable(), ti.nostem(), ti.noindex(), phonetic, ti.indexMissing(),
-        ti.indexEmpty());
+        ti.indexEmpty(), ti.withSuffixTrie());
   }
 
   GeoField indexAsGeoFieldFor(java.lang.reflect.Field field, boolean isDocument, String prefix, GeoIndexed gi) {
@@ -163,6 +170,11 @@ class SchemaFieldFactory {
 
   TagField getTagField(FieldName fieldName, String separator, boolean sortable, boolean indexMissing,
       boolean indexEmpty) {
+    return getTagField(fieldName, separator, sortable, indexMissing, indexEmpty, false);
+  }
+
+  TagField getTagField(FieldName fieldName, String separator, boolean sortable, boolean indexMissing,
+      boolean indexEmpty, boolean withSuffixTrie) {
     TagField tag = TagField.of(fieldName);
     if (separator != null) {
       if (separator.length() != 1) {
@@ -176,11 +188,18 @@ class SchemaFieldFactory {
       tag.indexMissing();
     if (indexEmpty)
       tag.indexEmpty();
+    if (withSuffixTrie)
+      tag.withSuffixTrie();
     return tag;
   }
 
   TextField getTextField(FieldName fieldName, double weight, boolean sortable, boolean noStem, boolean noIndex,
       String phonetic, boolean indexMissing, boolean indexEmpty) {
+    return getTextField(fieldName, weight, sortable, noStem, noIndex, phonetic, indexMissing, indexEmpty, false);
+  }
+
+  TextField getTextField(FieldName fieldName, double weight, boolean sortable, boolean noStem, boolean noIndex,
+      String phonetic, boolean indexMissing, boolean indexEmpty, boolean withSuffixTrie) {
     TextField text = TextField.of(fieldName);
     text.weight(weight);
     if (sortable)
@@ -195,6 +214,8 @@ class SchemaFieldFactory {
       text.indexMissing();
     if (indexEmpty)
       text.indexEmpty();
+    if (withSuffixTrie)
+      text.withSuffixTrie();
     return text;
   }
 

--- a/tests/src/test/java/com/redis/om/spring/annotations/WithSuffixTrieIndexTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/WithSuffixTrieIndexTest.java
@@ -31,11 +31,13 @@ import lombok.Data;
 class WithSuffixTrieIndexTest extends AbstractBaseOMTest {
   private static final String DOCUMENT_INDEX = "with_suffix_trie_document_idx";
   private static final String HASH_INDEX = "with_suffix_trie_hash_idx";
+  private static final String NESTED_DOCUMENT_INDEX = "with_suffix_trie_nested_document_idx";
 
   @AfterEach
   void tearDown() {
     dropIndex(DOCUMENT_INDEX);
     dropIndex(HASH_INDEX);
+    dropIndex(NESTED_DOCUMENT_INDEX);
   }
 
   @Test
@@ -52,11 +54,28 @@ class WithSuffixTrieIndexTest extends AbstractBaseOMTest {
     assertFieldsHaveSuffixTrie(HASH_INDEX, "searchable", "text", "tag", "indexed", "explicitTag");
   }
 
+  @Test
+  void appliesWithSuffixTrieToNestedDocumentTextFields() {
+    assertThat(indexer.createIndexFor(WithSuffixTrieNestedDocument.class, NESTED_DOCUMENT_INDEX,
+        "with-suffix-trie-nested-doc:")).isTrue();
+
+    assertFieldsHaveSuffixTrie(NESTED_DOCUMENT_INDEX, "items_searchable", "items_text");
+    assertFieldsHaveType(NESTED_DOCUMENT_INDEX, "TEXT", "items_searchable", "items_text");
+  }
+
   private void assertFieldsHaveSuffixTrie(String indexName, String... fieldNames) {
     List<List<String>> attributes = attributesFor(indexName);
 
     for (String fieldName : fieldNames) {
       assertThat(attributeFor(attributes, fieldName)).contains("WITHSUFFIXTRIE");
+    }
+  }
+
+  private void assertFieldsHaveType(String indexName, String type, String... fieldNames) {
+    List<List<String>> attributes = attributesFor(indexName);
+
+    for (String fieldName : fieldNames) {
+      assertThat(valueAfter(attributeFor(attributes, fieldName), "type")).isEqualTo(type);
     }
   }
 
@@ -134,6 +153,31 @@ class WithSuffixTrieIndexTest extends AbstractBaseOMTest {
         withSuffixTrie = true
     )
     private String explicitTag;
+  }
+
+  @Data
+  @Document
+  static class WithSuffixTrieNestedDocument {
+    @Id
+    private String id;
+
+    @Indexed(
+        schemaFieldType = SchemaFieldType.NESTED
+    )
+    private List<WithSuffixTrieNestedItem> items;
+  }
+
+  @Data
+  static class WithSuffixTrieNestedItem {
+    @Searchable(
+        withSuffixTrie = true
+    )
+    private String searchable;
+
+    @TextIndexed(
+        withSuffixTrie = true
+    )
+    private String text;
   }
 
   @Data

--- a/tests/src/test/java/com/redis/om/spring/annotations/WithSuffixTrieIndexTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/WithSuffixTrieIndexTest.java
@@ -1,0 +1,173 @@
+package com.redis.om.spring.annotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+
+import com.redis.om.spring.AbstractBaseOMTest;
+import com.redis.om.spring.TestConfig;
+
+import lombok.Data;
+
+@DirtiesContext
+@SpringBootTest(
+    classes = WithSuffixTrieIndexTest.Config.class,
+    properties = { "spring.main.allow-bean-definition-overriding=true" }
+)
+@TestPropertySource(
+    properties = { "spring.config.location=classpath:vss_on.yaml" }
+)
+class WithSuffixTrieIndexTest extends AbstractBaseOMTest {
+  private static final String DOCUMENT_INDEX = "with_suffix_trie_document_idx";
+  private static final String HASH_INDEX = "with_suffix_trie_hash_idx";
+
+  @AfterEach
+  void tearDown() {
+    dropIndex(DOCUMENT_INDEX);
+    dropIndex(HASH_INDEX);
+  }
+
+  @Test
+  void appliesWithSuffixTrieToDocumentTextAndTagFields() {
+    assertThat(indexer.createIndexFor(WithSuffixTrieDocument.class, DOCUMENT_INDEX, "with-suffix-trie-doc:")).isTrue();
+
+    assertFieldsHaveSuffixTrie(DOCUMENT_INDEX, "searchable", "text", "tag", "indexed", "explicitTag");
+  }
+
+  @Test
+  void appliesWithSuffixTrieToHashTextAndTagFields() {
+    assertThat(indexer.createIndexFor(WithSuffixTrieHash.class, HASH_INDEX, "with-suffix-trie-hash:")).isTrue();
+
+    assertFieldsHaveSuffixTrie(HASH_INDEX, "searchable", "text", "tag", "indexed", "explicitTag");
+  }
+
+  private void assertFieldsHaveSuffixTrie(String indexName, String... fieldNames) {
+    List<List<String>> attributes = attributesFor(indexName);
+
+    for (String fieldName : fieldNames) {
+      assertThat(attributeFor(attributes, fieldName)).contains("WITHSUFFIXTRIE");
+    }
+  }
+
+  private List<List<String>> attributesFor(String indexName) {
+    Map<String, Object> info = modulesOperations.opsForSearch(indexName).getInfo();
+    Object rawAttributes = info.get("attributes");
+
+    assertThat(rawAttributes).isInstanceOf(List.class);
+    return ((List<?>) rawAttributes).stream().map(attribute -> {
+      assertThat(attribute).isInstanceOf(List.class);
+      return ((List<?>) attribute).stream().map(String::valueOf).toList();
+    }).toList();
+  }
+
+  private List<String> attributeFor(List<List<String>> attributes, String fieldName) {
+    return attributes.stream().filter(attribute -> fieldName.equals(valueAfter(attribute, "attribute"))).findFirst()
+        .orElseThrow(() -> new AssertionError("No Redis Search attribute found for field " + fieldName));
+  }
+
+  private String valueAfter(List<String> values, String key) {
+    for (int i = 0; i < values.size() - 1; i++) {
+      if (key.equals(values.get(i))) {
+        return values.get(i + 1);
+      }
+    }
+    return null;
+  }
+
+  private void dropIndex(String indexName) {
+    try {
+      modulesOperations.opsForSearch(indexName).dropIndex();
+    } catch (Exception ignored) {
+    }
+  }
+
+  @SpringBootApplication
+  @Configuration
+  @EnableRedisDocumentRepositories(
+      basePackageClasses = WithSuffixTrieIndexTest.class
+  )
+  @EnableRedisEnhancedRepositories(
+      basePackageClasses = WithSuffixTrieIndexTest.class
+  )
+  static class Config extends TestConfig {
+  }
+
+  @Data
+  @Document
+  static class WithSuffixTrieDocument {
+    @Id
+    private String id;
+
+    @Searchable(
+        withSuffixTrie = true
+    )
+    private String searchable;
+
+    @TextIndexed(
+        withSuffixTrie = true
+    )
+    private String text;
+
+    @TagIndexed(
+        withSuffixTrie = true
+    )
+    private String tag;
+
+    @Indexed(
+        withSuffixTrie = true
+    )
+    private String indexed;
+
+    @Indexed(
+        schemaFieldType = SchemaFieldType.TAG,
+        withSuffixTrie = true
+    )
+    private String explicitTag;
+  }
+
+  @Data
+  @RedisHash(
+    "with-suffix-trie-hash"
+  )
+  static class WithSuffixTrieHash {
+    @Id
+    private String id;
+
+    @Searchable(
+        withSuffixTrie = true
+    )
+    private String searchable;
+
+    @TextIndexed(
+        withSuffixTrie = true
+    )
+    private String text;
+
+    @TagIndexed(
+        withSuffixTrie = true
+    )
+    private String tag;
+
+    @Indexed(
+        withSuffixTrie = true
+    )
+    private String indexed;
+
+    @Indexed(
+        schemaFieldType = SchemaFieldType.TAG,
+        withSuffixTrie = true
+    )
+    private String explicitTag;
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/annotations/WithSuffixTrieIndexTest.java
+++ b/tests/src/test/java/com/redis/om/spring/annotations/WithSuffixTrieIndexTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.TestPropertySource;
 
 import com.redis.om.spring.AbstractBaseOMTest;
 import com.redis.om.spring.TestConfig;
+import com.redis.om.spring.fixtures.document.model.WithSuffixTrieAutodetectedNestedDocument;
 
 import lombok.Data;
 
@@ -32,12 +33,14 @@ class WithSuffixTrieIndexTest extends AbstractBaseOMTest {
   private static final String DOCUMENT_INDEX = "with_suffix_trie_document_idx";
   private static final String HASH_INDEX = "with_suffix_trie_hash_idx";
   private static final String NESTED_DOCUMENT_INDEX = "with_suffix_trie_nested_document_idx";
+  private static final String AUTODETECTED_NESTED_DOCUMENT_INDEX = "with_suffix_trie_autodetected_nested_document_idx";
 
   @AfterEach
   void tearDown() {
     dropIndex(DOCUMENT_INDEX);
     dropIndex(HASH_INDEX);
     dropIndex(NESTED_DOCUMENT_INDEX);
+    dropIndex(AUTODETECTED_NESTED_DOCUMENT_INDEX);
   }
 
   @Test
@@ -61,6 +64,17 @@ class WithSuffixTrieIndexTest extends AbstractBaseOMTest {
 
     assertFieldsHaveSuffixTrie(NESTED_DOCUMENT_INDEX, "items_searchable", "items_text");
     assertFieldsHaveType(NESTED_DOCUMENT_INDEX, "TEXT", "items_searchable", "items_text");
+  }
+
+  @Test
+  void appliesWithSuffixTrieToAutodetectedNestedDocumentTextFields() {
+    assertThat(indexer.createIndexFor(WithSuffixTrieAutodetectedNestedDocument.class,
+        AUTODETECTED_NESTED_DOCUMENT_INDEX, "with-suffix-trie-autodetected-nested-doc:")).isTrue();
+
+    assertFieldsHaveSuffixTrie(AUTODETECTED_NESTED_DOCUMENT_INDEX, "autodetectedItems_searchable",
+        "autodetectedItems_text");
+    assertFieldsHaveType(AUTODETECTED_NESTED_DOCUMENT_INDEX, "TEXT", "autodetectedItems_searchable",
+        "autodetectedItems_text");
   }
 
   private void assertFieldsHaveSuffixTrie(String indexName, String... fieldNames) {

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/WithSuffixTrieAutodetectedNestedDocument.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/WithSuffixTrieAutodetectedNestedDocument.java
@@ -1,0 +1,20 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import java.util.List;
+
+import org.springframework.data.annotation.Id;
+
+import com.redis.om.spring.annotations.Document;
+import com.redis.om.spring.annotations.Indexed;
+
+import lombok.Data;
+
+@Data
+@Document
+public class WithSuffixTrieAutodetectedNestedDocument {
+  @Id
+  private String id;
+
+  @Indexed
+  private List<WithSuffixTrieAutodetectedNestedItem> autodetectedItems;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/document/model/WithSuffixTrieAutodetectedNestedItem.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/document/model/WithSuffixTrieAutodetectedNestedItem.java
@@ -1,0 +1,19 @@
+package com.redis.om.spring.fixtures.document.model;
+
+import com.redis.om.spring.annotations.Searchable;
+import com.redis.om.spring.annotations.TextIndexed;
+
+import lombok.Data;
+
+@Data
+public class WithSuffixTrieAutodetectedNestedItem {
+  @Searchable(
+      withSuffixTrie = true
+  )
+  private String searchable;
+
+  @TextIndexed(
+      withSuffixTrie = true
+  )
+  private String text;
+}


### PR DESCRIPTION
## Summary

Adds Redis Search `WITHSUFFIXTRIE` support to Redis OM Spring schema generation.

## Identified Problem

Redis Search supports `WITHSUFFIXTRIE` on `TEXT` and `TAG` schema fields, but Redis OM Spring did not expose a way to enable it through annotations.

Users could not generate schemas such as:

`TEXT WITHSUFFIXTRIE`

or:

`TAG WITHSUFFIXTRIE`

from Redis OM Spring entity annotations.

## Changes

- Add `withSuffixTrie` to `@Searchable`
- Add `withSuffixTrie` to `@TextIndexed`
- Add `withSuffixTrie` to `@TagIndexed`
- Add `withSuffixTrie` to `@Indexed`
- Emit `WITHSUFFIXTRIE` for supported `TEXT` and `TAG` schema fields
- Preserve the option across direct fields, referenced fields, nested fields, and map generated tag fields
- Add Redis schema regression coverage for JSON document and HASH indexes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central index-definition logic used for all entities; risk is mitigated by default-false opt-in and FT.INFO regression tests, but incorrect wiring could affect search index shape for adopters.
> 
> **Overview**
> Adds a **`withSuffixTrie`** flag on **`@Searchable`**, **`@TextIndexed`**, **`@TagIndexed`**, and **`@Indexed`** so Redis OM Spring can emit Redis Search **`WITHSUFFIXTRIE`** on **TEXT** and **TAG** schema fields (default **off**).
> 
> **`IndexDefinitionBuilder`** and **`SchemaFieldFactory`** pass the flag through Jedis **`TextField`/`TagField`** builders for top-level fields, **`@Reference`** subfields, nested list paths, map-derived tags, and explicit **`SchemaFieldType.NESTED`** / autodetected nested collections—including new handling for nested **`@TextIndexed`**.
> 
> **`WithSuffixTrieIndexTest`** asserts **`FT.INFO`** shows **`WITHSUFFIXTRIE`** on JSON documents, Redis Hashes, and nested shapes. The **roms-documents** demo documents **`Company.description`** (phonetic + suffix trie), seeds descriptions, and exposes **`GET /api/companies/description/{description}`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit daaaef64d3b98ed41b96fa364a08c33246137343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->