### PR TITLE
Fix Redis template fallback bean for repository startup

### DIFF
--- a/demos/roms-hashes/src/test/java/com/redis/om/hashes/RomsHashesBootRunContextTest.java
+++ b/demos/roms-hashes/src/test/java/com/redis/om/hashes/RomsHashesBootRunContextTest.java
@@ -1,0 +1,48 @@
+package com.redis.om.hashes;
+
+import static com.redis.testcontainers.RedisStackContainer.DEFAULT_IMAGE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.redis.testcontainers.RedisStackContainer;
+
+@SpringBootTest(
+    classes = RomsHashesApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
+)
+@Testcontainers(
+    disabledWithoutDocker = true
+)
+class RomsHashesBootRunContextTest {
+
+  @Container
+  static final RedisStackContainer REDIS;
+
+  static {
+    REDIS = new RedisStackContainer(DEFAULT_IMAGE_NAME.withTag("edge")).withReuse(true);
+    REDIS.start();
+  }
+
+  @DynamicPropertySource
+  static void redisProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.redis.host", REDIS::getHost);
+    registry.add("spring.data.redis.port", REDIS::getFirstMappedPort);
+  }
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void applicationContextStartsWithRedisTemplateRefDefaults() {
+    assertThat(applicationContext.containsBean("redisOmTemplate")).isTrue();
+    assertThat(applicationContext.containsBean("redisTemplate")).isTrue();
+  }
+}

--- a/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/RedisModulesConfiguration.java
@@ -463,6 +463,25 @@ public class RedisModulesConfiguration {
   }
 
   /**
+   * Exposes Redis OM's primary Redis template under Spring Data Redis's conventional bean name when no application or
+   * auto-configuration has already provided one.
+   *
+   * @param redisOmTemplate the Redis OM template
+   * @return the configured Redis OM template
+   */
+  @Bean(
+      name = "redisTemplate"
+  )
+  @ConditionalOnMissingBean(
+      name = "redisTemplate"
+  )
+  public RedisTemplate<?, ?> redisTemplateBean(@Qualifier(
+    "redisOmTemplate"
+  ) RedisTemplate<?, ?> redisOmTemplate) {
+    return redisOmTemplate;
+  }
+
+  /**
    * Creates the RediSearch indexer for managing search indexes.
    * <p>
    * This indexer is responsible for creating, updating, and managing RediSearch


### PR DESCRIPTION
## Summary
- Expose Redis OM's existing `redisOmTemplate` as the conventional `redisTemplate` bean when no application or Boot autoconfiguration has already provided one.
- Add a `roms-hashes` boot-context regression test that starts the real demo app context and verifies both template bean names are present.

Fixes #761

## Validation
- `./gradlew spotlessApply`
- `./gradlew spotlessCheck build aggregateTestReport -S`

## CI Notes
- Reviewed `.github/workflows/build.yml`: local validation covers `spotlessCheck`, `assemble` through `build`, main tests, demo tests, and aggregate test report generation.
- Reviewed `.github/workflows/dependency-review.yml`: no dependency changes in this PR, so there is no local equivalent to run.

## Follow-ups
- None known.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, conditional bean registration with no override when a custom `redisTemplate` exists; covered by a demo integration test.
> 
> **Overview**
> Registers a **`redisTemplate`** bean that returns the existing **`redisOmTemplate`** when neither the app nor Spring Boot has already defined `redisTemplate`, so Spring Data Redis repository wiring can resolve the conventional bean name at startup (fixes #761).
> 
> Adds **`RomsHashesBootRunContextTest`**, a Testcontainers-backed `@SpringBootTest` on the real `roms-hashes` app that asserts both **`redisOmTemplate`** and **`redisTemplate`** are present in the context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f149a18c7f8cd36592d9c659ff591201fba6e74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->