### PR TITLE
[1.1.x] Fix nested Redis hash map conversion

### DIFF
--- a/demos/roms-hashes/src/main/java/com/redis/om/hashes/domain/User.java
+++ b/demos/roms-hashes/src/main/java/com/redis/om/hashes/domain/User.java
@@ -1,6 +1,7 @@
 package com.redis.om.hashes.domain;
 
 import java.util.Date;
+import java.util.Map;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
@@ -42,6 +43,9 @@ public class User {
   @NonNull
   @Reference
   private Role role;
+
+  // arbitrary key/value metadata (may contain nested maps, e.g. from JSON deserialization)
+  private Map<String, Object> metadata;
 
   // audit fields
 

--- a/demos/roms-hashes/src/test/java/com/redis/om/hashes/RomsHashesApplicationTests.java
+++ b/demos/roms-hashes/src/test/java/com/redis/om/hashes/RomsHashesApplicationTests.java
@@ -1,12 +1,165 @@
 package com.redis.om.hashes;
 
-import org.junit.jupiter.api.Test;
+import static com.redis.testcontainers.RedisStackContainer.DEFAULT_IMAGE_NAME;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
-// @SpringBootTest
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisClientConfiguration;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.redis.om.hashes.domain.Role;
+import com.redis.om.hashes.domain.User;
+import com.redis.om.hashes.repositories.RoleRepository;
+import com.redis.om.hashes.repositories.UserRepository;
+import com.redis.om.spring.annotations.EnableRedisEnhancedRepositories;
+import com.redis.testcontainers.RedisStackContainer;
+
+import redis.clients.jedis.JedisPoolConfig;
+
+/**
+ * Regression test for gh-755: saving a @RedisHash entity whose Map<String,Object>
+ * field contains nested Map/List values (as produced by Jackson deserialization)
+ * must not throw a MappingException.
+ */
+@SpringBootTest(
+    classes = RomsHashesApplicationTests.Config.class,
+    properties = { "spring.main.allow-bean-definition-overriding=true" }
+)
+@Testcontainers(
+    disabledWithoutDocker = true
+)
+@DirtiesContext
 class RomsHashesApplicationTests {
+
+  @Container
+  static final RedisStackContainer REDIS;
+
+  static {
+    REDIS = new RedisStackContainer(DEFAULT_IMAGE_NAME.withTag("edge")).withReuse(true);
+    REDIS.start();
+  }
+
+  @DynamicPropertySource
+  static void redisProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.data.redis.host", REDIS::getHost);
+    registry.add("spring.data.redis.port", REDIS::getFirstMappedPort);
+  }
+
+  @SpringBootApplication
+  @Configuration
+  @EnableRedisEnhancedRepositories(
+      basePackages = "com.redis.om.hashes.*"
+  )
+  static class Config {
+    @Autowired
+    Environment env;
+
+    @Bean
+    public JedisConnectionFactory jedisConnectionFactory() {
+      String host = env.getProperty("spring.data.redis.host", "localhost");
+      int port = env.getProperty("spring.data.redis.port", Integer.class, 6379);
+
+      RedisStandaloneConfiguration conf = new RedisStandaloneConfiguration(host, port);
+
+      final JedisPoolConfig poolConfig = new JedisPoolConfig();
+      poolConfig.setTestWhileIdle(false);
+      poolConfig.setMinEvictableIdleDuration(Duration.ofMillis(60000));
+      poolConfig.setTimeBetweenEvictionRuns(Duration.ofMillis(30000));
+      poolConfig.setNumTestsPerEvictionRun(-1);
+
+      final JedisClientConfiguration jedisClientConfiguration = JedisClientConfiguration.builder().connectTimeout(
+          Duration.ofMillis(10000)).readTimeout(Duration.ofMillis(10000)).usePooling().poolConfig(poolConfig).build();
+
+      return new JedisConnectionFactory(conf, jedisClientConfiguration);
+    }
+
+    @Bean
+    public StringRedisTemplate redisTemplate(RedisConnectionFactory connectionFactory) {
+      StringRedisTemplate template = new StringRedisTemplate();
+      template.setConnectionFactory(connectionFactory);
+      return template;
+    }
+  }
+
+  @Autowired
+  UserRepository userRepository;
+
+  @Autowired
+  RoleRepository roleRepository;
+
+  @AfterEach
+  void tearDown() {
+    userRepository.deleteAll();
+    roleRepository.deleteAll();
+  }
 
   @Test
   void contextLoads() {
   }
 
+  @Test
+  void saveUserWithFlatMetadataDoesNotThrow() {
+    Role role = roleRepository.save(Role.of("ADMIN"));
+    User user = User.of("alice@example.com", "Alice", "Smith", role);
+    user.setMetadata(Map.of("department", "engineering", "level", 3));
+
+    assertThatNoException().isThrownBy(() -> userRepository.save(user));
+  }
+
+  /**
+   * Reproduces gh-755: metadata value is itself a LinkedHashMap (typical output
+   * from Jackson's ObjectMapper when deserializing into Map<String,Object>).
+   * Previously threw: MappingException: Couldn't find PersistentEntity for type
+   * class java.util.LinkedHashMap
+   */
+  @Test
+  void saveUserWithNestedMapMetadataDoesNotThrow() {
+    Role role = roleRepository.save(Role.of("ADMIN"));
+
+    LinkedHashMap<String, Object> address = new LinkedHashMap<>();
+    address.put("city", "Tel Aviv");
+    address.put("zip", "6100000");
+
+    User user = User.of("bob@example.com", "Bob", "Jones", role);
+    user.setMetadata(Map.of("address", address, "score", 99));
+
+    assertThatNoException().isThrownBy(() -> userRepository.save(user));
+  }
+
+  @Test
+  void saveAllUsersWithNestedMapMetadataDoesNotThrow() {
+    Role role = roleRepository.save(Role.of("USER"));
+
+    LinkedHashMap<String, Object> prefs = new LinkedHashMap<>();
+    prefs.put("theme", "dark");
+    prefs.put("notifications", Map.of("email", true, "sms", false));
+
+    User u1 = User.of("carol@example.com", "Carol", "White", role);
+    u1.setMetadata(Map.of("preferences", prefs));
+
+    User u2 = User.of("dave@example.com", "Dave", "Black", role);
+    u2.setMetadata(Map.of("plain", "value"));
+
+    assertThatNoException().isThrownBy(() -> userRepository.saveAll(List.of(u1, u2)));
+  }
 }

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/MappingRedisOMConverter.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/MappingRedisOMConverter.java
@@ -284,8 +284,8 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
       }
 
       if (conversionService.canConvert(byte[].class, mapValueType)) {
-        return readMapOfSimpleTypes(currentPath, typeInformation.getType(), typeInformation.getRequiredComponentType()
-            .getType(), mapValueType, source);
+        return readMapOfSimpleTypes(entityClass, currentPath, typeInformation.getType(), typeInformation
+            .getRequiredComponentType().getType(), mapValueType, source);
       }
 
       return readMapOfComplexTypes(entityClass, currentPath, typeInformation.getType(), typeInformation
@@ -625,6 +625,24 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
       return;
     }
 
+    // Spring Data 3.2.4+ does not create PersistentEntity for Map/Collection types.
+    // Handle Map values (e.g. nested LinkedHashMap from Jackson) by recursing into writeMap.
+    if (value instanceof Map<?, ?> nestedMap) {
+      writeContainerTypeIfNecessary(path, getMapTypeToWrite(typeHint), typeHint, sink);
+      writeMap(null, keyspace, path, Object.class, nestedMap, sink);
+      return;
+    }
+
+    // Handle Collection values (e.g. nested ArrayList from Jackson) by recursing into writeCollection.
+    if (value instanceof Collection<?> nestedCollection) {
+      writeContainerTypeIfNecessary(path, getCollectionTypeToWrite(nestedCollection, typeHint), typeHint, sink);
+      TypeInformation<?> componentType = typeHint.getComponentType() != null ?
+          typeHint.getComponentType() :
+          TypeInformation.of(Object.class);
+      writeCollection(Object.class, keyspace, path, nestedCollection, componentType, sink);
+      return;
+    }
+
     if (value.getClass() != typeHint.getType()) {
       typeMapper.writeType(value.getClass(), sink.getBucket().getPropertyPath(path));
     }
@@ -909,15 +927,7 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
 
         Bucket elementData = bucket.extract(key);
 
-        TypeInformation<?> typeInformation = typeMapper.readType(elementData.getPropertyPath(key), TypeInformation.of(
-            valueType));
-
-        Class<?> typeToUse = typeInformation.getType();
-        if (conversionService.canConvert(byte[].class, typeToUse)) {
-          target.add(fromBytes(elementData.get(key), typeToUse));
-        } else {
-          target.add(readInternal(entityClass, key, typeToUse, new RedisData(elementData)));
-        }
+        target.add(readNestedValue(entityClass, key, valueType, bucket, elementData));
       }
     }
 
@@ -968,6 +978,26 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
     return conversionService.convert(key, String.class);
   }
 
+  private void writeContainerTypeIfNecessary(String path, Class<?> containerType, TypeInformation<?> typeHint,
+      RedisData sink) {
+    if (StringUtils.hasText(path) && containerType != typeHint.getType()) {
+      typeMapper.writeType(containerType, sink.getBucket().getPropertyPath(path));
+    }
+  }
+
+  private Class<?> getMapTypeToWrite(TypeInformation<?> typeHint) {
+    Class<?> type = typeHint.getType();
+    return type != Object.class && !type.isInterface() && Map.class.isAssignableFrom(type) ? type : LinkedHashMap.class;
+  }
+
+  private Class<?> getCollectionTypeToWrite(Collection<?> collection, TypeInformation<?> typeHint) {
+    Class<?> type = typeHint.getType();
+    if (type != Object.class && !type.isInterface() && Collection.class.isAssignableFrom(type)) {
+      return type;
+    }
+    return collection instanceof Set<?> ? LinkedHashSet.class : ArrayList.class;
+  }
+
   /**
    * @param path
    * @param mapType
@@ -977,25 +1007,73 @@ public class MappingRedisOMConverter implements RedisConverter, InitializingBean
    * @return
    */
   @Nullable
-  private Map<?, ?> readMapOfSimpleTypes(String path, Class<?> mapType, Class<?> keyType, Class<?> valueType,
-      RedisData source) {
+  private Map<?, ?> readMapOfSimpleTypes(Class<?> entityClass, String path, Class<?> mapType, Class<?> keyType,
+      Class<?> valueType, RedisData source) {
 
-    Bucket partial = source.getBucket().extract(path + ".[");
+    Bucket bucket = source.getBucket();
+    Set<String> keys = bucket.extractAllKeysFor(path);
 
-    Map<Object, Object> target = CollectionFactory.createMap(mapType, partial.size());
+    Map<Object, Object> target = CollectionFactory.createMap(mapType, keys.size());
 
-    for (Entry<String, byte[]> entry : partial.entrySet()) {
+    for (String key : keys) {
 
-      if (typeMapper.isTypeKey(entry.getKey())) {
+      if (typeMapper.isTypeKey(key)) {
         continue;
       }
 
-      Object key = extractMapKeyForPath(path, entry.getKey(), keyType);
-      Class<?> typeToUse = getTypeHint(path + ".[" + key + "]", source.getBucket(), valueType);
-      target.put(key, fromBytes(entry.getValue(), typeToUse));
+      Object mapKey = extractMapKeyForPath(path, key, keyType);
+      target.put(mapKey, readNestedValue(entityClass, key, valueType, bucket, bucket.extract(key)));
     }
 
     return target.isEmpty() ? null : target;
+  }
+
+  private Object readNestedValue(Class<?> entityClass, String path, Class<?> valueType, Bucket bucket, Bucket partial) {
+    TypeInformation<?> typeInformation = typeMapper.readType(bucket.getPropertyPath(path), TypeInformation.of(
+        valueType));
+    Class<?> typeToUse = typeInformation.getType();
+
+    if (Map.class.isAssignableFrom(typeToUse)) {
+      return readMapOfSimpleTypes(entityClass, path, typeToUse, String.class, Object.class, new RedisData(bucket));
+    }
+
+    if (Collection.class.isAssignableFrom(typeToUse)) {
+      return readCollectionOrArray(entityClass, path, typeToUse, Object.class, bucket);
+    }
+
+    if (bucket.hasValue(path) && conversionService.canConvert(byte[].class, typeToUse)) {
+      return fromBytes(bucket.get(path), typeToUse);
+    }
+
+    if (typeToUse == Object.class && !bucket.hasValue(path) && hasNestedValues(bucket, path)) {
+      if (hasOnlyNumericNestedKeys(bucket, path)) {
+        return readCollectionOrArray(entityClass, path, ArrayList.class, Object.class, bucket);
+      }
+      return readMapOfSimpleTypes(entityClass, path, LinkedHashMap.class, String.class, Object.class, new RedisData(
+          bucket));
+    }
+
+    return readInternal(entityClass, path, typeToUse, new RedisData(partial));
+  }
+
+  private boolean hasNestedValues(Bucket bucket, String path) {
+    return !bucket.extractAllKeysFor(path).isEmpty();
+  }
+
+  private boolean hasOnlyNumericNestedKeys(Bucket bucket, String path) {
+    Set<String> nestedKeys = bucket.extractAllKeysFor(path);
+    if (nestedKeys.isEmpty()) {
+      return false;
+    }
+
+    for (String nestedKey : nestedKeys) {
+      Object nestedMapKey = extractMapKeyForPath(path, nestedKey, String.class);
+      if (!(nestedMapKey instanceof String nestedKeyString) || !nestedKeyString.matches("\\d+")) {
+        return false;
+      }
+    }
+
+    return true;
   }
 
   /**

--- a/redis-om-spring/src/main/java/com/redis/om/spring/convert/RedisOMCustomConversions.java
+++ b/redis-om-spring/src/main/java/com/redis/om/spring/convert/RedisOMCustomConversions.java
@@ -78,6 +78,15 @@ public class RedisOMCustomConversions extends RedisCustomConversions {
    * @param converters a list of converted to be added to the base list
    */
   public RedisOMCustomConversions(List<?> converters) {
-    super(omConverters);
+    super(mergeConverters(converters));
+  }
+
+  private static List<Object> mergeConverters(List<?> converters) {
+    if (converters == null || converters.isEmpty()) {
+      return omConverters;
+    }
+    List<Object> merged = new ArrayList<>(omConverters);
+    merged.addAll(converters);
+    return merged;
   }
 }

--- a/tests/src/test/java/com/redis/om/spring/convert/RedisOMCustomConversionsTest.java
+++ b/tests/src/test/java/com/redis/om/spring/convert/RedisOMCustomConversionsTest.java
@@ -1,0 +1,65 @@
+package com.redis.om.spring.convert;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.convert.WritingConverter;
+
+/**
+ * Verifies that user-provided converters passed to RedisOMCustomConversions are
+ * actually registered and not silently dropped (regression for gh-755).
+ */
+class RedisOMCustomConversionsTest {
+
+  @WritingConverter
+  static class FooToBytesConverter implements Converter<Foo, byte[]> {
+    @Override
+    public byte[] convert(Foo source) {
+      return source.value().getBytes();
+    }
+  }
+
+  @ReadingConverter
+  static class BytesToFooConverter implements Converter<byte[], Foo> {
+    @Override
+    public Foo convert(byte[] source) {
+      return new Foo(new String(source));
+    }
+  }
+
+  record Foo(String value) {
+  }
+
+  @Test
+  void emptyConstructorRegistersBuiltInConverters() {
+    RedisOMCustomConversions conversions = new RedisOMCustomConversions();
+    // Point converter is one of the built-ins
+    assertThat(conversions.hasCustomWriteTarget(org.springframework.data.geo.Point.class)).isTrue();
+  }
+
+  @Test
+  void userProvidedConvertersAreRegistered() {
+    RedisOMCustomConversions conversions = new RedisOMCustomConversions(
+        List.of(new FooToBytesConverter(), new BytesToFooConverter()));
+
+    Optional<Class<?>> writeTarget = conversions.getCustomWriteTarget(Foo.class);
+    assertThat(writeTarget).isPresent();
+    assertThat(writeTarget.get()).isEqualTo(byte[].class);
+  }
+
+  @Test
+  void builtInConvertersStillRegisteredWhenUserConvertersProvided() {
+    RedisOMCustomConversions conversions = new RedisOMCustomConversions(
+        List.of(new FooToBytesConverter()));
+
+    // built-in should still be present
+    assertThat(conversions.hasCustomWriteTarget(org.springframework.data.geo.Point.class)).isTrue();
+    // user converter should also be present
+    assertThat(conversions.hasCustomWriteTarget(Foo.class)).isTrue();
+  }
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/HashWithNestedMap.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/model/HashWithNestedMap.java
@@ -1,0 +1,23 @@
+package com.redis.om.spring.fixtures.hash.model;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@RedisHash
+public class HashWithNestedMap {
+  @Id
+  private String id = UUID.randomUUID().toString();
+
+  private Map<String, Object> attributes;
+
+  private List<Object> items;
+}

--- a/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/HashWithNestedMapRepository.java
+++ b/tests/src/test/java/com/redis/om/spring/fixtures/hash/repository/HashWithNestedMapRepository.java
@@ -1,0 +1,7 @@
+package com.redis.om.spring.fixtures.hash.repository;
+
+import com.redis.om.spring.repository.RedisEnhancedRepository;
+import com.redis.om.spring.fixtures.hash.model.HashWithNestedMap;
+
+public interface HashWithNestedMapRepository extends RedisEnhancedRepository<HashWithNestedMap, String> {
+}

--- a/tests/src/test/java/com/redis/om/spring/repository/HashWithNestedMapTest.java
+++ b/tests/src/test/java/com/redis/om/spring/repository/HashWithNestedMapTest.java
@@ -1,0 +1,162 @@
+package com.redis.om.spring.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.redis.om.spring.AbstractBaseEnhancedRedisTest;
+import com.redis.om.spring.fixtures.hash.model.HashWithNestedMap;
+import com.redis.om.spring.fixtures.hash.repository.HashWithNestedMapRepository;
+
+/**
+ * Regression tests for gh-755: MappingException when saving a @RedisHash entity
+ * with Map<String, Object> or List<Object> fields containing nested Map/Collection values
+ * (e.g. LinkedHashMap / ArrayList produced by Jackson deserialization).
+ * Spring Data Commons 3.2.4+ no longer creates PersistentEntity for Map/Collection types,
+ * so the converter must handle them explicitly before reaching getRequiredPersistentEntity().
+ */
+class HashWithNestedMapTest extends AbstractBaseEnhancedRedisTest {
+
+  @Autowired
+  private HashWithNestedMapRepository repository;
+
+  @AfterEach
+  void tearDown() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void saveWithFlatMapDoesNotThrow() {
+    HashWithNestedMap entity = new HashWithNestedMap();
+    entity.setAttributes(Map.of("key1", "value1", "key2", 42));
+
+    assertThatNoException().isThrownBy(() -> repository.save(entity));
+  }
+
+  @Test
+  void saveWithNestedLinkedHashMapDoesNotThrow() {
+    // Simulates a Map<String, Object> where a value is itself a LinkedHashMap,
+    // as produced by Jackson's ObjectMapper when deserializing generic Object fields.
+    LinkedHashMap<String, Object> nested = new LinkedHashMap<>();
+    nested.put("city", "Tel Aviv");
+    nested.put("zip", "6100000");
+
+    HashWithNestedMap entity = new HashWithNestedMap();
+    entity.setAttributes(Map.of("address", nested, "name", "Acme"));
+
+    assertThatNoException().isThrownBy(() -> repository.save(entity));
+  }
+
+  @Test
+  void saveWithNestedLinkedHashMapRoundTrips() {
+    LinkedHashMap<String, Object> nested = new LinkedHashMap<>();
+    nested.put("city", "Tel Aviv");
+    nested.put("zip", "6100000");
+
+    HashWithNestedMap entity = new HashWithNestedMap();
+    entity.setAttributes(Map.of("address", nested, "name", "Acme"));
+
+    HashWithNestedMap saved = repository.save(entity);
+
+    Optional<HashWithNestedMap> found = repository.findById(saved.getId());
+    assertThat(found).isPresent();
+    assertThat(found.get().getAttributes()).containsEntry("name", "Acme");
+    assertThat(found.get().getAttributes()).containsEntry("address", nested);
+  }
+
+  @Test
+  void saveAllWithNestedMapsDoesNotThrow() {
+    LinkedHashMap<String, Object> nested1 = new LinkedHashMap<>();
+    nested1.put("score", 99);
+    nested1.put("level", "gold");
+
+    HashWithNestedMap e1 = new HashWithNestedMap();
+    e1.setAttributes(Map.of("tier", nested1));
+
+    HashWithNestedMap e2 = new HashWithNestedMap();
+    e2.setAttributes(Map.of("plain", "value"));
+
+    assertThatNoException().isThrownBy(() -> repository.saveAll(List.of(e1, e2)));
+    assertThat(repository.count()).isEqualTo(2);
+  }
+
+  @Test
+  void saveWithNestedCollectionInListFieldDoesNotThrow() {
+    // Simulates a List<Object> where an element is itself an ArrayList,
+    // as produced by Jackson when deserializing generic Object fields.
+    ArrayList<Object> nestedList = new ArrayList<>();
+    nestedList.add("item1");
+    nestedList.add("item2");
+
+    HashWithNestedMap entity = new HashWithNestedMap();
+    entity.setItems(List.of(nestedList, "plain-string"));
+
+    assertThatNoException().isThrownBy(() -> repository.save(entity));
+  }
+
+  @Test
+  void saveWithNestedCollectionInListFieldRoundTrips() {
+    ArrayList<Object> nestedList = new ArrayList<>();
+    nestedList.add("item1");
+    nestedList.add("item2");
+
+    HashWithNestedMap entity = new HashWithNestedMap();
+    entity.setItems(List.of(nestedList, "plain-string"));
+
+    HashWithNestedMap saved = repository.save(entity);
+
+    Optional<HashWithNestedMap> found = repository.findById(saved.getId());
+    assertThat(found).isPresent();
+    assertThat(found.get().getItems()).containsExactly(nestedList, "plain-string");
+  }
+
+  @Test
+  void saveWithNestedCollectionInMapValueDoesNotThrow() {
+    // Map value is an ArrayList — another shape from Jackson deserialization.
+    ArrayList<Object> nestedList = new ArrayList<>();
+    nestedList.add("a");
+    nestedList.add("b");
+
+    HashWithNestedMap entity = new HashWithNestedMap();
+    entity.setAttributes(Map.of("tags", nestedList));
+
+    assertThatNoException().isThrownBy(() -> repository.save(entity));
+  }
+
+  @Test
+  void saveWithNestedCollectionInMapValueRoundTrips() {
+    ArrayList<Object> nestedList = new ArrayList<>();
+    nestedList.add("a");
+    nestedList.add("b");
+
+    HashWithNestedMap entity = new HashWithNestedMap();
+    entity.setAttributes(Map.of("tags", nestedList));
+
+    HashWithNestedMap saved = repository.save(entity);
+
+    Optional<HashWithNestedMap> found = repository.findById(saved.getId());
+    assertThat(found).isPresent();
+    assertThat(found.get().getAttributes()).containsEntry("tags", nestedList);
+  }
+
+  @Test
+  void savedEntityIsRetrievable() {
+    HashWithNestedMap entity = new HashWithNestedMap();
+    entity.setAttributes(Map.of("key", "value"));
+
+    HashWithNestedMap saved = repository.save(entity);
+
+    Optional<HashWithNestedMap> found = repository.findById(saved.getId());
+    assertThat(found).isPresent();
+    assertThat(found.get().getAttributes()).isNotNull();
+  }
+}


### PR DESCRIPTION
## Summary
- Backports #757 to 1.1.x so `@RedisHash` entities can persist and reload `Map<String, Object>` values containing nested maps and collections.
- Keeps Redis OM built-in custom converters registered when callers provide additional custom conversions.

## Validation
- Fail-first check: with only the new tests on the 1.1.x baseline, `./gradlew :tests:test --tests "com.redis.om.spring.repository.HashWithNestedMapTest" --tests "com.redis.om.spring.convert.RedisOMCustomConversionsTest"` failed 5 tests covering custom converter registration and nested map/list round trips.
- `./gradlew :tests:test --tests "com.redis.om.spring.repository.HashWithNestedMapTest" --tests "com.redis.om.spring.convert.RedisOMCustomConversionsTest"`
- `./gradlew :demos:roms-hashes:test --tests "com.redis.om.hashes.RomsHashesApplicationTests"`
- `./gradlew spotlessApply`
- `./gradlew spotlessCheck build aggregateTestReport -S`

## CI Notes
- Reviewed `.github/workflows/build.yml`: PR jobs run `spotlessCheck -S`, `assemble -S`, sharded `:tests:test -S`, and `:demos:build -S`.
- Local full validation covered the same formatting, build, tests, demos, and aggregate report surfaces via `spotlessCheck build aggregateTestReport -S`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core entity-to-Redis mapping for maps, lists, and custom conversions; broad regression tests reduce risk but any app relying on prior broken or partial behavior could see different serialized shapes on reload.
> 
> **Overview**
> Backports nested **Redis hash** conversion fixes so `@RedisHash` entities with `Map<String, Object>` or `List<Object>` fields can persist and reload **nested maps and collections** (e.g. Jackson `LinkedHashMap` / `ArrayList`) without `MappingException`.
> 
> **`MappingRedisOMConverter`** now recurses into nested `Map` and `Collection` values on write before Spring Data would call `getRequiredPersistentEntity` on types that no longer get a `PersistentEntity` (Spring Data Commons 3.2.4+). Read paths use **`readNestedValue`** and updated **`readMapOfSimpleTypes`** so map/list entries round-trip through nested structures.
> 
> **`RedisOMCustomConversions`** merges caller-supplied converters with built-in OM converters instead of replacing them, so custom types still register alongside defaults.
> 
> Regression coverage adds **`HashWithNestedMapTest`**, **`RedisOMCustomConversionsTest`**, an enabled **`roms-hashes`** integration test with **`User.metadata`**, and related fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9be1b0d81154d5ed7f0b9f56578a14ae84625d53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->