### PR TITLE
fix: pull --rebase before push in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           sed -i "s/^version\s*=.*/version = ${{ inputs.version }}/" gradle.properties
           git add gradle.properties
           git commit --allow-empty -m "release: Releasing version ${{ inputs.version }}"
+          git pull --rebase origin HEAD
           git push origin HEAD
 
       - name: Build


### PR DESCRIPTION
Adds `git pull --rebase origin HEAD` before `git push` to prevent non-fast-forward failures when a previous failed run already pushed a version-bump commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI change in the release bump/push step; no application or auth logic affected, with minor risk only if rebase conflicts on `gradle.properties`.
> 
> **Overview**
> The **Release** workflow’s version-bump step now runs **`git pull --rebase origin HEAD`** after committing `gradle.properties` and **before** `git push`.
> 
> That way a retry or a run where the bump commit already reached the remote won’t fail with a non-fast-forward push; the local release commit is replayed on top of the current branch tip instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03dd17bfb8a53f570d9b877d3f70753a982fe5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->